### PR TITLE
Remove screenshot key from domain screenshot fetch

### DIFF
--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -50,11 +50,11 @@ const Domains: NextPage = () => {
    }, [domainsData]);
 
    useEffect(() => {
-      if (domainsData?.domains && domainsData.domains.length > 0 && appSettings.screenshot_key) {
+      if (domainsData?.domains && domainsData.domains.length > 0) {
          const fetchAllScreenshots = async () => {
             const screenshotPromises = domainsData.domains.map(async (domain: DomainType) => {
                if (domain.domain) {
-                  const domainThumb = await fetchDomainScreenshot(domain.domain, appSettings.screenshot_key || '');
+                  const domainThumb = await fetchDomainScreenshot(domain.domain);
                   if (domainThumb) {
                      return { domain: domain.domain, thumb: domainThumb };
                   }
@@ -80,11 +80,11 @@ const Domains: NextPage = () => {
 
          fetchAllScreenshots();
       }
-   }, [domainsData, appSettings.screenshot_key]);
+   }, [domainsData]);
 
    const manuallyUpdateThumb = async (domain: string) => {
-      if (domain && appSettings.screenshot_key) {
-         const domainThumb = await fetchDomainScreenshot(domain, appSettings.screenshot_key, true);
+      if (domain) {
+         const domainThumb = await fetchDomainScreenshot(domain, true);
          if (domainThumb) {
             toast(`${domain} Screenshot Updated Successfully!`, { icon: '✔️' });
             setDomainThumbs((currentThumbs) => ({ ...currentThumbs, [domain]: domainThumb }));

--- a/services/domains.tsx
+++ b/services/domains.tsx
@@ -32,12 +32,12 @@ export async function fetchDomain(router: NextRouter, domainName: string): Promi
    return res.json();
 }
 
-export async function fetchDomainScreenshot(domain: string, screenshot_key:string, forceFetch = false): Promise<string | false> {
+export async function fetchDomainScreenshot(domain: string, forceFetch = false): Promise<string | false> {
    const domainThumbsRaw = localStorage.getItem('domainThumbs');
    const domThumbs = domainThumbsRaw ? JSON.parse(domainThumbsRaw) : {};
    if (!domThumbs[domain] || forceFetch) {
       try {
-         const screenshotURL = `https://image.thum.io/get/auth/${screenshot_key}/maxAge/96/width/200/https://${domain}`;
+         const screenshotURL = `https://image.thum.io/get/width/200/https/${domain}`;
          const domainImageRes = await fetch(screenshotURL);
          const domainImageBlob = domainImageRes.status === 200 ? await domainImageRes.blob() : false;
          if (domainImageBlob) {


### PR DESCRIPTION
## Summary
- Simplify domain screenshot fetching to use public Thum.io endpoint
- Drop `screenshot_key` parameter and update calls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b9f308200832a8a725445cbba2a7a