### PR TITLE
feat: centralize react-hot-toast provider

### DIFF
--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import React, { useState, useMemo } from 'react';
-import { Toaster } from 'react-hot-toast';
 import { useQuery } from 'react-query';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { useAddKeywords } from '../../services/keywords';
@@ -269,7 +268,6 @@ const IdeasKeywordsTable = ({
          {showKeyDetails && showKeyDetails.uid && (
             <IdeaDetails keyword={showKeyDetails} closeDetails={() => setShowKeyDetails(null)} />
          )}
-         <Toaster position='bottom-center' containerClassName="react_toaster" />
       </div>
    );
  };

--- a/components/insight/Insight.tsx
+++ b/components/insight/Insight.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Toaster } from 'react-hot-toast';
 import { sortInsightItems } from '../../utils/insight';
 import SelectField from '../common/SelectField';
 import InsightItem from './InsightItem';
@@ -124,7 +123,6 @@ const SCInsight = ({ insight, isLoading = true, isConsoleIntegrated = true, doma
                </div>
             </div>
          </div>
-         <Toaster position='bottom-center' containerClassName="react_toaster" />
       </div>
    );
  };

--- a/components/keywords/KeywordsTable.tsx
+++ b/components/keywords/KeywordsTable.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { Toaster } from 'react-hot-toast';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { filterKeywords, keywordsByDevice, sortKeywords } from '../../utils/client/sortFilter';
 import Icon from '../common/Icon';
@@ -331,7 +330,6 @@ const KeywordsTable = (props: KeywordsTableProps) => {
                closeModal={() => setShowAddTags(false)}
                />
          )}
-         <Toaster position='bottom-center' containerClassName="react_toaster" />
       </div>
    );
  };

--- a/components/keywords/SCKeywordsTable.tsx
+++ b/components/keywords/SCKeywordsTable.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import React, { useState, useMemo } from 'react';
-import { Toaster } from 'react-hot-toast';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { useAddKeywords, useFetchKeywords } from '../../services/keywords';
 import { SCfilterKeywords, SCkeywordsByDevice, SCsortKeywords } from '../../utils/client/SCsortFilter';
@@ -216,7 +215,6 @@ const SCKeywordsTable = ({ domain, keywords = [], isLoading = true, isConsoleInt
                </div>
             </div>
          </div>
-         <Toaster position='bottom-center' containerClassName="react_toaster" />
       </div>
    );
  };

--- a/components/settings/Settings.tsx
+++ b/components/settings/Settings.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { Toaster } from 'react-hot-toast';
 import { useFetchSettings, useUpdateSettings } from '../../services/settings';
 import Icon from '../common/Icon';
 import NotificationSettings from './NotificationSettings';
@@ -150,7 +149,6 @@ const Settings = ({ closeSettings }:SettingsProps) => {
                   </button>
                </div>
             </div>
-            <Toaster position='bottom-center' containerClassName="react_toaster" />
        </div>
    );
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import type { AppProps } from 'next/app';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import { Toaster } from 'react-hot-toast';
 
 function MyApp({ Component, pageProps }: AppProps) {
    const [queryClient] = React.useState(() => new QueryClient({
@@ -15,6 +16,7 @@ function MyApp({ Component, pageProps }: AppProps) {
    return <QueryClientProvider client={queryClient}>
             <Component {...pageProps} />
             <ReactQueryDevtools initialIsOpen={false} />
+            <Toaster position="bottom-center" containerClassName="react_toaster" />
           </QueryClientProvider>;
 }
 

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -3,7 +3,7 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { CSSTransition } from 'react-transition-group';
-import toast, { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
 import TopBar from '../../components/common/TopBar';
 import AddDomain from '../../components/domains/AddDomain';
 import Settings from '../../components/settings/Settings';
@@ -160,7 +160,6 @@ const Domains: NextPage = () => {
              <Settings closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
          <Footer currentVersion={appSettings?.version ? appSettings.version : ''} />
-         <Toaster position='bottom-center' containerClassName="react_toaster" />
       </div>
    );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import type { NextPage } from 'next';
 import { useEffect } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { Toaster } from 'react-hot-toast';
 import Icon from '../components/common/Icon';
 
 const Home: NextPage = () => {
@@ -22,7 +21,6 @@ const Home: NextPage = () => {
       <main role={'main'} className='main flex items-center justify-center w-full min-h-screen'>
         <Icon type='loading' size={36} color="#999" />
       </main>
-      <Toaster position='bottom-center' containerClassName="react_toaster" />
     </div>
   );
 };

--- a/services/adwords.tsx
+++ b/services/adwords.tsx
@@ -39,6 +39,7 @@ export async function fetchAdwordsKeywordIdeas(router: NextRouter, domainSlug: s
    return res.json();
 }
 
+// React hook; should be used within a React component or another hook
 export function useFetchKeywordIdeas(router: NextRouter, adwordsConnected = false) {
    const isResearch = router.pathname === '/research';
    const domainSlug = isResearch ? 'research' : (router.query.slug as string);
@@ -46,6 +47,7 @@ export function useFetchKeywordIdeas(router: NextRouter, adwordsConnected = fals
    return useQuery(`keywordIdeas-${domainSlug}`, () => domainSlug && fetchAdwordsKeywordIdeas(router, domainSlug), { enabled, retry: false });
 }
 
+// React hook; should be used within a React component or another hook
 export function useMutateKeywordIdeas(router:NextRouter, onSuccess?: Function) {
    const queryClient = useQueryClient();
    const domainSlug = router.pathname === '/research' ? 'research' : router.query.slug as string;


### PR DESCRIPTION
## Summary
- Render a single `Toaster` in `_app` within the `QueryClientProvider`
- Remove `Toaster` instances from pages and leaf components
- Document `useFetchKeywordIdeas` and `useMutateKeywordIdeas` as React-only hooks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a69cb1250832aa1269b263347acfe