### PR TITLE
Fix typo in domain update error message

### DIFF
--- a/pages/api/domains.ts
+++ b/pages/api/domains.ts
@@ -137,6 +137,6 @@ export const updateDomain = async (req: NextApiRequest, res: NextApiResponse<Dom
       return res.status(200).json({ domain: domainToUpdate });
    } catch (error) {
       console.log('[ERROR] Updating Domain: ', req.query.domain, error);
-      return res.status(400).json({ domain: null, error: 'Error Updating Domain. An Unknown Error Occured.' });
+      return res.status(400).json({ domain: null, error: 'Error Updating Domain. An Unknown Error Occurred.' });
    }
 };


### PR DESCRIPTION
## Summary
- correct typo in domain update API response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa3e16104832aa82681d55415012c