### PR TITLE
fix: increase domain header action menu z-index

### DIFF
--- a/components/domains/DomainHeader.tsx
+++ b/components/domains/DomainHeader.tsx
@@ -96,7 +96,7 @@ const DomainHeader = (
             }
             {isInsight && <button className={`${buttonStyle} lg:hidden invisible`}>x</button>}
             <div
-            className={`hidden w-40 ml-[-70px] lg:block absolute mt-10 bg-white border border-gray-100 z-40 rounded 
+            className={`hidden w-40 ml-[-70px] lg:block absolute mt-10 bg-white border border-gray-100 z-[60] rounded
             lg:z-auto lg:relative lg:mt-0 lg:border-0 lg:w-auto lg:bg-transparent`}
             style={{ display: showOptions ? 'block' : undefined }}>
                {!isInsight && (


### PR DESCRIPTION
## Summary
- ensure domain header action menu renders above domain selector on mobile by bumping z-index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a0088d164832aaf6e4c65553b904b