### PR TITLE
Fix typo in sort filter comments

### DIFF
--- a/utils/client/IdeasSortFilter.ts
+++ b/utils/client/IdeasSortFilter.ts
@@ -1,5 +1,5 @@
 /**
- * Sorrt Keyword Ideas by user's given input.
+ * Sort Keyword Ideas by user's given input.
  * @param {IdeaKeyword[]} theKeywords - The Keywords to sort.
  * @param {string} sortBy - The sort method.
  * @returns {IdeaKeyword[]}

--- a/utils/client/SCsortFilter.ts
+++ b/utils/client/SCsortFilter.ts
@@ -1,5 +1,5 @@
 /**
- * Sorrt Keywords by user's given input.
+ * Sort Keywords by user's given input.
  * @param {SCKeywordType[]} theKeywords - The Keywords to sort.
  * @param {string} sortBy - The sort method.
  * @returns {SCKeywordType[]}

--- a/utils/client/sortFilter.ts
+++ b/utils/client/sortFilter.ts
@@ -1,5 +1,5 @@
 /**
- * Sorrt Keywords by user's given input.
+ * Sort Keywords by user's given input.
  * @param {KeywordType[]} theKeywords - The Keywords to sort.
  * @param {string} sortBy - The sort method.
  * @returns {KeywordType[]}


### PR DESCRIPTION
## Summary
- correct header comments in sort helpers
- run eslint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686fa46912c8832aac5464b34bf69111