### PR TITLE
test: expand coverage for hooks and utilities

### DIFF
--- a/__tests__/domain-conversion.test.ts
+++ b/__tests__/domain-conversion.test.ts
@@ -5,6 +5,7 @@
 
 // Import the functions we need to test
 import { getSafeSCDataFilePath } from '../utils/searchConsole';
+import { slugToDomain } from '../utils/domains';
 
 // Mock the path module with more realistic behavior
 jest.mock('path', () => {
@@ -53,17 +54,16 @@ describe('Domain Conversion Fixes', () => {
 
    describe('Domain slug to domain conversion for keywords', () => {
       it('should convert domain slug back to domain format', () => {
-         const convertSlugToDomain = (slug: string) => slug.replace(/-/g, '.');
-
          // Test the main case from the issue
-         expect(convertSlugToDomain('vontainment-com')).toBe('vontainment.com');
+         expect(slugToDomain('vontainment-com')).toBe('vontainment.com');
 
          // Test other formats
-         expect(convertSlugToDomain('example-org')).toBe('example.org');
-         expect(convertSlugToDomain('my-test-domain-com')).toBe('my.test.domain.com');
+         expect(slugToDomain('example-org')).toBe('example.org');
+         expect(slugToDomain('my-test-domain-com')).toBe('my.test.domain.com');
+         expect(slugToDomain('sub-domain-example-com')).toBe('sub.domain.example.com');
 
          // Test research domain (special case - no conversion needed)
-         expect(convertSlugToDomain('research')).toBe('research');
+         expect(slugToDomain('research')).toBe('research');
       });
    });
 

--- a/__tests__/hooks/domains.test.tsx
+++ b/__tests__/hooks/domains.test.tsx
@@ -19,9 +19,7 @@ fetchMock.mockIf(`${window.location.origin}/api/domains`, async () => {
 describe('DomainHooks', () => {
    it('useFetchDomains should fetch the Domains', async () => {
       const { result } = renderHook(() => useFetchDomains(mockRouter), { wrapper: createWrapper() });
-      // const result = { current: { isSuccess: false, data: '' } };
-      await waitFor(() => {
-         return expect(result.current.isLoading).toBe(false);
-      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.domains).toContainEqual(dummyDomain);
    });
 });

--- a/__tests__/hooks/useIsMobile.test.tsx
+++ b/__tests__/hooks/useIsMobile.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook, act } from '@testing-library/react';
+import useIsMobile from '../../hooks/useIsMobile';
+
+describe('useIsMobile', () => {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  let mobile = false;
+
+  beforeEach(() => {
+    listeners.clear();
+    mobile = false;
+    // @ts-ignore
+    window.matchMedia = jest.fn().mockImplementation(() => ({
+      matches: mobile,
+      addEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => listeners.add(cb),
+      removeEventListener: (_: string, cb: (e: MediaQueryListEvent) => void) => listeners.delete(cb),
+    }));
+  });
+
+  it('should detect mobile changes', () => {
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current[0]).toBe(false);
+    act(() => {
+      mobile = true;
+      listeners.forEach((cb) => cb({ matches: true } as MediaQueryListEvent));
+    });
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/__tests__/hooks/useOnKey.test.tsx
+++ b/__tests__/hooks/useOnKey.test.tsx
@@ -1,0 +1,20 @@
+import { renderHook } from '@testing-library/react';
+import useOnKey from '../../hooks/useOnKey';
+
+describe('useOnKey', () => {
+  it('calls handler on specified key press', () => {
+    const handler = jest.fn();
+    renderHook(() => useOnKey('Escape', handler));
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    window.dispatchEvent(event);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('ignores other keys', () => {
+    const handler = jest.fn();
+    renderHook(() => useOnKey('Enter', handler));
+    const event = new KeyboardEvent('keydown', { key: 'Escape' });
+    window.dispatchEvent(event);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/useWindowResize.test.tsx
+++ b/__tests__/hooks/useWindowResize.test.tsx
@@ -1,0 +1,14 @@
+import { renderHook, act } from '@testing-library/react';
+import useWindowResize from '../../hooks/useWindowResize';
+
+describe('useWindowResize', () => {
+  it('invokes callback on mount and resize', () => {
+    const handler = jest.fn();
+    renderHook(() => useWindowResize(handler));
+    expect(handler).toHaveBeenCalledTimes(1);
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/services/domains.test.tsx
+++ b/__tests__/services/domains.test.tsx
@@ -1,0 +1,51 @@
+import { fetchDomain, fetchDomainScreenshot, useAddDomain } from '../../services/domains';
+import apiFetch from '../../services/apiClient';
+import mockRouter from 'next-router-mock';
+import { dummyDomain } from '../../__mocks__/data';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook, act } from '@testing-library/react';
+
+jest.mock('next/router', () => jest.requireActual('next-router-mock'));
+jest.mock('../../services/apiClient');
+jest.mock('react-hot-toast', () => ({ __esModule: true, default: jest.fn() }));
+
+describe('domain services', () => {
+  const apiFetchMock = apiFetch as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('fetchDomain returns domain data', async () => {
+    apiFetchMock.mockResolvedValue({ domain: dummyDomain });
+    const res = await fetchDomain(mockRouter, 'test.com');
+    expect(res.domain).toEqual(dummyDomain);
+  });
+
+  it('fetchDomain redirects on 401', async () => {
+    apiFetchMock.mockRejectedValue({ status: 401 });
+    await expect(fetchDomain(mockRouter, 'test.com')).rejects.toEqual({ status: 401 });
+    expect(mockRouter).toMatchObject({ pathname: '/login' });
+  });
+
+  it('fetchDomainScreenshot uses cached value', async () => {
+    localStorage.setItem('domainThumbs', JSON.stringify({ 'test.com': 'image' }));
+    const res = await fetchDomainScreenshot('test.com');
+    expect(res).toBe('image');
+  });
+
+  it('useAddDomain invalidates cache on success', async () => {
+    apiFetchMock.mockResolvedValue({ domains: [dummyDomain] });
+    const queryClient = new QueryClient();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: any) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useAddDomain(onSuccess), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(['test.com']);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(['domains']);
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});

--- a/__tests__/utils/parseKeywords.test.ts
+++ b/__tests__/utils/parseKeywords.test.ts
@@ -1,0 +1,32 @@
+import parseKeywords from '../../utils/parseKeywords';
+
+describe('parseKeywords', () => {
+  it('parses JSON fields correctly', () => {
+    const input: any = [{
+      history: '["h1"]',
+      tags: '["t1","t2"]',
+      lastResult: '{"r":1}',
+      lastUpdateError: 'false',
+      position: 1,
+      lastUpdated: new Date().toJSON(),
+    }];
+    const [parsed] = parseKeywords(input);
+    expect(parsed.history).toEqual(['h1']);
+    expect(parsed.tags).toEqual(['t1', 't2']);
+    expect(parsed.lastResult).toEqual({ r: 1 });
+    expect(parsed.lastUpdateError).toBe(false);
+  });
+
+  it('parses lastUpdateError json when present', () => {
+    const input: any = [{
+      history: '[]',
+      tags: '[]',
+      lastResult: '{}',
+      lastUpdateError: '{"msg":"err"}',
+      position: 1,
+      lastUpdated: new Date().toJSON(),
+    }];
+    const [parsed] = parseKeywords(input);
+    expect(parsed.lastUpdateError).toEqual({ msg: 'err' });
+  });
+});

--- a/__tests__/utils/searchConsole.test.ts
+++ b/__tests__/utils/searchConsole.test.ts
@@ -1,0 +1,43 @@
+import { parseSearchConsoleItem, integrateKeywordSCData } from '../../utils/searchConsole';
+
+jest.mock('../../utils/countries', () => ({
+  getCountryCodeFromAlphaThree: jest.fn().mockReturnValue('US'),
+}));
+
+describe('searchConsole utils', () => {
+  it('parses raw search console item', () => {
+    const raw: any = {
+      keys: ['test', 'DESKTOP', 'USA', 'https://example.com/page'],
+      clicks: 1,
+      impressions: 2,
+      ctr: 0.5,
+      position: 3,
+    };
+    const parsed = parseSearchConsoleItem(raw, 'example.com');
+    expect(parsed).toEqual({
+      keyword: 'test',
+      uid: 'us:desktop:test',
+      device: 'desktop',
+      country: 'US',
+      clicks: 1,
+      impressions: 2,
+      ctr: 50,
+      position: 3,
+      page: '/page',
+    });
+  });
+
+  it('integrates keyword sc data', () => {
+    const keyword: any = { keyword: 'test', country: 'US', device: 'desktop' };
+    const scData: any = {
+      threeDays: [{ uid: 'us:desktop:test', impressions: 3, clicks: 1, ctr: 0.1, position: 5 }],
+      sevenDays: [],
+      thirtyDays: [],
+    };
+    const result = integrateKeywordSCData(keyword, scData);
+    expect(result.scData.impressions.threeDays).toBe(3);
+    expect(result.scData.impressions.avgThreeDays).toBe(1);
+    expect(result.scData.visits.threeDays).toBe(1);
+    expect(result.scData.position.threeDays).toBe(5);
+  });
+});

--- a/__tests__/utils/verifyUser.test.ts
+++ b/__tests__/utils/verifyUser.test.ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import verifyUser from '../../utils/verifyUser';
+import Cookies from 'cookies';
+import jwt from 'jsonwebtoken';
+
+jest.mock('cookies');
+jest.mock('jsonwebtoken', () => ({ verify: jest.fn() }));
+
+describe('verifyUser', () => {
+  const res = {} as NextApiResponse;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete process.env.SECRET;
+    delete process.env.APIKEY;
+  });
+
+  it('authorizes valid token', () => {
+    (Cookies as unknown as jest.Mock).mockImplementation(() => ({ get: () => 'tok' }));
+    (jwt.verify as jest.Mock).mockImplementation(() => true);
+    process.env.SECRET = 's';
+    const reqTok = { headers: {} } as any;
+    const result = verifyUser(reqTok, res);
+    expect(result).toBe('authorized');
+  });
+
+  it('authorizes valid API key for allowed route', () => {
+    (Cookies as unknown as jest.Mock).mockImplementation(() => ({ get: () => undefined }));
+    process.env.APIKEY = 'key';
+    const apiReq = { headers: { authorization: 'Bearer key' }, method: 'GET', url: '/api/keywords' } as any;
+    const result = verifyUser(apiReq, res);
+    expect(result).toBe('authorized');
+  });
+
+  it('rejects invalid API key', () => {
+    (Cookies as unknown as jest.Mock).mockImplementation(() => ({ get: () => undefined }));
+    process.env.APIKEY = 'key';
+    const apiReq = { headers: { authorization: 'Bearer wrong' }, method: 'GET', url: '/api/keywords' } as any;
+    const result = verifyUser(apiReq, res);
+    expect(result).toBe('Invalid API Key Provided.');
+  });
+});

--- a/utils/domains.ts
+++ b/utils/domains.ts
@@ -59,4 +59,9 @@ const getdomainStats = async (domains:DomainType[]): Promise<DomainType[]> => {
    return finalDomains;
 };
 
+export const slugToDomain = (slug: string): string => {
+   if (slug === 'research') return 'research';
+   return slug.replace(/-/g, '.');
+};
+
 export default getdomainStats;


### PR DESCRIPTION
## Summary
- strengthen domain fetching hook test to verify success state and data
- add utility to convert slugs to domains and broaden related tests
- introduce comprehensive tests for custom hooks and service utilities

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689c17a237c4832aa8808ee79779dae6