### PR TITLE
Fix Google Ads re-authentication

### DIFF
--- a/components/settings/AdWordsSettings.tsx
+++ b/components/settings/AdWordsSettings.tsx
@@ -29,16 +29,14 @@ const AdWordsSettings = ({ settings, settingsError, updateSettings, performUpdat
    const cloudProjectIntegrated = adwords_client_id && adwords_client_secret && adwords_refresh_token;
    const hasAllCredentials = adwords_client_id && adwords_client_secret && adwords_refresh_token && adwords_developer_token && adwords_account_id;
 
-   const udpateAndAuthenticate = () => {
+   const udpateAndAuthenticate = async () => {
       if (adwords_client_id && adwords_client_secret) {
-         const link = document.createElement('a');
-         link.href = `https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?access_type=offline&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fadwords&response_type=code&client_id=${adwords_client_id}&redirect_uri=${`${encodeURIComponent(window.location.origin)}/api/adwords`}&service=lso&o2v=2&theme=glif&flowName=GeneralOAuthFlow`;
-         link.target = '_blank';
-         link.click();
          if (performUpdate) {
-            performUpdate();
-            closeSettings();
+            await performUpdate();
          }
+         const url = `https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?access_type=offline&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fadwords&response_type=code&client_id=${adwords_client_id}&redirect_uri=${`${encodeURIComponent(window.location.origin)}/api/adwords`}&service=lso&o2v=2&theme=glif&flowName=GeneralOAuthFlow`;
+         window.open(url, '_blank');
+         closeSettings();
       }
    };
 

--- a/components/settings/Settings.tsx
+++ b/components/settings/Settings.tsx
@@ -39,7 +39,7 @@ const Settings = ({ closeSettings }:SettingsProps) => {
    const [currentTab, setCurrentTab] = useState<string>('scraper');
    const [settings, setSettings] = useState<SettingsType>(defaultSettings);
    const [settingsError, setSettingsError] = useState<SettingsError|null>(null);
-   const { mutate: updateMutate, isLoading: isUpdating } = useUpdateSettings(() => console.log(''));
+   const { mutateAsync: updateMutateAsync, isLoading: isUpdating } = useUpdateSettings(() => console.log(''));
    const { data: appSettings, isLoading } = useFetchSettings();
    useOnKey('Escape', closeSettings);
 
@@ -59,7 +59,7 @@ const Settings = ({ closeSettings }:SettingsProps) => {
       setSettings({ ...settings, [key]: value });
    };
 
-   const performUpdate = () => {
+   const performUpdate = async () => {
       let error: null|SettingsError = null;
       const { notification_interval, notification_email, notification_email_from, scraper_type, smtp_port, smtp_server, scaping_api } = settings;
       if (notification_interval !== 'never') {
@@ -83,7 +83,7 @@ const Settings = ({ closeSettings }:SettingsProps) => {
          setTimeout(() => { setSettingsError(null); }, 3000);
       } else {
          // Perform Update
-         updateMutate(settings);
+         await updateMutateAsync(settings);
          // If Scraper is updated, refresh the page.
          if (appSettings.settings === 'none' && scraper_type !== 'none') {
             window.location.reload();


### PR DESCRIPTION
## Summary
- ensure settings update finishes before requesting a new OAuth token
- await settings update so re-auth works reliably

## Testing
- `npm run test:ci` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f93afb164832ab90ad0f16d5ab4f9