### PR TITLE
fix: remove stray quote in SelectField

### DIFF
--- a/components/common/SelectField.tsx
+++ b/components/common/SelectField.tsx
@@ -72,7 +72,7 @@ const SelectField = (props: SelectFieldProps) => {
    };
 
    return (
-       <div className={`select font-semibold text-gray-500 relative ${inline ? 'inline-block' : 'flex'} justify-between items-center"`}>
+      <div className={`select font-semibold text-gray-500 relative ${inline ? 'inline-block' : 'flex'} justify-between items-center`}>
          {label && <label className='mb-2 font-semibold inline-block text-sm text-gray-700 capitalize'>{label}</label>}
          <div
          className={`selected flex border ${rounded} p-1.5 px-4 cursor-pointer select-none ${fullWidth ? 'w-full' : 'w-full sm:w-[210px]'} 


### PR DESCRIPTION
## Summary
- fix template string in `SelectField` to remove stray quote at end of className

## Testing
- `npm run build` *(fails: Do not nest ternary expressions)*
- `npm run build -- --no-lint`


------
https://chatgpt.com/codex/tasks/task_e_6899efd6d440832a959fca92713ddaa3