### PR TITLE
Potential fix for code scanning alert no. 3: Inefficient regular expression

### DIFF
--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -42,7 +42,7 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
       let error: DomainSettingsError | null = null;
       if (domainSettings.notification_emails) {
          const notification_emails = domainSettings.notification_emails.split(',');
-         const invalidEmails = notification_emails.find((x) => /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,15})+$/.test(x) === false);
+         const invalidEmails = notification_emails.find((x) => /^\w+(?:[.-]\w+)*@\w+(?:[.-]\w+)*(\.\w{2,15})+$/.test(x) === false);
          console.log('invalidEmails: ', invalidEmails);
          if (invalidEmails) {
             error = { type: 'email', msg: 'Invalid Email' };


### PR DESCRIPTION
Potential fix for [https://github.com/djav1985/v-serpbear/security/code-scanning/3](https://github.com/djav1985/v-serpbear/security/code-scanning/3)

To fix the inefficient regular expression, we need to remove the ambiguity in the repeated subexpressions. The main issue is with `\w+([.-]?\w+)*`, which can match the same substring in multiple ways. A common solution is to replace this with a pattern that does not allow ambiguous matches, such as `\w+(?:[.-]\w+)*`, which requires that dots or hyphens are always followed by at least one word character, and does not allow for optional empty matches. This change should be made in the regular expression on line 45 of `components/domains/DomainSettings.tsx`. No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
