### PR TITLE
Fix chart series property typo

### DIFF
--- a/components/common/Chart.tsx
+++ b/components/common/Chart.tsx
@@ -6,12 +6,12 @@ ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, T
 
 type ChartProps ={
    labels: string[],
-   sreies: number[],
+   series: number[],
    reverse? : boolean,
    noMaxLimit?: boolean
 }
 
-const Chart = ({ labels, sreies, reverse = true, noMaxLimit = false }:ChartProps) => {
+const Chart = ({ labels, series, reverse = true, noMaxLimit = false }:ChartProps) => {
    const options = {
       responsive: true,
       maintainAspectRatio: false,
@@ -38,7 +38,7 @@ const Chart = ({ labels, sreies, reverse = true, noMaxLimit = false }:ChartProps
             datasets: [
                {
                   fill: 'start',
-                  data: sreies,
+                  data: series,
                   borderColor: 'rgb(31, 205, 176)',
                   backgroundColor: 'rgba(31, 205, 176, 0.5)',
                },

--- a/components/common/ChartSlim.tsx
+++ b/components/common/ChartSlim.tsx
@@ -6,12 +6,12 @@ ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, 
 
 type ChartProps ={
    labels: string[],
-   sreies: number[],
+   series: number[],
    noMaxLimit?: boolean,
    reverse?: boolean
 }
 
-const ChartSlim = ({ labels, sreies, noMaxLimit = false, reverse = true }:ChartProps) => {
+const ChartSlim = ({ labels, series, noMaxLimit = false, reverse = true }:ChartProps) => {
    const options = {
       responsive: true,
       maintainAspectRatio: false,
@@ -47,7 +47,7 @@ const ChartSlim = ({ labels, sreies, noMaxLimit = false, reverse = true }:ChartP
                {
                   fill: 'start',
                   showLine: false,
-                  data: sreies,
+                  data: series,
                   pointRadius: 0,
                   borderColor: 'rgb(31, 205, 176)',
                   backgroundColor: 'rgba(31, 205, 176, 0.5)',

--- a/components/ideas/IdeaDetails.tsx
+++ b/components/ideas/IdeaDetails.tsx
@@ -37,12 +37,12 @@ const IdeaDetails = ({ keyword, closeDetails }:IdeaDetailsProps) => {
    useOnKey('Escape', closeDetails);
 
    const chartData = useMemo(() => {
-      const chartDataObj: { labels: string[], sreies: number[] } = { labels: [], sreies: [] };
+      const chartDataObj: { labels: string[], series: number[] } = { labels: [], series: [] };
       Object.keys(monthlySearchVolumes).forEach((dateKey:string) => {
          const dateKeyArr = dateKey.split('-');
          const labelDate = `${dateKeyArr[0].slice(0, 1).toUpperCase()}${dateKeyArr[0].slice(1, 3).toLowerCase()}, ${dateKeyArr[1].slice(2)}`;
          chartDataObj.labels.push(labelDate);
-         chartDataObj.sreies.push(parseInt(monthlySearchVolumes[dateKey], 10));
+         chartDataObj.series.push(parseInt(monthlySearchVolumes[dateKey], 10));
       });
       return chartDataObj;
    }, [monthlySearchVolumes]);
@@ -80,7 +80,7 @@ const IdeaDetails = ({ keyword, closeDetails }:IdeaDetailsProps) => {
                         <h3 className=' font-bold text-gray-700 text-lg'>Search Volume Trend</h3>
                      </div>
                      <div className='IdeaDetails__section__chart h-64'>
-                        <Chart labels={chartData.labels} sreies={chartData.sreies} noMaxLimit={true} reverse={false} />
+                        <Chart labels={chartData.labels} series={chartData.series} noMaxLimit={true} reverse={false} />
                      </div>
                   </div>
                   <div className='IdeaDetails__section mt-10'>

--- a/components/ideas/KeywordIdea.tsx
+++ b/components/ideas/KeywordIdea.tsx
@@ -20,10 +20,10 @@ const KeywordIdea = (props: KeywordIdeaProps) => {
    const { keyword, uid, position, country, monthlySearchVolumes, avgMonthlySearches, competition, competitionIndex } = keywordData;
 
    const chartData = useMemo(() => {
-      const chartDataObj: { labels: string[], sreies: number[] } = { labels: [], sreies: [] };
+      const chartDataObj: { labels: string[], series: number[] } = { labels: [], series: [] };
       Object.keys(monthlySearchVolumes).forEach((dateKey:string) => {
          chartDataObj.labels.push(dateKey);
-         chartDataObj.sreies.push(parseInt(monthlySearchVolumes[dateKey], 10));
+         chartDataObj.series.push(parseInt(monthlySearchVolumes[dateKey], 10));
       });
       return chartDataObj;
    }, [monthlySearchVolumes]);
@@ -61,7 +61,7 @@ const KeywordIdea = (props: KeywordIdeaProps) => {
           onClick={() => showKeywordDetails()}
          className={`keyword_visits text-center hidden mt-4 mr-5 ml-5 cursor-pointer
          lg:flex-1 lg:m-0 lg:ml-10 max-w-[70px] lg:max-w-none lg:pr-5 lg:flex justify-center`}>
-            {chartData.labels.length > 0 && <ChartSlim labels={chartData.labels} sreies={chartData.sreies} noMaxLimit={true} reverse={false} />}
+            {chartData.labels.length > 0 && <ChartSlim labels={chartData.labels} series={chartData.series} noMaxLimit={true} reverse={false} />}
          </div>
 
          <div className='keyword_ctr text-center inline-block ml-4 lg:flex mt-4 relative lg:flex-1 lg:m-0 justify-center'>

--- a/components/keywords/Keyword.tsx
+++ b/components/keywords/Keyword.tsx
@@ -147,7 +147,7 @@ const Keyword = (props: KeywordProps) => {
             <div
                className={`hidden basis-20 grow-0 cursor-pointer lg:block ${!tableColumns.includes('History') ? 'lg:hidden' : ''}`}
                onClick={() => showKeywordDetails()}>
-               <ChartSlim labels={chartData.labels} sreies={chartData.sreies} />
+               <ChartSlim labels={chartData.labels} series={chartData.series} />
             </div>
          )}
 

--- a/components/keywords/KeywordDetails.tsx
+++ b/components/keywords/KeywordDetails.tsx
@@ -86,7 +86,7 @@ const KeywordDetails = ({ keyword, closeDetails }:KeywordDetailsProps) => {
                         </div>
                      </div>
                      <div className='keywordDetails__section__chart h-64'>
-                           <Chart labels={chartData.labels} sreies={chartData.sreies} />
+                           <Chart labels={chartData.labels} series={chartData.series} />
                      </div>
                   </div>
                   <div className='keywordDetails__section mt-10'>

--- a/utils/client/generateChartData.ts
+++ b/utils/client/generateChartData.ts
@@ -1,6 +1,6 @@
 type ChartData = {
    labels: string[],
-   sreies: number[]
+   series: number[]
 }
 
 export const generateChartData = (history: KeywordHistory): ChartData => {
@@ -23,18 +23,18 @@ export const generateChartData = (history: KeywordHistory): ChartData => {
       if (lastFoundSerp < serpOftheDate) { lastFoundSerp = serpOftheDate; }
    }
 
-   return { labels: priorDates, sreies: Object.values(seriesDates) };
+   return { labels: priorDates, series: Object.values(seriesDates) };
 };
 
 export const generateTheChartData = (history: KeywordHistory, time:string = '30'): ChartData => {
    const currentDate = new Date(); let lastFoundSerp = 0;
-   const chartData: ChartData = { labels: [], sreies: [] };
+   const chartData: ChartData = { labels: [], series: [] };
 
    if (time === 'all') {
       Object.keys(history).forEach((dateKey) => {
          const serpVal = history[dateKey] ? history[dateKey] : 111;
          chartData.labels.push(dateKey);
-         chartData.sreies.push(serpVal);
+         chartData.series.push(serpVal);
       });
    } else {
       // First Generate Labels. The labels should be the last 30 days dates. Format: Oct 26
@@ -47,7 +47,7 @@ export const generateTheChartData = (history: KeywordHistory, time:string = '30'
          const serpVal = prevSerp || (lastFoundSerp > 0 ? lastFoundSerp : 111);
          if (serpVal !== 0) { lastFoundSerp = prevSerp; }
          chartData.labels.push(pastDateKey);
-         chartData.sreies.push(serpVal);
+         chartData.series.push(serpVal);
       }
    }
    // console.log(chartData);


### PR DESCRIPTION
## Summary
- rename chart prop `sreies` to `series`
- update chart components to use the corrected prop
- adjust keyword and idea components for updated API
- update generateChartData helper to output `series`

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686fa44a26b8832a9384f406eab91592