### PR TITLE
Fix domain query validation

### DIFF
--- a/pages/api/domain.ts
+++ b/pages/api/domain.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 const getDomain = async (req: NextApiRequest, res: NextApiResponse<DomainGetResponse>) => {
-   if (!req.query.domain && typeof req.query.domain !== 'string') {
+   if (!req.query.domain || typeof req.query.domain !== 'string') {
        return res.status(400).json({ error: 'Domain Name is Required!' });
    }
 

--- a/pages/api/domains.ts
+++ b/pages/api/domains.ts
@@ -95,7 +95,7 @@ const addDomain = async (req: NextApiRequest, res: NextApiResponse<DomainsAddRes
 };
 
 export const deleteDomain = async (req: NextApiRequest, res: NextApiResponse<DomainsDeleteRes>) => {
-   if (!req.query.domain && typeof req.query.domain !== 'string') {
+   if (!req.query.domain || typeof req.query.domain !== 'string') {
       return res.status(400).json({ domainRemoved: 0, keywordsRemoved: 0, SCDataRemoved: false, error: 'Domain is Required!' });
    }
    try {
@@ -111,7 +111,7 @@ export const deleteDomain = async (req: NextApiRequest, res: NextApiResponse<Dom
 };
 
 export const updateDomain = async (req: NextApiRequest, res: NextApiResponse<DomainsUpdateRes>) => {
-   if (!req.query.domain) {
+   if (!req.query.domain || typeof req.query.domain !== 'string') {
       return res.status(400).json({ domain: null, error: 'Domain is Required!' });
    }
    const { domain } = req.query || {};

--- a/pages/api/insight.ts
+++ b/pages/api/insight.ts
@@ -23,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 const getDomainSearchConsoleInsight = async (req: NextApiRequest, res: NextApiResponse<SCInsightRes>) => {
-   if (!req.query.domain && typeof req.query.domain !== 'string') return res.status(400).json({ data: null, error: 'Domain is Missing.' });
+   if (!req.query.domain || typeof req.query.domain !== 'string') return res.status(400).json({ data: null, error: 'Domain is Missing.' });
    const domainname = (req.query.domain as string).replaceAll('-', '.').replaceAll('_', '-');
    const getInsightFromSCData = (localSCData: SCDomainDataType): InsightDataType => {
       const { stats = [] } = localSCData;

--- a/pages/api/searchconsole.ts
+++ b/pages/api/searchconsole.ts
@@ -30,7 +30,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 const getDomainSearchConsoleData = async (req: NextApiRequest, res: NextApiResponse<searchConsoleRes>) => {
-   if (!req.query.domain && typeof req.query.domain !== 'string') return res.status(400).json({ data: null, error: 'Domain is Missing.' });
+   if (!req.query.domain || typeof req.query.domain !== 'string') return res.status(400).json({ data: null, error: 'Domain is Missing.' });
    const domainname = (req.query.domain as string).replaceAll('-', '.').replaceAll('_', '-');
    const localSCData = await readLocalSCData(domainname);
    if (localSCData && localSCData.thirtyDays && localSCData.thirtyDays.length) {


### PR DESCRIPTION
## Summary
- fix conditional checks on domain query param
- ensure domain routes validate empty strings or non-string types

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_686f9d845d38832ab25cc5d4b2e00392