### PR TITLE
refactor: improve domain and keyword utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file. See [standa
 * Extracted scraping helper and finalization logic in keyword refresh utility for clearer control flow.
 * Modularized Adwords keyword idea flow by extracting seeding, request, fetch, and persistence helpers.
 
+### Bug Fixes
+* Standardized react-query keys and invalidations for domains and keywords.
+* Hardened JSON parsing across services and utilities to avoid crashes.
+* Updated mobile detection hook to return a boolean and adjusted consumers.
+* Ensured keyword volume updates and scraper retry queues validate IDs and await async updates.
+
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 
 ### Features

--- a/__tests__/hooks/useIsMobile.test.tsx
+++ b/__tests__/hooks/useIsMobile.test.tsx
@@ -18,11 +18,11 @@ describe('useIsMobile', () => {
 
   it('should detect mobile changes', () => {
     const { result } = renderHook(() => useIsMobile());
-    expect(result.current[0]).toBe(false);
+    expect(result.current).toBe(false);
     act(() => {
       mobile = true;
       listeners.forEach((cb) => cb({ matches: true } as MediaQueryListEvent));
     });
-    expect(result.current[0]).toBe(true);
+    expect(result.current).toBe(true);
   });
 });

--- a/__tests__/services/domains.test.tsx
+++ b/__tests__/services/domains.test.tsx
@@ -35,6 +35,14 @@ describe('domain services', () => {
     expect(res).toBe('image');
   });
 
+  it('fetchDomainScreenshot handles invalid cache gracefully', async () => {
+    // @ts-ignore
+    global.fetch = jest.fn().mockResolvedValue({ status: 404 });
+    localStorage.setItem('domainThumbs', 'not-json');
+    const res = await fetchDomainScreenshot('test.com');
+    expect(res).toBe(false);
+  });
+
   it('useAddDomain invalidates cache on success', async () => {
     apiFetchMock.mockResolvedValue({ domains: [dummyDomain] });
     const queryClient = new QueryClient();
@@ -45,7 +53,7 @@ describe('domain services', () => {
     await act(async () => {
       await result.current.mutateAsync(['test.com']);
     });
-    expect(invalidateSpy).toHaveBeenCalledWith(['domains']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['domains'] });
     expect(onSuccess).toHaveBeenCalled();
   });
 });

--- a/__tests__/services/keywords.test.ts
+++ b/__tests__/services/keywords.test.ts
@@ -1,0 +1,9 @@
+import { fetchKeywords } from '../../services/keywords';
+
+describe('fetchKeywords', () => {
+  it('returns empty keywords array when domain is falsy', async () => {
+    // @ts-ignore - router not used when domain is falsy
+    const result = await fetchKeywords({}, '');
+    expect(result).toEqual({ keywords: [] });
+  });
+});

--- a/__tests__/utils/parseKeywords.test.ts
+++ b/__tests__/utils/parseKeywords.test.ts
@@ -29,4 +29,20 @@ describe('parseKeywords', () => {
     const [parsed] = parseKeywords(input);
     expect(parsed.lastUpdateError).toEqual({ msg: 'err' });
   });
+
+  it('handles invalid json gracefully', () => {
+    const input: any = [{
+      history: 'invalid',
+      tags: 'oops',
+      lastResult: 'bad',
+      lastUpdateError: 'notjson',
+      position: 1,
+      lastUpdated: new Date().toJSON(),
+    }];
+    const [parsed] = parseKeywords(input);
+    expect(parsed.history).toEqual({});
+    expect(parsed.tags).toEqual([]);
+    expect(parsed.lastResult).toEqual([]);
+    expect(parsed.lastUpdateError).toBe(false);
+  });
 });

