### PR TITLE
test: convert fs/promises require to esm import

### DIFF
--- a/__tests__/utils/generateEmail.test.ts
+++ b/__tests__/utils/generateEmail.test.ts
@@ -1,10 +1,11 @@
+import { readFile } from 'fs/promises';
+import generateEmail from '../../utils/generateEmail';
+
 jest.mock('fs/promises', () => ({
   readFile: jest.fn(),
 }));
 
-import generateEmail from '../../utils/generateEmail';
-
-const { readFile: mockReadFile } = require('fs/promises') as { readFile: jest.Mock };
+const mockReadFile = readFile as jest.Mock;
 
 describe('generateEmail', () => {
   it('includes city in keyword table when keyword.city is provided', async () => {


### PR DESCRIPTION
## Summary
- move imports above `jest.mock` in `generateEmail.test.ts`
- switch to ES module `readFile` import and alias to `jest.Mock`

## Testing
- `npm test -- __tests__/utils/generateEmail.test.ts`
- `npx eslint __tests__/utils/generateEmail.test.ts -f json`


------
https://chatgpt.com/codex/tasks/task_e_689a09691f20832a82c402b68a6043a7