### PR TITLE
Separate domain slug and URL for keyword ideas

### DIFF
--- a/components/ideas/KeywordIdeasUpdater.tsx
+++ b/components/ideas/KeywordIdeasUpdater.tsx
@@ -49,7 +49,7 @@ const KeywordIdeasUpdater = ({ onUpdate, settings, domain, searchConsoleConnecte
       updateKeywordIdeas({
          seedType,
          language,
-         domain: domain?.domain,
+         domainUrl: domain?.domain,
          domainSlug: domain?.slug,
          keywords: keywordPaylod,
          country: countries[0],

--- a/database/migrations/1715920000000-update-ideas-domain-slug.js
+++ b/database/migrations/1715920000000-update-ideas-domain-slug.js
@@ -1,0 +1,43 @@
+// Migration: ensure keyword ideas files use domainSlug and domainUrl fields.
+
+module.exports = {
+   up: async () => {
+      const fs = require('fs/promises');
+      const path = require('path');
+      try {
+         const dataDir = path.resolve(process.cwd(), 'data');
+         const files = await fs.readdir(dataDir);
+         const ideaFiles = files.filter((f) => /^IDEAS_.*\.json$/.test(f));
+         for (const file of ideaFiles) {
+            try {
+               const filePath = path.resolve(dataDir, file);
+               const raw = await fs.readFile(filePath, 'utf-8');
+               const content = JSON.parse(raw);
+               const domainName = file.replace(/^IDEAS_|\.json$/g, '');
+               const domainSlug = domainName.replace(/\./g, '-');
+
+               if (Array.isArray(content.keywords)) {
+                  content.keywords = content.keywords.map((k) => ({ ...k, domain: domainSlug }));
+               }
+
+               content.settings = content.settings || {};
+               if (content.settings.domain && !content.settings.domainUrl) {
+                  content.settings.domainUrl = content.settings.domain;
+                  delete content.settings.domain;
+               }
+               if (!content.settings.domainSlug) {
+                  content.settings.domainSlug = domainSlug;
+               }
+
+               await fs.writeFile(filePath, JSON.stringify(content, null, 2), 'utf-8');
+            } catch (err) {
+               console.log('[Migration] Failed to update', file, err);
+            }
+         }
+      } catch (err) {
+         // ignore missing data directory
+      }
+   },
+   down: async () => { /* no rollback */ },
+};
+

--- a/pages/api/ideas.ts
+++ b/pages/api/ideas.ts
@@ -52,13 +52,25 @@ const getKeywordIdeas = async (req: NextApiRequest, res: NextApiResponse<keyword
 
 const updateKeywordIdeas = async (req: NextApiRequest, res: NextApiResponse<keywordsIdeasUpdateResp>) => {
    const errMsg = 'Error Fetching Keywords. Please try again!';
-   const { keywords = [], country = 'US', language = '1000', domain = '', seedSCKeywords, seedCurrentKeywords, seedType } = req.body;
+   const {
+      keywords = [],
+      country = 'US',
+      language = '1000',
+      domainUrl = '',
+      domainSlug = '',
+      seedSCKeywords,
+      seedCurrentKeywords,
+      seedType,
+   } = req.body;
 
    if (!country || !language) {
       return res.status(400).json({ keywords: [], error: 'Please provide both country and language' });
    }
-   if (!domain) {
-      return res.status(400).json({ keywords: [], error: 'Missing domain' });
+   if (!domainSlug) {
+      return res.status(400).json({ keywords: [], error: 'Missing domainSlug' });
+   }
+   if (seedType === 'auto' && !domainUrl) {
+      return res.status(400).json({ keywords: [], error: 'Missing domainUrl' });
    }
    if (!seedType) {
       return res.status(400).json({ keywords: [], error: 'Missing seedType' });
@@ -68,7 +80,7 @@ const updateKeywordIdeas = async (req: NextApiRequest, res: NextApiResponse<keyw
       return res.status(400).json({ keywords: [], error: 'Invalid seedType' });
    }
    if (seedType === 'custom' && (keywords.length === 0 && !seedSCKeywords && !seedCurrentKeywords)) {
-      return res.status(400).json({ keywords: [], error: 'Error Fetching Keywords. Please Provide one of these: keywords, url or domain' });
+      return res.status(400).json({ keywords: [], error: 'Error Fetching Keywords. Please Provide one of these: keywords, url or domainSlug' });
    }
    try {
       const adwordsCreds = await getAdwordsCredentials();
@@ -76,7 +88,7 @@ const updateKeywordIdeas = async (req: NextApiRequest, res: NextApiResponse<keyw
       if (!adwordsCreds || !client_id || !client_secret || !developer_token || !account_id || !refresh_token) {
          return res.status(500).json({ keywords: [], error: 'Google Ads credentials not configured' });
       }
-      const ideaOptions = { country, language, keywords, domain, seedSCKeywords, seedCurrentKeywords, seedType };
+      const ideaOptions = { country, language, keywords, domainUrl, domainSlug, seedSCKeywords, seedCurrentKeywords, seedType };
       try {
          const keywordIdeas = await getAdwordsKeywordIdeas(adwordsCreds, ideaOptions);
          if (keywordIdeas && Array.isArray(keywordIdeas) && keywordIdeas.length > 1) {

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -41,7 +41,7 @@ const Research: NextPage = () => {
 
    const reloadKeywordIdeas = () => {
       const keywordPaylod = seedKeywords ? seedKeywords.split(',').map((key) => key.trim()) : undefined;
-      updateKeywordIdeas({ seedType: 'custom', language, domain: 'research', keywords: keywordPaylod, country });
+      updateKeywordIdeas({ seedType: 'custom', language, domainSlug: 'research', domainUrl: '', keywords: keywordPaylod, country });
    };
 
    const countryOptions = useMemo(() => {


### PR DESCRIPTION
## Summary
- send domain slug and URL separately when requesting keyword ideas
- persist Ads keyword ideas using domain slugs and migrate existing idea files
- update keyword ideas API to validate new fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a426987b4832ab468396e825bda5e