### PR TITLE
feat: add state-based location targeting

### DIFF
--- a/__tests__/utils/generateEmail.test.ts
+++ b/__tests__/utils/generateEmail.test.ts
@@ -7,7 +7,7 @@ import generateEmail from '../../utils/generateEmail';
 const { readFile: mockReadFile } = require('fs/promises') as { readFile: jest.Mock };
 
 describe('generateEmail', () => {
-  it('includes city in keyword table when keyword.city is provided', async () => {
+  it('includes city and state in keyword table when provided', async () => {
     mockReadFile.mockResolvedValue('<html>{{keywordsTable}}</html>');
 
     const keywords = [
@@ -29,12 +29,13 @@ describe('generateEmail', () => {
         updating: false,
         lastUpdateError: false,
         city: 'Berlin',
+        state: 'Berlin State',
       },
     ] as any;
 
     const settings = { search_console_client_email: '', search_console_private_key: '', keywordsColumns: [] } as any;
 
     const html = await generateEmail('example.com', keywords, settings);
-    expect(html).toContain('(Berlin)');
+    expect(html).toContain('(Berlin, Berlin State)');
   });
 });

--- a/components/keywords/AddKeywords.tsx
+++ b/components/keywords/AddKeywords.tsx
@@ -20,6 +20,7 @@ type KeywordsInput = {
    domain: string,
    tags: string,
    city?:string,
+   state?:string,
 }
 
 const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCity = false }: AddKeywordsProps) => {
@@ -28,7 +29,7 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
 
    const [error, setError] = useState<string>('');
    const [showTagSuggestions, setShowTagSuggestions] = useState(false);
-   const [newKeywordsData, setNewKeywordsData] = useState<KeywordsInput>({ keywords: '', device: 'desktop', country: defCountry, domain, tags: '' });
+   const [newKeywordsData, setNewKeywordsData] = useState<KeywordsInput>({ keywords: '', device: 'desktop', country: defCountry, domain, tags: '', city: '', state: '' });
    const { mutate: addMutate, isLoading: isAdding } = useAddKeywords(() => closeModal(false));
 
    const existingTags: string[] = useMemo(() => {
@@ -52,10 +53,10 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
          const devices = nkwrds.device.split(',');
          const multiDevice = nkwrds.device.includes(',') && devices.length > 1;
          const keywordsArray = [...new Set(nkwrds.keywords.split('\n').map((item) => item.trim()).filter((item) => !!item))];
-         const currentKeywords = keywords.map((k) => `${k.keyword}-${k.device}-${k.country}${k.city ? `-${k.city}` : ''}`);
+         const currentKeywords = keywords.map((k) => `${k.keyword}-${k.device}-${k.country}${k.state ? `-${k.state}` : ''}${k.city ? `-${k.city}` : ''}`);
 
          const keywordExist = keywordsArray.filter((k) =>
-            devices.some((device) => currentKeywords.includes(`${k}-${device}-${nkwrds.country}${nkwrds.city ? `-${nkwrds.city}` : ''}`)),
+            devices.some((device) => currentKeywords.includes(`${k}-${device}-${nkwrds.country}${nkwrds.state ? `-${nkwrds.state}` : ''}${nkwrds.city ? `-${nkwrds.city}` : ''}`)),
          );
 
          if (!multiDevice && (keywordsArray.length === 1 || currentKeywords.length === keywordExist.length) && keywordExist.length > 0) {
@@ -64,7 +65,7 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
          } else {
             const newKeywords = keywordsArray.flatMap((k) =>
                devices.filter((device) =>
-                 !currentKeywords.includes(`${k}-${device}-${nkwrds.country}${nkwrds.city ? `-${nkwrds.city}` : ''}`),
+                 !currentKeywords.includes(`${k}-${device}-${nkwrds.country}${nkwrds.state ? `-${nkwrds.state}` : ''}${nkwrds.city ? `-${nkwrds.city}` : ''}`),
                ).map((device) => ({
                  keyword: k,
                  device,
@@ -72,8 +73,9 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
                  domain: nkwrds.domain,
                  tags: nkwrds.tags,
                  city: nkwrds.city,
+                 state: nkwrds.state,
                })),
-             );
+            );
             addMutate(newKeywords);
          }
       } else {
@@ -164,13 +166,25 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
                                  )
                            );
                         })}
