### PR TITLE
Fix settings column removal check

### DIFF
--- a/database/migrations/1707068556345-add-new-keyword-fields.js
+++ b/database/migrations/1707068556345-add-new-keyword-fields.js
@@ -33,7 +33,7 @@ module.exports = {
                if (keywordTableDefinition.latlong) {
                   await queryInterface.removeColumn('keyword', 'latlong', { transaction: t });
                }
-               if (keywordTableDefinition.latlong) {
+               if (keywordTableDefinition.settings) {
                   await queryInterface.removeColumn('keyword', 'settings', { transaction: t });
                }
             }


### PR DESCRIPTION
## Summary
- correct the check for dropping the `settings` column in the down migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa40edb54832ab8e323f20ed140a8