### PR TITLE
Fix syntax in Search Console test

### DIFF
--- a/__tests__/api/searchconsole.test.ts
+++ b/__tests__/api/searchconsole.test.ts
@@ -89,7 +89,7 @@ describe('/api/searchconsole - CRON functionality', () => {
       lastFetched: new Date().toISOString(),
       lastFetchError: '',
       stats: [],
-    },);
+    });
 
     await handler(req as NextApiRequest, res as NextApiResponse);
 


### PR DESCRIPTION
## Summary
- remove stray comma in Search Console API test to restore valid syntax

## Testing
- `npm test __tests__/api/searchconsole.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689a02bce550832aa18730130c012c17