### PR TITLE
Expand domain layouts and widen keyword columns

### DIFF
--- a/components/keywords/Keyword.tsx
+++ b/components/keywords/Keyword.tsx
@@ -109,7 +109,7 @@ const Keyword = (props: KeywordProps) => {
       className={`keyword relative py-5 px-4 text-gray-600 border-b-[1px] border-gray-200 lg:py-4 lg:px-6 lg:border-0 
       lg:flex lg:justify-between lg:items-center ${selected ? ' bg-indigo-50 keyword--selected' : ''} ${lastItem ? 'border-b-0' : ''}`}>
 
-         <div className=' w-3/4 font-semibold cursor-pointer lg:flex-1 lg:shrink-0 lg:basis-28 lg:w-auto lg:flex lg:items-center'>
+         <div className=' w-3/4 font-semibold cursor-pointer lg:flex-1 lg:shrink-0 lg:basis-40 lg:w-auto lg:flex lg:items-center lg:min-w-[300px]'>
             <button
                className={`p-0 mr-2 leading-[0px] inline-block rounded-sm pt-0 px-[1px] pb-[3px] border 
                ${selected ? ' bg-blue-700 border-blue-700 text-white' : 'text-transparent'}`}
@@ -117,13 +117,13 @@ const Keyword = (props: KeywordProps) => {
                >
                   <Icon type="check" size={10} />
             </button>
-            <a
-            style={{ maxWidth: `${maxTitleColumnWidth - 35}px` }}
-            className={'py-2 hover:text-blue-600 lg:flex lg:items-center w-full'}
-            onClick={() => showKeywordDetails()}
-            title={keyword}
-            >
-               <span className={`fflag fflag-${country} w-[18px] h-[12px] mr-2`} title={countries[country][0]} />
+              <a
+              style={{ maxWidth: `${maxTitleColumnWidth - 35}px` }}
+              className={'py-2 hover:text-blue-600 flex items-center w-full'}
+              onClick={() => showKeywordDetails()}
+              title={keyword}
+              >
+                 <span className={`fflag fflag-${country} w-[18px] h-[12px] mr-2 relative top-[1px]`} title={countries[country][0]} />
                <span className="inline-block w-[calc(100%-50px)]">
                   <span className="block text-ellipsis overflow-hidden whitespace-nowrap">
                      {keyword}
@@ -179,7 +179,7 @@ const Keyword = (props: KeywordProps) => {
          </div>
 
          <div
-         className={`keyword_url inline-block mt-4 mr-5 ml-5 lg:flex-1 text-gray-400 lg:m-0 max-w-[70px] 
+         className={`keyword_url inline-block mt-4 mr-5 ml-5 lg:flex-1 lg:min-w-[220px] text-gray-400 lg:m-0 max-w-[120px]
          overflow-hidden text-ellipsis whitespace-nowrap lg:max-w-none lg:pr-5 lg:pl-3`}>
             <a href={url} target="_blank" rel="noreferrer"><span className='mr-3 lg:hidden'>
                <Icon type="link-alt" size={14} color="#999" /></span>{turncatedURL || '-'}

--- a/components/keywords/KeywordsTable.tsx
+++ b/components/keywords/KeywordsTable.tsx
@@ -39,7 +39,7 @@ const KeywordsTable = (props: KeywordsTableProps) => {
    const [sortBy, setSortBy] = useState<string>('date_asc');
    const [scDataType, setScDataType] = useState<string>('threeDays');
    const [showScDataTypes, setShowScDataTypes] = useState<boolean>(false);
-   const [maxTitleColumnWidth, setMaxTitleColumnWidth] = useState(235);
+   const [maxTitleColumnWidth, setMaxTitleColumnWidth] = useState(300);
    const { mutate: deleteMutate } = useDeleteKeywords(() => {});
    const { mutate: favoriteMutate } = useFavKeywords(() => {});
    const { mutate: refreshMutate } = useRefreshKeywords(() => {});
@@ -231,8 +231,12 @@ const KeywordsTable = (props: KeywordsTableProps) => {
                <div className=' lg:min-w-[800px]'>
                   <div className={`domKeywords_head domKeywords_head--${sortBy} hidden sm:flex p-3 px-6 bg-[#FCFCFF]
                    text-gray-600 justify-between items-center font-semibold border-y`}>
-                     <span ref={titleColumnRef} className={`domKeywords_head_keyword flex-1 basis-[4rem] w-auto lg:flex-1 
-                        ${showSCData && tableColumns.includes('Search Console') ? 'lg:basis-20' : 'lg:basis-10'} lg:w-auto lg:flex lg:items-center `}>
+                       <span
+                          ref={titleColumnRef}
+                          className={`domKeywords_head_keyword flex-1 basis-[6rem] w-auto lg:flex-1 ${
+                             showSCData && tableColumns.includes('Search Console') ? 'lg:basis-24' : 'lg:basis-14'
+                          } lg:w-auto lg:flex lg:items-center lg:min-w-[300px]`}
+                       >
                      {processedKeywords[device].length > 0 && (
                         <button
                            className={`p-0 mr-2 leading-[0px] inline-block rounded-sm pt-0 px-[1px] pb-[3px]  border border-slate-300 
@@ -243,8 +247,8 @@ const KeywordsTable = (props: KeywordsTableProps) => {
                         </button>
                      )}
                   {/* ${showSCData ? 'lg:min-w-[220px]' : 'lg:min-w-[280px]'} */}
-                        <span className={`inline-block lg:flex lg:items-center 
-                           ${showSCData && tableColumns.includes('Search Console') ? 'lg:max-w-[235px]' : ''}`}>
+                          <span className={`inline-block lg:flex lg:items-center
+                             ${showSCData && tableColumns.includes('Search Console') ? 'lg:max-w-[300px]' : ''}`}>
                            Keyword
                         </span>
                      </span>
@@ -252,7 +256,7 @@ const KeywordsTable = (props: KeywordsTableProps) => {
                      <span className={`domKeywords_head_best flex-1 basis-16 grow-0 text-center  ${shouldHideColumn('Best')}`}>Best</span>
                      <span className={`domKeywords_head_history flex-1 basis-20 grow-0  ${shouldHideColumn('History')}`}>History (7d)</span>
                      <span className={`domKeywords_head_volume flex-1 basis-24 grow-0 text-center ${shouldHideColumn('Volume')}`}>Volume</span>
-                     <span className='domKeywords_head_url flex-1'>URL</span>
+                       <span className='domKeywords_head_url flex-1 lg:min-w-[220px]'>URL</span>
                      <span className='domKeywords_head_updated flex-1 relative left-3 max-w-[150px]'>Updated</span>
                      {showSCData && tableColumns.includes('Search Console') && (
                         <div className='domKeywords_head_sc flex-1 min-w-[170px] lg:max-w-[170px] mr-7 text-center'>

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -60,7 +60,7 @@ const SingleDomain: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-7xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
                {activDomain && activDomain.domain

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -95,7 +95,7 @@ const DiscoverPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-7xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
                {activDomain && activDomain.domain

--- a/pages/domain/ideas/[slug]/index.tsx
+++ b/pages/domain/ideas/[slug]/index.tsx
@@ -53,7 +53,7 @@ const DiscoverPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-7xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
                {activDomain && activDomain.domain ? (

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -53,7 +53,7 @@ const InsightPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-7xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
                {activDomain && activDomain.domain

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,6 +13,10 @@ body {
    max-width: 90rem;
 }
 
+.max-w-8xl {
+   max-width: 110rem;
+}
+
 .domKeywords {
    /* min-height: 70vh; */
    border-color: #e9ebff;


### PR DESCRIPTION
## Summary
- enlarge main domain container with new `max-w-8xl` utility
- widen keyword and URL columns in keyword tables and center flag icons

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb6fcf19c832a8414e9d75d1fb788