### PR TITLE
fix: default keywords to empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. See [standa
 * Removed incorrect default values for domain and slug fields to avoid saving "true".
 * Validated Bearer prefix in API-key authorization and improved component typings.
 * Parallelized Search Console requests and switched cron file reads to async/await.
+* Ensured keyword list defaults to an empty array when keyword data is unavailable.
 
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -45,7 +45,7 @@ const SingleDomain: NextPage = () => {
 
    const { keywordsData, keywordsLoading } = useFetchKeywords(router, activDomain?.domain || '', setKeywordSPollInterval, keywordSPollInterval);
    const theDomains: DomainType[] = (domainsData && domainsData.domains) || [];
-   const theKeywords: KeywordType[] = (keywordsData && keywordsData.keywords) || [];
+   const theKeywords: KeywordType[] = keywordsData?.keywords ?? [];
 
    return (
       <div className="Domain ">


### PR DESCRIPTION
## Summary
- ensure keywords list is always an array on SingleDomain page
- document keyword default array fix in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d27484144832a920da6bb6c5af297