### PR TITLE
fix trailing comma in searchconsole test mock

### DIFF
--- a/__tests__/api/searchconsole.test.ts
+++ b/__tests__/api/searchconsole.test.ts
@@ -199,7 +199,7 @@ describe('/api/searchconsole - CRON functionality', () => {
         lastFetched: new Date().toISOString(),
         lastFetchError: '',
         stats: [],
-      },);
+      });
 
     await handler(req as NextApiRequest, res as NextApiResponse);
 


### PR DESCRIPTION
## Summary
- remove stray comma from searchconsole test mockResolvedValueOnce call

## Testing
- `npm run lint` *(fails: max-len errors in unrelated files)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a09b5b3f8832a935ef0b376d48369