### PR TITLE
Fix AddKeywords placeholder typo

### DIFF
--- a/components/keywords/AddKeywords.tsx
+++ b/components/keywords/AddKeywords.tsx
@@ -167,7 +167,7 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
                      outline-none focus:border-indigo-300 ${!allowsCity ? ' cursor-not-allowed' : ''} `}
                      disabled={!allowsCity}
                      title={!allowsCity ? `Your scraper ${scraperName} doesn't have city level scraping feature.` : ''}
-                     placeholder={`City (Optional)${!allowsCity ? `. Not avaialable for ${scraperName}.` : ''}`}
+                     placeholder={`City (Optional)${!allowsCity ? `. Not available for ${scraperName}.` : ''}`}
                      value={newKeywordsData.city}
                      onChange={(e) => setNewKeywordsData({ ...newKeywordsData, city: e.target.value })}
                   />


### PR DESCRIPTION
## Summary
- correct spelling in AddKeywords placeholder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa407afbc832a8d9933a00e378f4e