### PR TITLE
Fix search console variable typo

### DIFF
--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -39,8 +39,8 @@ const SingleDomain: NextPage = () => {
    }, [router.query.slug, domainsData]);
 
    const domainHasScAPI = useMemo(() => {
-      const doaminSc = activDomain?.search_console ? JSON.parse(activDomain.search_console) : {};
-      return !!(doaminSc?.client_email && doaminSc?.private_key);
+      const domainSc = activDomain?.search_console ? JSON.parse(activDomain.search_console) : {};
+      return !!(domainSc?.client_email && domainSc?.private_key);
    }, [activDomain]);
 
    const { keywordsData, keywordsLoading } = useFetchKeywords(router, activDomain?.domain || '', setKeywordSPollInterval, keywordSPollInterval);

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -83,8 +83,8 @@ const DiscoverPage: NextPage = () => {
    }, [router.query.slug, domainsData]);
 
    const domainHasScAPI = useMemo(() => {
-      const doaminSc = activDomain?.search_console ? JSON.parse(activDomain.search_console) : {};
-      return !!(doaminSc?.client_email && doaminSc?.private_key);
+      const domainSc = activDomain?.search_console ? JSON.parse(activDomain.search_console) : {};
+      return !!(domainSc?.client_email && domainSc?.private_key);
    }, [activDomain]);
 
    return (

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -41,8 +41,8 @@ const InsightPage: NextPage = () => {
    }, [router.query.slug, domainsData]);
 
    const domainHasScAPI = useMemo(() => {
-      const doaminSc = activDomain?.search_console ? JSON.parse(activDomain.search_console) : {};
-      return !!(doaminSc?.client_email && doaminSc?.private_key);
+      const domainSc = activDomain?.search_console ? JSON.parse(activDomain.search_console) : {};
+      return !!(domainSc?.client_email && domainSc?.private_key);
    }, [activDomain]);
 
    return (


### PR DESCRIPTION
## Summary
- correct `doaminSc` typo to `domainSc` in domain pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fa45ff3a4832a8a016d4aec6af02a