### PR TITLE
Fix typo in language options variable

### DIFF
--- a/components/ideas/KeywordIdeasUpdater.tsx
+++ b/components/ideas/KeywordIdeasUpdater.tsx
@@ -62,7 +62,7 @@ const KeywordIdeasUpdater = ({ onUpdate, settings, domain, searchConsoleConnecte
       .map((countryISO) => ({ label: allCountries[countryISO][0], value: countryISO }));
    }, []);
 
-   const languageOPtions = useMemo(() => Object.entries(adwordsLanguages).map(([value, label]) => ({ label, value })), []);
+   const languageOptions = useMemo(() => Object.entries(adwordsLanguages).map(([value, label]) => ({ label, value })), []);
 
    const labelStyle = 'mb-2 font-semibold inline-block text-sm text-gray-700 capitalize w-full';
    return (
@@ -114,7 +114,7 @@ const KeywordIdeasUpdater = ({ onUpdate, settings, domain, searchConsoleConnecte
                   <label className={labelStyle}>Language</label>
                   <SelectField
                      selected={[language]}
-                     options={languageOPtions}
+                     options={languageOptions}
                      defaultLabel='All Languages'
                      updateField={(updated:string[]) => setLanguage(updated[0])}
                      rounded='rounded'

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -50,7 +50,7 @@ const Research: NextPage = () => {
       .map((countryISO) => ({ label: allCountries[countryISO][0], value: countryISO }));
    }, []);
 
-   const languageOPtions = useMemo(() => Object.entries(adwordsLanguages).map(([value, label]) => ({ label, value })), []);
+   const languageOptions = useMemo(() => Object.entries(adwordsLanguages).map(([value, label]) => ({ label, value })), []);
 
    const buttonStyle = 'leading-6 inline-block px-2 py-2 text-gray-500 hover:text-gray-700';
    const buttonLabelStyle = 'ml-2 text-sm not-italic lg:invisible lg:opacity-0';
@@ -96,7 +96,7 @@ const Research: NextPage = () => {
                      <label className={labelStyle}>Language</label>
                      <SelectField
                         selected={[language]}
-                        options={languageOPtions}
+                        options={languageOptions}
                         defaultLabel='All Languages'
                         updateField={(updated:string[]) => setLanguage(updated[0])}
                         rounded='rounded'


### PR DESCRIPTION
## Summary
- fix the `languageOptions` spelling in `KeywordIdeasUpdater` and research page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fa45ac6f8832aabb5b411a686042b