### PR TITLE
Improve keyword idea error handling

### DIFF
--- a/services/adwords.tsx
+++ b/services/adwords.tsx
@@ -54,7 +54,8 @@ export function useMutateKeywordIdeas(router:NextRouter, onSuccess?: Function) {
       const fetchOpts = { method: 'POST', headers, body: JSON.stringify({ ...data }) };
       const res = await fetch(`${window.location.origin}/api/ideas`, fetchOpts);
       if (res.status >= 400 && res.status < 600) {
-         throw new Error('Bad response from server');
+         const errorData = await res.json();
+         throw new Error(errorData?.error ? errorData.error : 'Bad response from server');
       }
       return res.json();
    }, {
@@ -68,7 +69,8 @@ export function useMutateKeywordIdeas(router:NextRouter, onSuccess?: Function) {
       },
       onError: (error) => {
          console.log('Error Loading Keyword Ideas!!!', error);
-         toast('Error Loading Keyword Ideas', { icon: '⚠️' });
+         const message = (error as Error)?.message || 'Error Loading Keyword Ideas';
+         toast(message, { icon: '⚠️' });
       },
    });
 }

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -193,8 +193,9 @@ export const getAdwordsKeywordIdeas = async (credentials:AdwordsCredentials, adw
          const ideaData = await resp.json();
 
          if (resp.status !== 200) {
-            console.log('[ERROR] Google Ads Response :', ideaData?.error?.details[0]?.errors[0]?.message);
-            // console.log('Response from Ads :', JSON.stringify(ideaData, null, 2));
+            const errMessage = ideaData?.error?.details?.[0]?.errors?.[0]?.message || 'Failed to fetch keyword ideas';
+            console.log('[ERROR] Google Ads Response :', errMessage);
+            throw new Error(errMessage);
          }
 
          if (ideaData?.results) {
@@ -206,6 +207,7 @@ export const getAdwordsKeywordIdeas = async (credentials:AdwordsCredentials, adw
          }
       } catch (error) {
          console.log('[ERROR] Fetching Keyword Ideas from Google Ads :', error);
+         throw error;
       }
    }
 


### PR DESCRIPTION
## Summary
- propagate server error messages in keyword idea mutation hook
- validate keyword idea requests and report missing Google Ads credentials
- surface Google Ads API errors to clients

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3f73f424832a84d2cc52f6529604