### PR TITLE
Fix updatedSelectd typo

### DIFF
--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -78,11 +78,11 @@ const IdeasKeywordsTable = ({
    }, [keywords]);
 
    const selectKeyword = (keywordID: string) => {
-      let updatedSelectd = [...selectedKeywords, keywordID];
+      let updatedSelected = [...selectedKeywords, keywordID];
       if (selectedKeywords.includes(keywordID)) {
-         updatedSelectd = selectedKeywords.filter((keyID) => keyID !== keywordID);
+         updatedSelected = selectedKeywords.filter((keyID) => keyID !== keywordID);
       }
-      setSelectedKeywords(updatedSelectd);
+      setSelectedKeywords(updatedSelected);
    };
 
    const favoriteKeyword = (keywordID: string) => {

--- a/components/keywords/KeywordsTable.tsx
+++ b/components/keywords/KeywordsTable.tsx
@@ -85,11 +85,11 @@ const KeywordsTable = (props: KeywordsTableProps) => {
 
    const selectKeyword = (keywordID: number) => {
       console.log('Select Keyword: ', keywordID);
-      let updatedSelectd = [...selectedKeywords, keywordID];
+      let updatedSelected = [...selectedKeywords, keywordID];
       if (selectedKeywords.includes(keywordID)) {
-         updatedSelectd = selectedKeywords.filter((keyID) => keyID !== keywordID);
+         updatedSelected = selectedKeywords.filter((keyID) => keyID !== keywordID);
       }
-      setSelectedKeywords(updatedSelectd);
+      setSelectedKeywords(updatedSelected);
    };
 
    const updateColumns = (column:string) => {

--- a/components/keywords/SCKeywordsTable.tsx
+++ b/components/keywords/SCKeywordsTable.tsx
@@ -78,11 +78,11 @@ const SCKeywordsTable = ({ domain, keywords = [], isLoading = true, isConsoleInt
 
    const selectKeyword = (keywordID: string) => {
       console.log('Select Keyword: ', keywordID);
-      let updatedSelectd = [...selectedKeywords, keywordID];
+      let updatedSelected = [...selectedKeywords, keywordID];
       if (selectedKeywords.includes(keywordID)) {
-         updatedSelectd = selectedKeywords.filter((keyID) => keyID !== keywordID);
+         updatedSelected = selectedKeywords.filter((keyID) => keyID !== keywordID);
       }
-      setSelectedKeywords(updatedSelectd);
+      setSelectedKeywords(updatedSelected);
    };
 
    const addSCKeywordsToTracker = () => {


### PR DESCRIPTION
## Summary
- fix typo `updatedSelectd` -> `updatedSelected` in keyword tables

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686fa463d1ac832aad16053b1d627a73