### PR TITLE
Display keyword location in emailed reports

### DIFF
--- a/__tests__/utils/generateEmail.test.ts
+++ b/__tests__/utils/generateEmail.test.ts
@@ -1,0 +1,42 @@
+import path from 'path';
+import fs from 'fs';
+import generateEmail from '../../utils/generateEmail';
+import { readFile } from 'fs/promises';
+
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+
+describe('generateEmail', () => {
+  it('includes city in keyword table when keyword.city is provided', async () => {
+    const template = fs.readFileSync(path.join(process.cwd(), 'email', 'email.html'), 'utf-8');
+    (readFile as jest.Mock).mockResolvedValue(template);
+
+    const keywords = [
+      {
+        ID: 1,
+        keyword: 'test keyword',
+        device: 'desktop',
+        country: 'US',
+        domain: 'example.com',
+        lastUpdated: new Date().toISOString(),
+        added: new Date().toISOString(),
+        position: 5,
+        volume: 0,
+        sticky: false,
+        history: {},
+        lastResult: [],
+        url: '',
+        tags: [],
+        updating: false,
+        lastUpdateError: false,
+        city: 'Berlin',
+      },
+    ] as any;
+
+    const settings = { search_console_client_email: '', search_console_private_key: '', keywordsColumns: [] } as any;
+
+    const html = await generateEmail('example.com', keywords, settings);
+    expect(html).toContain('(Berlin)');
+  });
+});

--- a/email/email.html
+++ b/email/email.html
@@ -441,6 +441,7 @@
                            <tbody>
                               <tr align="left">
                                  <th>Keyword</th>
+                                 <th>Location</th>
                                  <th>Position</th>
                                  <th>Best</th>
                                  <th>Updated</th>

--- a/utils/generateEmail.ts
+++ b/utils/generateEmail.ts
@@ -109,6 +109,7 @@ const generateEmail = async (domainName:string, keywords:KeywordType[], settings
       const posChangeIcon = positionChange ? `<span class="pos_change">${positionChangeIcon} ${positionChange}</span>` : '';
       keywordsTable += `<tr class="keyword">
                            <td>${countryFlag} ${deviceIcon} ${keyword.keyword}</td>
+                           <td>${keyword.city ? `(${keyword.city})` : ''}</td>
                            <td>${keyword.position}${posChangeIcon}</td>
                            <td>${getBestKeywordPosition(keyword.history)}</td>
                            <td>${timeSince(new Date(keyword.lastUpdated).getTime() / 1000)}</td>


### PR DESCRIPTION
## Summary
- include keyword city in emailed keyword table rows
- add `Location` column to email template
- test that email HTML contains the keyword city when provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979ee117c8832a912d652e945ae507