### PR TITLE
Fix trailing commas in Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,10 +15,10 @@ const customJestConfig = {
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
   transformIgnorePatterns: [
-    '/node_modules/(?!(sequelize)/)'
+    '/node_modules/(?!(sequelize)/)',
   ],
   moduleNameMapper: {
-    '^uuid$': '<rootDir>/node_modules/uuid/dist/index.js'
+    '^uuid$': '<rootDir>/node_modules/uuid/dist/index.js',
   },
 };
 


### PR DESCRIPTION
## Summary
- add trailing commas to `transformIgnorePatterns` and `moduleNameMapper` in `jest.config.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fb1321aac832a8ee4c41ed660c8e2