### PR TITLE
Fix react-query invalidation for domains and keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. See [standa
 * Validated Bearer prefix in API-key authorization and improved component typings.
 * Parallelized Search Console requests and switched cron file reads to async/await.
 * Ensured keyword list defaults to an empty array when keyword data is unavailable.
+* Fixed invalidateQueries syntax and refreshed domain stats after keyword mutations.
 
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 

--- a/__tests__/services/domains-average.test.ts
+++ b/__tests__/services/domains-average.test.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+import { useFetchDomains } from '../../services/domains';
+import { useRefreshKeywords } from '../../services/keywords';
+import apiFetch from '../../services/apiClient';
+import { dummyDomain } from '../../__mocks__/data';
+
+jest.mock('next/router', () => jest.requireActual('next-router-mock'));
+jest.mock('../../services/apiClient');
+jest.mock('react-hot-toast', () => ({ __esModule: true, default: jest.fn() }));
+
+describe('domain average refresh', () => {
+  const apiFetchMock = apiFetch as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('refetches domains after keyword mutations', async () => {
+    const queryClient = new QueryClient();
+    const wrapper = ({ children }: any) =>
+      React.createElement(QueryClientProvider, { client: queryClient, children });
+
+    apiFetchMock
+      .mockResolvedValueOnce({ domains: [dummyDomain] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ domains: [{ ...dummyDomain, avgPosition: 10 }] });
+
+    const { result: domainsHook } = renderHook(
+      () => useFetchDomains(mockRouter as any, true),
+      { wrapper }
+    );
+
+    await waitFor(() =>
+      expect(domainsHook.current.data?.domains[0].avgPosition).toBe(
+        dummyDomain.avgPosition
+      )
+    );
+
+    const { result: refreshHook } = renderHook(
+      () => useRefreshKeywords(jest.fn()),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await refreshHook.current.mutateAsync({ ids: [], domain: dummyDomain.domain });
+    });
+
+    await waitFor(() =>
+      expect(domainsHook.current.data?.domains[0].avgPosition).toBe(10)
+    );
+  });
+});

--- a/__tests__/services/domains.test.tsx
+++ b/__tests__/services/domains.test.tsx
@@ -53,7 +53,7 @@ describe('domain services', () => {
     await act(async () => {
       await result.current.mutateAsync(['test.com']);
     });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['domains'] });
+    expect(invalidateSpy).toHaveBeenCalledWith('domains');
     expect(onSuccess).toHaveBeenCalled();
   });
 });

--- a/services/domains.tsx
+++ b/services/domains.tsx
@@ -104,7 +104,7 @@ export function useAddDomain(onSuccess:Function) {
          if (singleDomain) {
             router.push(`/domain/${newDomain[0].slug}`);
          }
-         queryClient.invalidateQueries({ queryKey: ['domains'] });
+         queryClient.invalidateQueries('domains');
       },
       onError: () => {
          console.log('Error Adding New Domain!!!');
@@ -124,7 +124,7 @@ export function useUpdateDomain(onSuccess:Function) {
          console.log('Settings Updated!!!');
          toast('Settings Updated!', { icon: '✔️' });
          onSuccess();
-         queryClient.invalidateQueries({ queryKey: ['domains'] });
+         queryClient.invalidateQueries('domains');
       },
       onError: (error) => {
          console.log('Error Updating Domain Settings!!!', error);
@@ -141,7 +141,7 @@ export function useDeleteDomain(onSuccess:Function) {
       onSuccess: async () => {
          toast('Domain Removed Successfully!', { icon: '✔️' });
          onSuccess();
-         queryClient.invalidateQueries({ queryKey: ['domains'] });
+         queryClient.invalidateQueries('domains');
       },
       onError: () => {
          console.log('Error Removing Domain!!!');

--- a/services/keywords.tsx
+++ b/services/keywords.tsx
@@ -53,7 +53,8 @@ export function useAddKeywords(onSuccess:Function) {
          console.log('Keywords Added!!!');
          toast('Keywords Added Successfully!', { icon: '✔️' });
          onSuccess();
-         queryClient.invalidateQueries({ queryKey: ['keywords'] });
+         queryClient.invalidateQueries('keywords');
+         queryClient.invalidateQueries('domains');
       },
       onError: () => {
          console.log('Error Adding New Keywords!!!');
@@ -72,7 +73,8 @@ export function useDeleteKeywords(onSuccess:Function) {
          console.log('Removed Keyword!!!');
          onSuccess();
          toast('Keywords Removed Successfully!', { icon: '✔️' });
-         queryClient.invalidateQueries({ queryKey: ['keywords'] });
+         queryClient.invalidateQueries('keywords');
+         queryClient.invalidateQueries('domains');
       },
       onError: () => {
          console.log('Error Removing Keyword!!!');
@@ -92,7 +94,8 @@ export function useFavKeywords(onSuccess:Function) {
          onSuccess();
          const isSticky = data.keywords[0] && data.keywords[0].sticky;
          toast(isSticky ? 'Keywords Made Favorite!' : 'Keywords Unfavorited!', { icon: '✔️' });
-         queryClient.invalidateQueries({ queryKey: ['keywords'] });
+         queryClient.invalidateQueries('keywords');
+         queryClient.invalidateQueries('domains');
       },
       onError: () => {
          console.log('Error Changing Favorite Status!!!');
@@ -112,7 +115,8 @@ export function useUpdateKeywordTags(onSuccess:Function) {
       onSuccess: async () => {
          onSuccess();
          toast('Keyword Tags Updated!', { icon: '✔️' });
-         queryClient.invalidateQueries({ queryKey: ['keywords'] });
+         queryClient.invalidateQueries('keywords');
+         queryClient.invalidateQueries('domains');
       },
       onError: () => {
          console.log('Error Updating Keyword Tags!!!');
@@ -133,7 +137,8 @@ export function useRefreshKeywords(onSuccess:Function) {
          console.log('Keywords Added to Refresh Queue!!!');
          onSuccess();
          toast('Keywords Added to Refresh Queue', { icon: '🔄' });
-         queryClient.invalidateQueries({ queryKey: ['keywords'] });
+         queryClient.invalidateQueries('keywords');
+         queryClient.invalidateQueries('domains');
       },
       onError: () => {
          console.log('Error Refreshing Keywords!!!');


### PR DESCRIPTION
## Summary
- use string syntax for `invalidateQueries`
- refresh domain stats after keyword mutations
- add regression test ensuring domain averages refresh

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1fb05bbbc832a966a3fbc6336cc97