### PR TITLE
chore: improve typing and async flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file. See [standa
 * Hardened JSON parsing across services and utilities to avoid crashes.
 * Updated mobile detection hook to return a boolean and adjusted consumers.
 * Ensured keyword volume updates and scraper retry queues validate IDs and await async updates.
+* Removed incorrect default values for domain and slug fields to avoid saving "true".
+* Validated Bearer prefix in API-key authorization and improved component typings.
+* Parallelized Search Console requests and switched cron file reads to async/await.
 
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 

--- a/__tests__/utils/verifyUser.test.ts
+++ b/__tests__/utils/verifyUser.test.ts
@@ -39,4 +39,12 @@ describe('verifyUser', () => {
     const result = verifyUser(apiReq, res);
     expect(result).toBe('Invalid API Key Provided.');
   });
+
+  it('rejects authorization header without Bearer prefix', () => {
+    (Cookies as unknown as jest.Mock).mockImplementation(() => ({ get: () => undefined }));
+    process.env.APIKEY = 'key';
+    const apiReq = { headers: { authorization: 'key' }, method: 'GET', url: '/api/keywords' } as any;
+    const result = verifyUser(apiReq, res);
+    expect(result).toBe('Invalid API Key Provided.');
+  });
 });

--- a/components/common/InputField.tsx
+++ b/components/common/InputField.tsx
@@ -1,16 +1,16 @@
 type InputFieldProps = {
    label: string;
    value: string;
-   onChange: Function;
+   onChange: (value: string) => void;
    placeholder?: string;
    classNames?: string;
    hasError?: boolean;
 }
 
