### PR TITLE
refactor: remove nested ternaries from keyword tables

### DIFF
--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -128,6 +128,67 @@ const IdeasKeywordsTable = ({
       );
    };
 
+   let keywordsContent: JSX.Element | null = null;
+   if (!isLoading && finalKeywords && finalKeywords.length > 0) {
+      if (isMobile) {
+         keywordsContent = (
+            <div className='block sm:hidden'>
+               {finalKeywords.map((keyword, index) => (
+                  <KeywordIdea
+                     key={keyword.uid}
+                     style={{}}
+                     selected={selectedKeywords.includes(keyword.uid)}
+                     selectKeyword={selectKeyword}
+                     favoriteKeyword={() => favoriteKeyword(keyword.uid)}
+                     showKeywordDetails={() => setShowKeyDetails(keyword)}
+                     isFavorite={favoriteIDs.includes(keyword.uid)}
+                     keywordData={keyword}
+                     lastItem={index === (finalKeywords.length - 1)}
+                  />
+               ))}
+            </div>
+         );
+      } else {
+         keywordsContent = (
+            <div className='hidden sm:block'>
+               <List
+               innerElementType="div"
+               itemData={finalKeywords}
+               itemCount={finalKeywords.length}
+               itemSize={isMobile ? 100 : 57}
+               height={listHeight}
+               width={'100%'}
+               className={'styled-scrollbar'}
+               >
+                  {Row}
+               </List>
+            </div>
+         );
+      }
+   } else {
+      keywordsContent = (
+         <>
+            {isAdwordsIntegrated && isLoading && (
+               <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Keywords Ideas...</p>
+            )}
+            {isAdwordsIntegrated && noIdeasDatabase && !isLoading && (
+               <p className=' p-9 pt-[10%] text-center text-gray-500'>
+                  {'No keyword Ideas has been generated for this domain yet. Click the "Load Ideas" button to generate keyword ideas.'}
+               </p>
+            )}
+            {isAdwordsIntegrated && !isLoading && finalKeywords.length === 0 && !noIdeasDatabase && (
+               <p className=' p-9 pt-[10%] text-center text-gray-500'>
+                  {'No Keyword Ideas found. Please try generating Keyword Ideas again by clicking the "Load Ideas" button.'}
+               </p>
+            )}
+            {!isAdwordsIntegrated && (
+               <p className=' p-9 pt-[10%] text-center text-gray-500'>
+                  Google Ads has not been Integrated yet. Please follow <a className='text-indigo-600 underline' href='https://docs.serpbear.com/miscellaneous/integrate-google-ads' target="_blank" rel='noreferrer'>These Steps</a> to integrate Google Ads.
+               </p>
+            )}
+         </>
+      );
+   }
    return (
       <div>
          <div className='domKeywords flex flex-col bg-[white] rounded-md text-sm border mb-5'>
@@ -200,60 +261,7 @@ const IdeasKeywordsTable = ({
                      <span className='domKeywords_head_competition flex-1 text-center'>Competition</span>
                   </div>
                   <div className='domKeywords_keywords border-gray-200 min-h-[55vh] relative' data-domain={domain?.domain}>
-                     {!isLoading && finalKeywords && finalKeywords.length > 0 ? (
-                        isMobile ? (
-                           <div className='block sm:hidden'>
-                              {finalKeywords.map((keyword, index) => (
-                                 <KeywordIdea
-                                    key={keyword.uid}
-                                    style={{}}
-                                    selected={selectedKeywords.includes(keyword.uid)}
-                                    selectKeyword={selectKeyword}
-                                    favoriteKeyword={() => favoriteKeyword(keyword.uid)}
-                                    showKeywordDetails={() => setShowKeyDetails(keyword)}
-                                    isFavorite={favoriteIDs.includes(keyword.uid)}
-                                    keywordData={keyword}
-                                    lastItem={index === (finalKeywords.length - 1)}
-                                 />
-                              ))}
-                           </div>
-                        ) : (
-                           <div className='hidden sm:block'>
-                              <List
-                              innerElementType="div"
-                              itemData={finalKeywords}
-                              itemCount={finalKeywords.length}
-                              itemSize={isMobile ? 100 : 57}
-                              height={listHeight}
-                              width={'100%'}
-                              className={'styled-scrollbar'}
-                              >
-                                 {Row}
-                              </List>
-                           </div>
-                        )
-                     ) : (
-                        <>
-                           {isAdwordsIntegrated && isLoading && (
-                              <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Keywords Ideas...</p>
-                           )}
-                           {isAdwordsIntegrated && noIdeasDatabase && !isLoading && (
-                              <p className=' p-9 pt-[10%] text-center text-gray-500'>
-                                 {'No keyword Ideas has been generated for this domain yet. Click the "Load Ideas" button to generate keyword ideas.'}
-                              </p>
-                           )}
-                           {isAdwordsIntegrated && !isLoading && finalKeywords.length === 0 && !noIdeasDatabase && (
-                              <p className=' p-9 pt-[10%] text-center text-gray-500'>
-                                 {'No Keyword Ideas found. Please try generating Keyword Ideas again by clicking the "Load Ideas" button.'}
-                              </p>
-                           )}
-                           {!isAdwordsIntegrated && (
-                              <p className=' p-9 pt-[10%] text-center text-gray-500'>
-                                 Google Ads has not been Integrated yet. Please follow <a className='text-indigo-600 underline' href='https://docs.serpbear.com/miscellaneous/integrate-google-ads' target="_blank" rel='noreferrer'>These Steps</a> to integrate Google Ads.
-                              </p>
-                           )}
-                        </>
-                     )}
+                     {keywordsContent}
                   </div>
                </div>
             </div>

--- a/components/keywords/KeywordsTable.tsx
+++ b/components/keywords/KeywordsTable.tsx
@@ -127,6 +127,59 @@ const KeywordsTable = (props: KeywordsTableProps) => {
 
    const selectedAllItems = selectedKeywords.length === processedKeywords[device].length;
 
+   let keywordsContent: JSX.Element | null = null;
+   if (processedKeywords[device] && processedKeywords[device].length > 0) {
+      if (isMobile) {
+         keywordsContent = (
+            <div className='block sm:hidden'>
+               {processedKeywords[device].map((keyword, index) => (
+                  <Keyword
+                     key={keyword.ID}
+                     style={{}}
+                     index={index}
+                     selected={selectedKeywords.includes(keyword.ID)}
+                     selectKeyword={selectKeyword}
+                     keywordData={keyword}
+                     refreshkeyword={() => refreshMutate({ ids: [keyword.ID] })}
+                     favoriteKeyword={favoriteMutate}
+                     manageTags={() => setShowTagManager(keyword.ID)}
+                     removeKeyword={() => { setSelectedKeywords([keyword.ID]); setShowRemoveModal(true); }}
+                     showKeywordDetails={() => setShowKeyDetails(keyword)}
+                     lastItem={index === (processedKeywords[device].length - 1)}
+                     showSCData={showSCData}
+                     scDataType={scDataType}
+                     maxTitleColumnWidth={maxTitleColumnWidth}
+                     tableColumns={tableColumns}
+                  />
+               ))}
+            </div>
+         );
+      } else {
+         keywordsContent = (
+            <div className='hidden sm:block'>
+               <List
+               innerElementType="div"
+               itemData={processedKeywords[device]}
+               itemCount={processedKeywords[device].length}
+               itemSize={isMobile ? 146 : 57}
+               height={SCListHeight}
+               width={'100%'}
+               className={'styled-scrollbar'}
+               >
+                  {Row}
+               </List>
+            </div>
+         );
+      }
+   } else {
+      keywordsContent = (
+         !isLoading ? (
+            <p className=' p-9 pt-[10%] text-center text-gray-500'>No Keywords Added for this Device Type.</p>
+         ) : (
+            <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Keywords...</p>
+         )
+      );
+   }
    return (
       <div>
          <div className='domKeywords flex flex-col bg-[white] rounded-md text-sm border mb-5'>
@@ -237,52 +290,7 @@ const KeywordsTable = (props: KeywordsTableProps) => {
                      )}
                   </div>
                   <div className='domKeywords_keywords border-gray-200 min-h-[55vh] relative'>
-                     {processedKeywords[device] && processedKeywords[device].length > 0 ? (
-                        isMobile ? (
-                           <div className='block sm:hidden'>
-                              {processedKeywords[device].map((keyword, index) => (
-                                 <Keyword
-                                    key={keyword.ID}
-                                    style={{}}
-                                    index={index}
-                                    selected={selectedKeywords.includes(keyword.ID)}
-                                    selectKeyword={selectKeyword}
-                                    keywordData={keyword}
-                                    refreshkeyword={() => refreshMutate({ ids: [keyword.ID] })}
-                                    favoriteKeyword={favoriteMutate}
-                                    manageTags={() => setShowTagManager(keyword.ID)}
-                                    removeKeyword={() => { setSelectedKeywords([keyword.ID]); setShowRemoveModal(true); }}
-                                    showKeywordDetails={() => setShowKeyDetails(keyword)}
-                                    lastItem={index === (processedKeywords[device].length - 1)}
-                                    showSCData={showSCData}
-                                    scDataType={scDataType}
-                                    maxTitleColumnWidth={maxTitleColumnWidth}
-                                    tableColumns={tableColumns}
-                                 />
-                              ))}
-                           </div>
-                        ) : (
-                           <div className='hidden sm:block'>
-                              <List
-                              innerElementType="div"
-                              itemData={processedKeywords[device]}
-                              itemCount={processedKeywords[device].length}
-                              itemSize={isMobile ? 146 : 57}
-                              height={SCListHeight}
-                              width={'100%'}
-                              className={'styled-scrollbar'}
-                              >
-                                 {Row}
-                              </List>
-                           </div>
-                        )
-                     ) : (
-                        !isLoading ? (
-                           <p className=' p-9 pt-[10%] text-center text-gray-500'>No Keywords Added for this Device Type.</p>
-                        ) : (
-                           <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Keywords...</p>
-                        )
-                     )}
+                       {keywordsContent}
                   </div>
                </div>
             </div>


### PR DESCRIPTION
## Summary
- replace nested ternary logic in KeywordIdeasTable with clearer conditional rendering
- refactor KeywordsTable to compute content before rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f9a1f784832a8f9f59465ab253bf