### PR TITLE
refactor: modularize Adwords keyword ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Refactoring
 * Extracted scraping helper and finalization logic in keyword refresh utility for clearer control flow.
+* Modularized Adwords keyword idea flow by extracting seeding, request, fetch, and persistence helpers.
 
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 

--- a/__tests__/utils/adwordsKeywordIdeas.test.ts
+++ b/__tests__/utils/adwordsKeywordIdeas.test.ts
@@ -1,10 +1,14 @@
-import Keyword from '../../database/models/keyword';
-import * as scUtils from '../../utils/searchConsole';
-import * as adwordsUtils from '../../utils/adwords';
-
 jest.mock('../../utils/searchConsole', () => ({
   readLocalSCData: jest.fn(),
 }));
+jest.mock('../../utils/parseKeywords', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue([{ keyword: 'db-kw' }]),
+}));
+
+import Keyword from '../../database/models/keyword';
+import * as scUtils from '../../utils/searchConsole';
+import * as adwordsUtils from '../../utils/adwords';
 
 describe('getAdwordsKeywordIdeas', () => {
   const creds = {
@@ -50,5 +54,57 @@ describe('getAdwordsKeywordIdeas', () => {
         true,
       ),
     ).rejects.toThrow('No search console keywords found for this domain');
+  });
+});
+
+describe('seedKeywordsFromSources', () => {
+  it('gathers keywords from multiple sources', async () => {
+    (scUtils.readLocalSCData as jest.Mock).mockResolvedValue({
+      thirtyDays: [{ keyword: 'sc1', impressions: 50 }],
+    });
+    jest.spyOn(Keyword, 'findAll').mockResolvedValue([{ get: () => ({}) }] as any);
+    const seeds = await adwordsUtils.seedKeywordsFromSources({
+      seedType: 'searchconsole',
+      seedSCKeywords: true,
+      seedCurrentKeywords: true,
+      domainUrl: 'example.com',
+      keywords: ['base'],
+    });
+    expect(seeds).toEqual(expect.arrayContaining(['base', 'sc1', 'db-kw']));
+  });
+});
+
+describe('buildAdwordsRequest', () => {
+  it('creates payload with keywordSeed', () => {
+    const payload = adwordsUtils.buildAdwordsRequest({
+      seedType: 'custom',
+      country: 'US',
+      language: '1000',
+      seedKeywords: ['a', 'b'],
+      domainUrl: 'example.com',
+      test: true,
+    });
+    expect(payload).toMatchObject({
+      keywordSeed: { keywords: ['a', 'b'] },
+      pageSize: '1',
+      geoTargetConstants: 'geoTargetConstants/2840',
+      language: 'languageConstants/1000',
+    });
+  });
+
+  it('creates payload with siteSeed for auto', () => {
+    const payload = adwordsUtils.buildAdwordsRequest({
+      seedType: 'auto',
+      country: 'US',
+      language: '1000',
+      seedKeywords: [],
+      domainUrl: 'example.com',
+      test: false,
+    });
+    expect(payload).toMatchObject({
+      siteSeed: { site: 'example.com' },
+      pageSize: '1000',
+    });
+    expect((payload as any).keywordSeed).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- extract helpers for seeding keywords, building requests, fetching ideas, and persisting results
- streamline `getAdwordsKeywordIdeas` with early returns
- cover new helpers with unit tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cefe1e008832a802004a1673dca64