-const InputField = ({ label = '', value = '', placeholder = '', onChange, hasError = false }: InputFieldProps) => {
+const InputField = ({ label = '', value = '', placeholder = '', onChange, hasError = false, classNames = '' }: InputFieldProps) => {
    const labelStyle = 'mb-2 font-semibold inline-block text-sm text-gray-700 capitalize';
    return (
-      <div className="field--input w-full relative flex justify-between items-center">
+      <div className={`field--input w-full relative flex justify-between items-center ${classNames}`}>
          <label className={labelStyle}>{label}</label>
          <input
             className={`p-2 border border-gray-200 rounded focus:outline-none w-[210px]

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -7,7 +7,7 @@ type ModalProps = {
    width?: string,
    title?: string,
    verticalCenter?: boolean,
-   closeModal: Function,
+   closeModal: () => void,
 }
 
 const Modal = ({ children, width = '1/2', closeModal, title, verticalCenter = false }:ModalProps) => {

--- a/components/common/SecretField.tsx
+++ b/components/common/SecretField.tsx
@@ -4,17 +4,17 @@ import Icon from './Icon';
 type SecretFieldProps = {
    label: string;
    value: string;
-   onChange: Function;
+   onChange: (value: string) => void;
    placeholder?: string;
    classNames?: string;
    hasError?: boolean;
 }
 
-const SecretField = ({ label = '', value = '', placeholder = '', onChange, hasError = false }: SecretFieldProps) => {
+const SecretField = ({ label = '', value = '', placeholder = '', onChange, hasError = false, classNames = '' }: SecretFieldProps) => {
    const [showValue, setShowValue] = useState(false);
    const labelStyle = 'mb-2 font-semibold inline-block text-sm text-gray-700 capitalize';
    return (
-      <div className="settings__section__secret w-full relative flex justify-between items-center">
+      <div className={`settings__section__secret w-full relative flex justify-between items-center ${classNames}`}>
          <label className={labelStyle}>{label}</label>
          <span
          className="absolute top-1 right-0 px-2 py-1 cursor-pointer text-gray-400 select-none"

--- a/components/common/SidePanel.tsx
+++ b/components/common/SidePanel.tsx
@@ -4,7 +4,7 @@ import useOnKey from '../../hooks/useOnKey';
 
 type SidePanelProps = {
    children: React.ReactNode,
-   closePanel: Function,
+   closePanel: () => void,
    title?: string,
    width?: 'large' | 'medium' | 'small',
    position?: 'left' | 'right'

--- a/components/ideas/IdeaDetails.tsx
+++ b/components/ideas/IdeaDetails.tsx
@@ -11,7 +11,7 @@ import { fetchSearchResults } from '../../services/keywords';
 
 type IdeaDetailsProps = {
    keyword: IdeaKeyword,
-   closeDetails: Function
+   closeDetails: () => void
 }
 
 const dummySearchResults = [

--- a/components/keywords/KeywordDetails.tsx
+++ b/components/keywords/KeywordDetails.tsx
@@ -10,8 +10,8 @@ import { generateTheChartData } from '../../utils/client/generateChartData';
 
 type KeywordDetailsProps = {
    keyword: KeywordType,
-   closeDetails: Function
-}
+   closeDetails: () => void
+ }
 
 const KeywordDetails = ({ keyword, closeDetails }:KeywordDetailsProps) => {
    const updatedDate = new Date(keyword.lastUpdated);

--- a/components/settings/Settings.tsx
+++ b/components/settings/Settings.tsx
@@ -7,9 +7,9 @@ import useOnKey from '../../hooks/useOnKey';
 import IntegrationSettings from './IntegrationSettings';
 
 type SettingsProps = {
-   closeSettings: Function,
+   closeSettings: () => void,
    settings?: SettingsType
-}
+ }
 
 type SettingsError = {
    type: string,

--- a/database/models/domain.ts
+++ b/database/models/domain.ts
@@ -11,11 +11,11 @@ class Domain extends Model {
    ID!: number;
 
    @Unique
-   @Column({ type: DataType.STRING, allowNull: false, defaultValue: true, unique: true })
+   @Column({ type: DataType.STRING, allowNull: false, defaultValue: '', unique: true })
    domain!: string;
 
    @Unique
-   @Column({ type: DataType.STRING, allowNull: false, defaultValue: true, unique: true })
+   @Column({ type: DataType.STRING, allowNull: false, defaultValue: '', unique: true })
    slug!: string;
 
    @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 0 })

--- a/hooks/useOnKey.tsx
+++ b/hooks/useOnKey.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-const useOnKey = (key:string, onPress: Function) => {
+const useOnKey = (key:string, onPress: () => void) => {
    useEffect(() => {
       // Only run on client side
       if (typeof window !== 'undefined') {

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -45,7 +45,7 @@ const SingleDomain: NextPage = () => {
 
    const { keywordsData, keywordsLoading } = useFetchKeywords(router, activDomain?.domain || '', setKeywordSPollInterval, keywordSPollInterval);
    const theDomains: DomainType[] = (domainsData && domainsData.domains) || [];
-   const theKeywords: KeywordType[] = keywordsData && keywordsData.keywords;
+   const theKeywords: KeywordType[] = (keywordsData && keywordsData.keywords) || [];
 
    return (
       <div className="Domain ">

--- a/utils/searchConsole.ts
+++ b/utils/searchConsole.ts
@@ -104,9 +104,10 @@ export const fetchDomainSCData = async (domain:DomainType, scAPI?: SCAPISettings
    const scDomainData:SCDomainDataType = { threeDays: [], sevenDays: [], thirtyDays: [], lastFetched: '', lastFetchError: '', stats: [] };
    if (domain.domain && scAPI) {
       const theDomain = domain;
-      for (const day of days) {
-         const items = await fetchSearchConsoleData(theDomain, day, undefined, scAPI);
-          scDomainData.lastFetched = new Date().toJSON();
+      const results = await Promise.all(days.map((day) => fetchSearchConsoleData(theDomain, day, undefined, scAPI)));
+      scDomainData.lastFetched = new Date().toJSON();
+      results.forEach((items, idx) => {
+         const day = days[idx];
          if (Array.isArray(items)) {
             if (day === 3) scDomainData.threeDays = items as SearchAnalyticsItem[];
             if (day === 7) scDomainData.sevenDays = items as SearchAnalyticsItem[];
@@ -114,7 +115,7 @@ export const fetchDomainSCData = async (domain:DomainType, scAPI?: SCAPISettings
          } else if (items.error) {
             scDomainData.lastFetchError = items.errorMsg;
          }
-      }
+      });
       const stats = await fetchSearchConsoleData(theDomain, 30, 'stat', scAPI);
       if (stats && Array.isArray(stats) && stats.length > 0) {
          scDomainData.stats = stats as SearchAnalyticsStat[];

--- a/utils/verifyUser.ts
+++ b/utils/verifyUser.ts
@@ -24,7 +24,9 @@ const verifyUser = (req: NextApiRequest, res: NextApiResponse): string => {
       'GET:/api/searchconsole',
       'GET:/api/insight',
    ];
-   const verifiedAPI = req.headers.authorization ? req.headers.authorization.substring('Bearer '.length) === process.env.APIKEY : false;
+   const authHeader = req.headers.authorization;
+   const verifiedAPI = authHeader?.startsWith('Bearer ')
+      && authHeader.slice('Bearer '.length) === process.env.APIKEY;
    const accessingAllowedRoute = req.url && req.method && allowedApiRoutes.includes(`${req.method}:${req.url.replace(/\?(.*)/, '')}`);
 
    let authorized: string = 'Not authorized';


### PR DESCRIPTION
## Summary
- fix domain and slug defaults
- harden API key validation
- refine typings and keyword refresh parsing
- parallelize Search Console fetches and async cron file reads

## Testing
- `npm run lint`
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d17807ba0832a801aac56f72c6be6