-                        {existingTags.length === 0 && <p>No Existing Tags Found... </p>}
-                     </ul>
-                  )}
+               {existingTags.length === 0 && <p>No Existing Tags Found... </p>}
+                    </ul>
+                 )}
+              </div>
+               <div className='relative mt-2'>
+                  <input
+                     className={`w-full border rounded border-gray-200 py-2 px-4 pl-8
+                     outline-none focus:border-indigo-300 ${!allowsCity ? ' cursor-not-allowed' : ''} `}
+                     disabled={!allowsCity}
+                     title={!allowsCity ? `Your scraper ${scraperName} doesn't have city level scraping feature.` : ''}
+                     placeholder={`State (Optional)${!allowsCity ? `. Not available for ${scraperName}.` : ''}`}
+                     value={newKeywordsData.state}
+                     onChange={(e) => setNewKeywordsData({ ...newKeywordsData, state: e.target.value })}
+                  />
+                  <span className='absolute text-gray-400 top-2 left-2'><Icon type="city" size={16} /></span>
                </div>
                <div className='relative mt-2'>
                   <input
-                     className={`w-full border rounded border-gray-200 py-2 px-4 pl-8 
+                     className={`w-full border rounded border-gray-200 py-2 px-4 pl-8
                      outline-none focus:border-indigo-300 ${!allowsCity ? ' cursor-not-allowed' : ''} `}
                      disabled={!allowsCity}
                      title={!allowsCity ? `Your scraper ${scraperName} doesn't have city level scraping feature.` : ''}

--- a/components/keywords/Keyword.tsx
+++ b/components/keywords/Keyword.tsx
@@ -45,7 +45,7 @@ const Keyword = (props: KeywordProps) => {
       maxTitleColumnWidth,
    } = props;
    const {
-      keyword, domain, ID, city, position, url = '', lastUpdated, country, sticky, history = {}, updating = false, lastUpdateError = false, volume,
+      keyword, domain, ID, city, state, position, url = '', lastUpdated, country, sticky, history = {}, updating = false, lastUpdateError = false, volume,
    } = keywordData;
 
    const [showOptions, setShowOptions] = useState(false);
@@ -113,7 +113,7 @@ const Keyword = (props: KeywordProps) => {
             >
                <span className={`fflag fflag-${country} w-[18px] h-[12px] mr-2`} title={countries[country][0]} />
                <span className='inline-block text-ellipsis overflow-hidden whitespace-nowrap w-[calc(100%-50px)]'>
-                  {keyword}{city ? ` (${city})` : ''}
+                  {keyword}{city || state ? ` (${[city, state].filter(Boolean).join(', ')})` : ''}
                </span>
             </a>
             {sticky && <button className='ml-2 relative top-[2px]' title='Favorite'><Icon type="star-filled" size={16} color="#fbd346" /></button>}

--- a/database/migrations/1710000000000-add-keyword-state-field.js
+++ b/database/migrations/1710000000000-add-keyword-state-field.js
@@ -1,0 +1,29 @@
+// Migration: Adds state field to keyword table.
+
+// CLI Migration
+module.exports = {
+   up: async (queryInterface, Sequelize) => {
+      return queryInterface.sequelize.transaction(async (t) => {
+         try {
+            const keywordTableDefinition = await queryInterface.describeTable('keyword');
+            if (keywordTableDefinition && !keywordTableDefinition.state) {
+               await queryInterface.addColumn('keyword', 'state', { type: Sequelize.DataTypes.STRING }, { transaction: t });
+            }
+         } catch (error) {
+            console.log('error :', error);
+         }
+      });
+   },
+   down: (queryInterface) => {
+      return queryInterface.sequelize.transaction(async (t) => {
+         try {
+            const keywordTableDefinition = await queryInterface.describeTable('keyword');
+            if (keywordTableDefinition && keywordTableDefinition.state) {
+               await queryInterface.removeColumn('keyword', 'state', { transaction: t });
+            }
+         } catch (error) {
+            console.log('error :', error);
+         }
+      });
+   },
+};

--- a/database/models/keyword.ts
+++ b/database/models/keyword.ts
@@ -23,6 +23,9 @@ class Keyword extends Model {
    city!: string;
 
    @Column({ type: DataType.STRING, allowNull: true, defaultValue: '' })
+   state!: string;
+
+   @Column({ type: DataType.STRING, allowNull: true, defaultValue: '' })
    latlong!: string;
 
    @Column({ type: DataType.STRING, allowNull: false, defaultValue: '{}' })

--- a/pages/api/keywords.ts
+++ b/pages/api/keywords.ts
@@ -82,7 +82,7 @@ const addKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsGet
       const keywordsToAdd: any = []; // QuickFIX for bug: https://github.com/sequelize/sequelize-typescript/issues/936
 
       keywords.forEach((kwrd: KeywordAddPayload) => {
-         const { keyword, device, country, domain, tags, city } = kwrd;
+         const { keyword, device, country, domain, tags, city, state } = kwrd;
          const tagsArray = tags ? tags.split(',').map((item:string) => item.trim()) : [];
          const newKeyword = {
             keyword,
@@ -90,6 +90,7 @@ const addKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsGet
             domain,
             country,
             city,
+            state,
             position: 0,
             updating: true,
             history: JSON.stringify({}),

--- a/scrapers/services/hasdata.ts
+++ b/scrapers/services/hasdata.ts
@@ -20,7 +20,8 @@ const hasdata:ScraperSettings = {
    scrapeURL: (keyword, settings) => {
       const country = keyword.country || 'US';
       const countryName = countries[country][0];
-      const location = keyword.city && countryName ? `&location=${encodeURIComponent(`${keyword.city},${countryName}`)}` : '';
+      const locationParts = [keyword.city, keyword.state, countryName].filter(Boolean);
+      const location = keyword.city || keyword.state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
       return `https://api.scrape-it.cloud/scrape/google/serp?q=${encodeURIComponent(keyword.keyword)}${location}&num=100&gl=${country.toLowerCase()}&deviceType=${keyword.device}`;
    },
    resultObjectKey: 'organicResults',

--- a/scrapers/services/searchapi.ts
+++ b/scrapers/services/searchapi.ts
@@ -20,7 +20,8 @@ const searchapi:ScraperSettings = {
   scrapeURL: (keyword) => {
    const country = keyword.country || 'US';
    const countryName = countries[country][0];
-   const location = keyword.city && countryName ? `&location=${encodeURIComponent(`${keyword.city},${countryName}`)}` : '';
+   const locationParts = [keyword.city, keyword.state, countryName].filter(Boolean);
+   const location = keyword.city || keyword.state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
      return `https://www.searchapi.io/api/v1/search?engine=google&q=${encodeURIComponent(keyword.keyword)}&num=100&gl=${country}&device=${keyword.device}${location}`;
   },
   resultObjectKey: 'organic_results',

--- a/scrapers/services/serpapi.ts
+++ b/scrapers/services/serpapi.ts
@@ -19,7 +19,8 @@ const serpapi:ScraperSettings = {
    },
    scrapeURL: (keyword, settings) => {
       const countryName = countries[keyword.country || 'US'][0];
-      const location = keyword.city && keyword.country ? `&location=${encodeURIComponent(`${keyword.city},${countryName}`)}` : '';
+      const locationParts = [keyword.city, keyword.state, countryName].filter(Boolean);
+      const location = keyword.city || keyword.state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
       return `https://serpapi.com/search?q=${encodeURIComponent(keyword.keyword)}&num=100&gl=${keyword.country}&device=${keyword.device}${location}&api_key=${settings.scaping_api}`;
    },
    resultObjectKey: 'organic_results',

--- a/scrapers/services/spaceserp.ts
+++ b/scrapers/services/spaceserp.ts
@@ -15,7 +15,8 @@ const spaceSerp:ScraperSettings = {
    scrapeURL: (keyword, settings, countryData) => {
       const country = keyword.country || 'US';
       const countryName = countries[country][0];
-      const location = keyword.city ? `&location=${encodeURIComponent(`${keyword.city},${countryName}`)}` : '';
+      const locationParts = [keyword.city, keyword.state, countryName].filter(Boolean);
+      const location = keyword.city || keyword.state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
       const device = keyword.device === 'mobile' ? '&device=mobile' : '';
       const lang = countryData[country][2];
       return `https://api.spaceserp.com/google/search?apiKey=${settings.scaping_api}&q=${encodeURIComponent(keyword.keyword)}&pageSize=100&gl=${country}&hl=${lang}${location}${device}&resultBlocks=`;

--- a/scrapers/services/valueserp.ts
+++ b/scrapers/services/valueserp.ts
@@ -15,7 +15,8 @@ const valueSerp:ScraperSettings = {
    scrapeURL: (keyword, settings, countryData) => {
       const country = keyword.country || 'US';
       const countryName = countries[country][0];
-      const location = keyword.city ? `&location=${encodeURIComponent(`${keyword.city},${countryName}`)}` : '';
+      const locationParts = [keyword.city, keyword.state, countryName].filter(Boolean);
+      const location = keyword.city || keyword.state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
       const device = keyword.device === 'mobile' ? '&device=mobile' : '';
       const lang = countryData[country][2];
       console.log(`https://api.valueserp.com/search?api_key=${settings.scaping_api}&q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}${device}${location}&num=100&output=json&include_answer_box=false&include_advertiser_info=false`);

--- a/types.d.ts
+++ b/types.d.ts
@@ -43,6 +43,7 @@ type KeywordType = {
    scData?: KeywordSCData,
    uid?: string
    city?: string
+   state?: string
 }
 
 type KeywordLastResult = {
@@ -131,7 +132,8 @@ type KeywordAddPayload = {
    country: string,
    domain: string,
    tags?: string,
-   city?:string
+   city?:string,
+   state?:string
 }
 
 type SearchAnalyticsRawItem = {

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -27,6 +27,7 @@ type keywordIdeasResponseItem = {
 type IdeaSettings = {
    country?: string;
    city?: string;
+   state?: string;
    language?: string;
    keywords?: string[];
    url?: string;

--- a/utils/client/exportcsv.ts
+++ b/utils/client/exportcsv.ts
@@ -9,7 +9,7 @@ import countries from '../countries';
 const exportCSV = (keywords: KeywordType[] | SCKeywordType[], domain:string, scDataDuration = 'lastThreeDays') => {
    if (!keywords || (keywords && Array.isArray(keywords) && keywords.length === 0)) { return; }
    const isSCKeywords = !!(keywords && keywords[0] && keywords[0].uid);
-   let csvHeader = 'ID,Keyword,Position,URL,Country,City,Device,Updated,Added,Tags\r\n';
+   let csvHeader = 'ID,Keyword,Position,URL,Country,State,City,Device,Updated,Added,Tags\r\n';
    let csvBody = '';
    let fileName = `${domain}-keywords_serp.csv`;
 
@@ -26,9 +26,9 @@ const exportCSV = (keywords: KeywordType[] | SCKeywordType[], domain:string, scD
       });
    } else {
       keywords.forEach((keywordData) => {
-         const { ID, keyword, position, url, country, city, device, lastUpdated, added, tags } = keywordData as KeywordType;
+         const { ID, keyword, position, url, country, state, city, device, lastUpdated, added, tags } = keywordData as KeywordType;
          // eslint-disable-next-line max-len
-         csvBody += `${ID}, ${keyword}, ${position === 0 ? '-' : position}, ${url || '-'}, ${countries[country][0]}, ${city || '-'}, ${device}, ${lastUpdated}, ${added}, ${tags.join(',')}\r\n`;
+         csvBody += `${ID}, ${keyword}, ${position === 0 ? '-' : position}, ${url || '-'}, ${countries[country][0]}, ${state || '-'}, ${city || '-'}, ${device}, ${lastUpdated}, ${added}, ${tags.join(',')}\r\n`;
       });
    }
 

--- a/utils/generateEmail.ts
+++ b/utils/generateEmail.ts
@@ -109,7 +109,7 @@ const generateEmail = async (domainName:string, keywords:KeywordType[], settings
       const posChangeIcon = positionChange ? `<span class="pos_change">${positionChangeIcon} ${positionChange}</span>` : '';
       keywordsTable += `<tr class="keyword">
                            <td>${countryFlag} ${deviceIcon} ${keyword.keyword}</td>
-                           <td>${keyword.city ? `(${keyword.city})` : ''}</td>
+                           <td>${keyword.city || keyword.state ? `(${[keyword.city, keyword.state].filter(Boolean).join(', ')})` : ''}</td>
                            <td>${keyword.position}${posChangeIcon}</td>
                            <td>${getBestKeywordPosition(keyword.history)}</td>
                            <td>${timeSince(new Date(keyword.lastUpdated).getTime() / 1000)}</td>


### PR DESCRIPTION
## Summary
- expand keyword model with optional state field
- update Add Keywords UI and API to capture state
- include state in scraper location parameters and exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a02615bc4832ab9cda18b6afae2d4