### PR TITLE
fix: improve mobile menu behavior

### DIFF
--- a/components/common/TopBar.tsx
+++ b/components/common/TopBar.tsx
@@ -30,7 +30,7 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
    };
 
    return (
-       <div className={`topbar flex w-full mx-auto justify-between 
+       <div className={`topbar flex items-center w-full mx-auto justify-between
        ${isDomainsPage ? 'max-w-5xl lg:justify-between' : 'max-w-7xl lg:justify-end'}  bg-white lg:bg-transparent`}>
 
          <h3 className={`p-4 text-base font-bold text-blue-700 ${isDomainsPage ? 'lg:pl-0' : 'lg:hidden'}`}>
@@ -50,7 +50,7 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
                <Icon type="hamburger" size={24} />
             </button>
             <ul
-               className={`text-sm font-semibold text-gray-500 absolute mt-[-10px] right-3 bg-white
+               className={`text-sm font-semibold text-gray-500 absolute mt-0 right-3 bg-white
                border border-gray-200 lg:mt-2 lg:relative lg:block lg:border-0 lg:bg-transparent ${showMobileMenu ? 'block z-50' : 'hidden'}`}
             >
                <li className={`block lg:inline-block lg:ml-5 ${router.asPath === '/domains' ? ' text-blue-700' : ''}`}>

--- a/components/common/TopBar.tsx
+++ b/components/common/TopBar.tsx
@@ -50,8 +50,9 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
                <Icon type="hamburger" size={24} />
             </button>
             <ul
-            className={`text-sm font-semibold text-gray-500 absolute mt-[-10px] right-3 bg-white 
-            border border-gray-200 lg:mt-2 lg:relative lg:block lg:border-0 lg:bg-transparent ${showMobileMenu ? 'block' : 'hidden'}`}>
+               className={`text-sm font-semibold text-gray-500 absolute mt-[-10px] right-3 bg-white
+               border border-gray-200 lg:mt-2 lg:relative lg:block lg:border-0 lg:bg-transparent ${showMobileMenu ? 'block z-50' : 'hidden'}`}
+            >
                <li className={`block lg:inline-block lg:ml-5 ${router.asPath === '/domains' ? ' text-blue-700' : ''}`}>
                   <Link href={'/domains'} passHref={true}>
                      <a className='block px-3 py-2 cursor-pointer'>

--- a/components/domains/DomainHeader.tsx
+++ b/components/domains/DomainHeader.tsx
@@ -103,7 +103,7 @@ const DomainHeader = (
                   <button
                   className={`domheader_action_button relative ${buttonStyle}`}
                   aria-pressed="false"
-                  onClick={() => exportCsv()}>
+                  onClick={() => { exportCsv(); setShowOptions(false); }}>
                      <Icon type='download' size={20} /><i className={`${buttonLabelStyle}`}>Export as csv</i>
                   </button>
                )}
@@ -111,7 +111,7 @@ const DomainHeader = (
                   <button
                   className={`domheader_action_button relative ${buttonStyle} lg:ml-3`}
                   aria-pressed="false"
-                  onClick={() => refreshMutate({ ids: [], domain: domain.domain })}>
+                  onClick={() => { refreshMutate({ ids: [], domain: domain.domain }); setShowOptions(false); }}>
                      <Icon type='reload' size={14} /><i className={`${buttonLabelStyle}`}>Reload All Serps</i>
                   </button>
                 )}
@@ -119,7 +119,7 @@ const DomainHeader = (
                data-testid="show_domain_settings"
                className={`domheader_action_button relative ${buttonStyle} lg:ml-3`}
                aria-pressed="false"
-               onClick={() => showSettingsModal(true)}><Icon type='settings' size={20} />
+               onClick={() => { showSettingsModal(true); setShowOptions(false); }}><Icon type='settings' size={20} />
                   <i className={`${buttonLabelStyle}`}>Domain Settings</i>
                </button>
             </div>

--- a/components/domains/DomainHeader.tsx
+++ b/components/domains/DomainHeader.tsx
@@ -96,9 +96,9 @@ const DomainHeader = (
             }
             {isInsight && <button className={`${buttonStyle} lg:hidden invisible`}>x</button>}
             <div
-            className={'absolute top-full right-0 w-40 mt-2 bg-white border border-gray-100 rounded z-[70]'
-            + ' lg:block lg:static lg:mt-0 lg:border-0 lg:w-auto lg:bg-transparent'}
-            style={{ display: showOptions ? 'block' : undefined }}>
+            className={`absolute top-full right-0 w-40 mt-2 bg-white border border-gray-100 rounded z-[70] ${
+               showOptions ? 'block' : 'hidden'
+            } lg:block lg:static lg:mt-0 lg:border-0 lg:w-auto lg:bg-transparent`}>
                {!isInsight && (
                   <button
                   className={`domheader_action_button relative ${buttonStyle}`}


### PR DESCRIPTION
## Summary
- ensure topbar mobile menu displays above other elements with higher z-index
- close domain action menu after selecting an option on mobile

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3422ca60832a81192b05656d5273