### PR TITLE
Fix OAuth refresh token issue

### DIFF
--- a/components/settings/AdWordsSettings.tsx
+++ b/components/settings/AdWordsSettings.tsx
@@ -34,7 +34,7 @@ const AdWordsSettings = ({ settings, settingsError, updateSettings, performUpdat
          if (performUpdate) {
             await performUpdate();
          }
-         const url = `https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?access_type=offline&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fadwords&response_type=code&client_id=${adwords_client_id}&redirect_uri=${`${encodeURIComponent(window.location.origin)}/api/adwords`}&service=lso&o2v=2&theme=glif&flowName=GeneralOAuthFlow`;
+        const url = `https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?access_type=offline&prompt=consent&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fadwords&response_type=code&client_id=${adwords_client_id}&redirect_uri=${`${encodeURIComponent(window.location.origin)}/api/adwords`}&service=lso&o2v=2&theme=glif&flowName=GeneralOAuthFlow`;
          window.open(url, '_blank');
          closeSettings();
       }


### PR DESCRIPTION
## Summary
- include `prompt=consent` when requesting Google Ads authorization so a refresh token is always returned

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fa561cc20832abb20ebc6b3bd4589