### PR TITLE
fix: resolve Next.js lint errors and remove deprecated option

### DIFF
--- a/components/keywords/Keyword.tsx
+++ b/components/keywords/Keyword.tsx
@@ -44,9 +44,22 @@ const Keyword = (props: KeywordProps) => {
       tableColumns = [],
       maxTitleColumnWidth,
    } = props;
-   const {
-      keyword, domain, ID, city, state, position, url = '', lastUpdated, country, sticky, history = {}, updating = false, lastUpdateError = false, volume,
-   } = keywordData;
+     const {
+        keyword,
+        domain,
+        ID,
+        city,
+        state,
+        position,
+        url = '',
+        lastUpdated,
+        country,
+        sticky,
+        history = {},
+        updating = false,
+        lastUpdateError = false,
+        volume,
+     } = keywordData;
 
    const [showOptions, setShowOptions] = useState(false);
    const [showPositionError, setPositionError] = useState(false);

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,6 @@ const { version } = require('./package.json');
 
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: false,
   output: 'standalone',
   publicRuntimeConfig: {
    version,


### PR DESCRIPTION
## Summary
- refactor AddKeywords to split long lines and use intermediate variables
- break up large destructuring in Keyword component
- drop deprecated `swcMinify` option from Next.js config

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a0b168ef0832a8ee10bfdd1a3e6f9