--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -38,10 +38,14 @@ const IdeasKeywordsTable = ({
    const [addKeywordDomain, setAddKeywordDomain] = useState('');
    const { mutate: addKeywords } = useAddKeywords(() => { if (domain && domain.slug) router.push(`/domain/${domain.slug}`); });
    const { mutate: faveKeyword, isLoading: isFaving } = useMutateFavKeywordIdeas(router);
-   const [isMobile] = useIsMobile();
+   const isMobile = useIsMobile();
    const isResearchPage = router.pathname === '/research';
 
-   const { data: domainsData } = useQuery('domains', () => fetchDomains(router, false), { enabled: selectedKeywords.length > 0, retry: false });
+   const { data: domainsData } = useQuery(
+      ['domains', false],
+      () => fetchDomains(router, false),
+      { enabled: selectedKeywords.length > 0, retry: false },
+   );
    const theDomains: DomainType[] = (domainsData && domainsData.domains) || [];
 
    useWindowResize(() => setListHeight(window.innerHeight - (isMobile ? 200 : 400)));

--- a/components/keywords/KeywordsTable.tsx
+++ b/components/keywords/KeywordsTable.tsx
@@ -43,7 +43,7 @@ const KeywordsTable = (props: KeywordsTableProps) => {
    const { mutate: deleteMutate } = useDeleteKeywords(() => {});
    const { mutate: favoriteMutate } = useFavKeywords(() => {});
    const { mutate: refreshMutate } = useRefreshKeywords(() => {});
-   const [isMobile] = useIsMobile();
+   const isMobile = useIsMobile();
 
    useWindowResize(() => {
       setSCListHeight(window.innerHeight - (isMobile ? 200 : 400));

--- a/components/keywords/SCKeywordsTable.tsx
+++ b/components/keywords/SCKeywordsTable.tsx
@@ -33,7 +33,7 @@ const SCKeywordsTable = ({ domain, keywords = [], isLoading = true, isConsoleInt
    const { keywordsData } = useFetchKeywords(router, domain?.domain || '');
    const addedkeywords: string[] = keywordsData?.keywords?.map((key: KeywordType) => `${key.keyword}:${key.country}:${key.device}`) || [];
    const { mutate: addKeywords } = useAddKeywords(() => { if (domain && domain.slug) router.push(`/domain/${domain.slug}`); });
-   const [isMobile] = useIsMobile();
+   const isMobile = useIsMobile();
    useWindowResize(() => setSCListHeight(window.innerHeight - (isMobile ? 200 : 400)));
 
    const finalKeywords: {[key:string] : SCKeywordType[] } = useMemo(() => {

--- a/cron.js
+++ b/cron.js
@@ -21,7 +21,13 @@ const getAppSettings = async () => {
       const exists = await promises.stat(`${process.cwd()}/data/settings.json`).then(() => true).catch(() => false);
       if (exists) {
          const settingsRaw = await promises.readFile(`${process.cwd()}/data/settings.json`, { encoding: 'utf-8' });
-         const settings = settingsRaw ? JSON.parse(settingsRaw) : {};
+         let settings = {};
+         try {
+            settings = settingsRaw ? JSON.parse(settingsRaw) : {};
+         } catch (err) {
+            console.log('Error parsing settings file', err);
+            return defaultSettings;
+         }
 
          try {
             const cryptr = new Cryptr(process.env.SECRET);

--- a/hooks/useIsMobile.tsx
+++ b/hooks/useIsMobile.tsx
@@ -27,7 +27,7 @@ const useIsMobile = () => {
    }, []);
 
    // Return false during SSR to prevent hydration mismatch
-   return [isClient ? isMobile : false];
+   return isClient ? isMobile : false;
 };
 
 export default useIsMobile;

--- a/services/keywords.tsx
+++ b/services/keywords.tsx
@@ -3,8 +3,11 @@ import { NextRouter } from 'next/router';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import apiFetch from './apiClient';
 
-export const fetchKeywords = async (router: NextRouter, domain: string) => {
-   if (!domain) { return []; }
+export const fetchKeywords = async (
+   router: NextRouter,
+   domain: string,
+): Promise<{ keywords: KeywordType[] }> => {
+   if (!domain) { return { keywords: [] }; }
    return apiFetch(`${window.location.origin}/api/keywords?domain=${domain}`);
 };
 
@@ -50,7 +53,7 @@ export function useAddKeywords(onSuccess:Function) {
          console.log('Keywords Added!!!');
          toast('Keywords Added Successfully!', { icon: '✔️' });
          onSuccess();
-         queryClient.invalidateQueries(['keywords']);
+         queryClient.invalidateQueries({ queryKey: ['keywords'] });
       },
       onError: () => {
          console.log('Error Adding New Keywords!!!');
@@ -69,7 +72,7 @@ export function useDeleteKeywords(onSuccess:Function) {
          console.log('Removed Keyword!!!');
          onSuccess();
          toast('Keywords Removed Successfully!', { icon: '✔️' });
-         queryClient.invalidateQueries(['keywords']);
+         queryClient.invalidateQueries({ queryKey: ['keywords'] });
       },
       onError: () => {
          console.log('Error Removing Keyword!!!');
@@ -89,7 +92,7 @@ export function useFavKeywords(onSuccess:Function) {
          onSuccess();
          const isSticky = data.keywords[0] && data.keywords[0].sticky;
          toast(isSticky ? 'Keywords Made Favorite!' : 'Keywords Unfavorited!', { icon: '✔️' });
-         queryClient.invalidateQueries(['keywords']);
+         queryClient.invalidateQueries({ queryKey: ['keywords'] });
       },
       onError: () => {
          console.log('Error Changing Favorite Status!!!');
@@ -109,7 +112,7 @@ export function useUpdateKeywordTags(onSuccess:Function) {
       onSuccess: async () => {
          onSuccess();
          toast('Keyword Tags Updated!', { icon: '✔️' });
-         queryClient.invalidateQueries(['keywords']);
+         queryClient.invalidateQueries({ queryKey: ['keywords'] });
       },
       onError: () => {
          console.log('Error Updating Keyword Tags!!!');
@@ -130,7 +133,7 @@ export function useRefreshKeywords(onSuccess:Function) {
          console.log('Keywords Added to Refresh Queue!!!');
          onSuccess();
          toast('Keywords Added to Refresh Queue', { icon: '🔄' });
-         queryClient.invalidateQueries(['keywords']);
+         queryClient.invalidateQueries({ queryKey: ['keywords'] });
       },
       onError: () => {
          console.log('Error Refreshing Keywords!!!');

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -443,16 +443,15 @@ export const getKeywordsVolume = async (keywords: KeywordType[]): Promise<{ erro
  */
 export const updateKeywordsVolumeData = async (volumesData: false | Record<number, number>) => {
    if (volumesData === false) { return false; }
-
-   Object.keys(volumesData).forEach(async (keywordID) => {
+   for (const keywordID of Object.keys(volumesData)) {
       const keyID = parseInt(keywordID, 10);
-      const volumeData = volumesData && volumesData[keyID] ? volumesData[keyID] : 0;
+      const volumeData = volumesData[keyID] ? volumesData[keyID] : 0;
       try {
          await Keyword.update({ volume: volumeData }, { where: { ID: keyID } });
       } catch (error) {
          // Silently ignore update errors
       }
-   });
+   }
    return true;
 };
 

--- a/utils/parseKeywords.ts
+++ b/utils/parseKeywords.ts
@@ -6,13 +6,45 @@ import Keyword from '../database/models/keyword';
  * @returns {KeywordType[]}
  */
 const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
-   const parsedItems = allKeywords.map((keywrd:Keyword) => ({
+   const parsedItems = allKeywords.map((keywrd:Keyword) => {
+      let history: any = {};
+      let tags: any = [];
+      let lastResult: any = [];
+      let lastUpdateError: any = false;
+      try {
+         history = JSON.parse(keywrd.history);
+      } catch (err) {
+         console.log('Error parsing history JSON', err);
+         history = {};
+      }
+      try {
+         tags = JSON.parse(keywrd.tags);
+      } catch (err) {
+         console.log('Error parsing tags JSON', err);
+         tags = [];
+      }
+      try {
+         lastResult = JSON.parse(keywrd.lastResult);
+      } catch (err) {
+         console.log('Error parsing lastResult JSON', err);
+         lastResult = [];
+      }
+      try {
+         lastUpdateError = keywrd.lastUpdateError !== 'false' && keywrd.lastUpdateError.includes('{')
+            ? JSON.parse(keywrd.lastUpdateError)
+            : false;
+      } catch (err) {
+         console.log('Error parsing lastUpdateError JSON', err);
+         lastUpdateError = false;
+      }
+      return {
          ...keywrd,
-         history: JSON.parse(keywrd.history),
-         tags: JSON.parse(keywrd.tags),
-         lastResult: JSON.parse(keywrd.lastResult),
-         lastUpdateError: keywrd.lastUpdateError !== 'false' && keywrd.lastUpdateError.includes('{') ? JSON.parse(keywrd.lastUpdateError) : false,
-      }));
+         history,
+         tags,
+         lastResult,
+         lastUpdateError,
+      };
+   });
    return parsedItems;
 };
 

--- a/utils/refresh.ts
+++ b/utils/refresh.ts
@@ -12,12 +12,12 @@ import Keyword from '../database/models/keyword';
  * @returns {Promise}
  */
 const refreshAndUpdateKeywords = async (rawkeyword:Keyword[], settings:SettingsType): Promise<KeywordType[]> => {
-   const keywords:KeywordType[] = rawkeyword.map((el) => el.get({ plain: true }));
    if (!rawkeyword || rawkeyword.length === 0) { return []; }
    const start = performance.now();
    const updatedKeywords: KeywordType[] = [];
 
    if (['scrapingant', 'serpapi', 'searchapi'].includes(settings.scraper_type)) {
+      const keywords:KeywordType[] = rawkeyword.map((el) => el.get({ plain: true }));
       const refreshedResults = await refreshParallel(keywords, settings);
       if (refreshedResults.length > 0) {
          for (const keyword of rawkeyword) {
@@ -33,7 +33,7 @@ const refreshAndUpdateKeywords = async (rawkeyword:Keyword[], settings:SettingsT
          console.log('START SCRAPE: ', keyword.keyword);
          const updatedkeyword = await refreshAndUpdateKeyword(keyword, settings);
          updatedKeywords.push(updatedkeyword);
-         if (keywords.length > 0 && settings.scrape_delay && settings.scrape_delay !== '0') {
+         if (settings.scrape_delay && settings.scrape_delay !== '0') {
             await sleep(parseInt(settings.scrape_delay, 10));
          }
       }

--- a/utils/scraper.ts
+++ b/utils/scraper.ts
@@ -289,7 +289,7 @@ export const getSerp = (domainURL:string, result:SearchResult[]) : SERPObject =>
  * @returns {void}
  */
 export const retryScrape = async (keywordID: number) : Promise<void> => {
-   if (!keywordID && !Number.isInteger(keywordID)) { return; }
+   if (!Number.isInteger(keywordID) || keywordID <= 0) return;
    let currentQueue: number[] = [];
 
    const filePath = `${process.cwd()}/data/failed_queue.json`;
@@ -309,7 +309,7 @@ export const retryScrape = async (keywordID: number) : Promise<void> => {
  * @returns {void}
  */
 export const removeFromRetryQueue = async (keywordID: number) : Promise<void> => {
-   if (!keywordID && !Number.isInteger(keywordID)) { return; }
+   if (!Number.isInteger(keywordID) || keywordID <= 0) return;
    let currentQueue: number[] = [];
 
    const filePath = `${process.cwd()}/data/failed_queue.json`;


### PR DESCRIPTION
## Summary
- standardize react-query keys for domains and keywords and improve screenshot parsing
- ensure fetchKeywords always returns an object and handle async keyword volume updates
- simplify mobile hook API and harden JSON parsing across utilities and cron

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cfa3d5e80832a853608fae6117863