### PR TITLE
feat: key domain queries and harden stats

### DIFF
--- a/__tests__/hooks/domains.test.tsx
+++ b/__tests__/hooks/domains.test.tsx
@@ -18,7 +18,7 @@ fetchMock.mockIf(`${window.location.origin}/api/domains`, async () => {
 
 describe('DomainHooks', () => {
    it('useFetchDomains should fetch the Domains', async () => {
-      const { result } = renderHook(() => useFetchDomains(mockRouter), { wrapper: createWrapper() });
+      const { result } = renderHook(() => useFetchDomains(mockRouter, false), { wrapper: createWrapper() });
       // const result = { current: { isSuccess: false, data: '' } };
       await waitFor(() => {
          return expect(result.current.isLoading).toBe(false);

--- a/__tests__/utils/domains.test.ts
+++ b/__tests__/utils/domains.test.ts
@@ -1,0 +1,43 @@
+import getdomainStats from '../../utils/domains';
+import Keyword from '../../database/models/keyword';
+import parseKeywords from '../../utils/parseKeywords';
+import { readLocalSCData } from '../../utils/searchConsole';
+
+jest.mock('../../database/models/keyword', () => ({
+  __esModule: true,
+  default: { findAll: jest.fn() },
+}));
+
+jest.mock('../../utils/parseKeywords', () => ({ __esModule: true, default: jest.fn() }));
+
+jest.mock('../../utils/searchConsole', () => ({
+  __esModule: true,
+  readLocalSCData: jest.fn(),
+}));
+
+const mockFindAll = (Keyword as any).findAll as jest.Mock;
+const mockParseKeywords = parseKeywords as jest.Mock;
+const mockReadLocalSCData = readLocalSCData as jest.Mock;
+
+describe('getdomainStats', () => {
+  it('returns avgPosition 0 when domain has no keywords', async () => {
+    mockFindAll.mockResolvedValue([]);
+    mockParseKeywords.mockReturnValue([]);
+    mockReadLocalSCData.mockResolvedValue(null);
+
+    const domain = {
+      ID: 1,
+      domain: 'example.com',
+      slug: 'example-com',
+      notification: false,
+      notification_interval: '',
+      notification_emails: '',
+      lastUpdated: new Date().toISOString(),
+      added: new Date().toISOString(),
+    } as any;
+
+    const result = await getdomainStats([domain]);
+    expect(result[0].avgPosition).toBe(0);
+    expect(result[0].keywordCount).toBe(0);
+  });
+});

--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -33,7 +33,7 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
    const { mutate: deleteMutate } = useDeleteDomain(() => { closeModal(false); router.push('/domains'); });
 
    // Get the Full Domain Data along with the Search Console API Data.
-   useFetchDomain(router, domain && domain.domain ? domain.domain : '', (domainObj:DomainType) => {
+   useFetchDomain(router, domain && domain.slug ? domain.slug : '', (domainObj:DomainType) => {
       const currentSearchConsoleSettings = domainObj.search_console && JSON.parse(domainObj.search_console);
       setDomainSettings({ ...domainSettings, search_console: currentSearchConsoleSettings || domainSettings.search_console });
    });

--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -41,7 +41,11 @@ const IdeasKeywordsTable = ({
    const [isMobile] = useIsMobile();
    const isResearchPage = router.pathname === '/research';
 
-   const { data: domainsData } = useQuery('domains', () => fetchDomains(router, false), { enabled: selectedKeywords.length > 0, retry: false });
+   const { data: domainsData } = useQuery(
+      ['domains', false],
+      () => fetchDomains(router, false),
+      { enabled: selectedKeywords.length > 0, retry: false },
+   );
    const theDomains: DomainType[] = (domainsData && domainsData.domains) || [];
 
    useWindowResize(() => setListHeight(window.innerHeight - (isMobile ? 200 : 400)));

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -25,7 +25,7 @@ const SingleDomain: NextPage = () => {
    const [showSettings, setShowSettings] = useState(false);
    const [keywordSPollInterval, setKeywordSPollInterval] = useState<undefined|number>(undefined);
    const { data: appSettingsData, isLoading: isAppSettingsLoading } = useFetchSettings();
-   const { data: domainsData } = useFetchDomains(router);
+   const { data: domainsData } = useFetchDomains(router, false);
    const appSettings: SettingsType = appSettingsData?.settings || {};
    const { scraper_type = '', available_scapers = [] } = appSettings;
    const activeScraper = useMemo(() => available_scapers.find((scraper) => scraper.value === scraper_type), [scraper_type, available_scapers]);

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -25,7 +25,7 @@ const DiscoverPage: NextPage = () => {
    const [showAddDomain, setShowAddDomain] = useState(false);
    const [scDateFilter, setSCDateFilter] = useState('thirtyDays');
    const { data: appSettings } = useFetchSettings();
-   const { data: domainsData } = useFetchDomains(router);
+   const { data: domainsData } = useFetchDomains(router, false);
    const scConnected = !!(appSettings && appSettings?.settings?.search_console_integrated);
    const { data: keywordsData, isLoading: keywordsLoading, isFetching } = useFetchSCKeywords(router, !!(domainsData?.domains?.length) && scConnected);
 

--- a/pages/domain/ideas/[slug]/index.tsx
+++ b/pages/domain/ideas/[slug]/index.tsx
@@ -27,7 +27,7 @@ const DiscoverPage: NextPage = () => {
    const [showFavorites, setShowFavorites] = useState(false);
 
    const { data: appSettings } = useFetchSettings();
-   const { data: domainsData } = useFetchDomains(router);
+   const { data: domainsData } = useFetchDomains(router, false);
    const adwordsConnected = !!(appSettings && appSettings?.settings?.adwords_refresh_token
       && appSettings?.settings?.adwords_developer_token, appSettings?.settings?.adwords_account_id);
    const searchConsoleConnected = !!(appSettings && appSettings?.settings?.search_console_integrated);

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -25,7 +25,7 @@ const InsightPage: NextPage = () => {
    const [showAddDomain, setShowAddDomain] = useState(false);
    const [scDateFilter, setSCDateFilter] = useState('thirtyDays');
    const { data: appSettings } = useFetchSettings();
-   const { data: domainsData } = useFetchDomains(router);
+   const { data: domainsData } = useFetchDomains(router, false);
    const scConnected = !!(appSettings && appSettings?.settings?.search_console_integrated);
    const { data: insightData } = useFetchSCInsight(router, !!(domainsData?.domains?.length) && scConnected);
 

--- a/services/domains.tsx
+++ b/services/domains.tsx
@@ -19,9 +19,9 @@ export async function fetchDomains(router: NextRouter, withStats:boolean): Promi
    return res.json();
 }
 
-export async function fetchDomain(router: NextRouter, domainName: string): Promise<{domain: DomainType}> {
-   if (!domainName) { throw new Error('No Domain Name Provided!'); }
-   const res = await fetch(`${window.location.origin}/api/domain?domain=${domainName}`, { method: 'GET' });
+export async function fetchDomain(router: NextRouter, slug: string): Promise<{domain: DomainType}> {
+   if (!slug) { throw new Error('No Domain Name Provided!'); }
+   const res = await fetch(`${window.location.origin}/api/domain?domain=${slug}`, { method: 'GET' });
    if (res.status >= 400 && res.status < 600) {
       if (res.status === 401) {
          console.log('Unauthorized!!');
@@ -63,11 +63,11 @@ export async function fetchDomainScreenshot(domain: string, forceFetch = false):
 }
 
 export function useFetchDomains(router: NextRouter, withStats:boolean = false) {
-   return useQuery('domains', () => fetchDomains(router, withStats));
+   return useQuery(['domains', withStats], () => fetchDomains(router, withStats));
 }
 
-export function useFetchDomain(router: NextRouter, domainName:string, onSuccess: Function) {
-   return useQuery('domain', () => fetchDomain(router, domainName), {
+export function useFetchDomain(router: NextRouter, slug:string, onSuccess: Function) {
+   return useQuery(['domain', slug], () => fetchDomain(router, slug), {
       onSuccess: async (data) => {
          console.log('Domain Loaded!!!', data.domain);
          onSuccess(data.domain);

--- a/utils/domains.ts
+++ b/utils/domains.ts
@@ -10,7 +10,6 @@ import { readLocalSCData } from './searchConsole';
  */
 const getdomainStats = async (domains:DomainType[]): Promise<DomainType[]> => {
    const finalDomains: DomainType[] = [];
-   console.log('domains: ', domains.length);
 
    for (const domain of domains) {
       const domainWithStat = domain;
@@ -23,7 +22,7 @@ const getdomainStats = async (domains:DomainType[]): Promise<DomainType[]> => {
       const KeywordsUpdateDates: number[] = keywords.reduce((acc: number[], itm) => [...acc, new Date(itm.lastUpdated).getTime()], [0]);
       const lastKeywordUpdateDate = Math.max(...KeywordsUpdateDates);
       domainWithStat.keywordsUpdated = new Date(lastKeywordUpdateDate || new Date(domain.lastUpdated).getTime()).toJSON();
-      domainWithStat.avgPosition = Math.round(keywordPositions / keywords.length);
+      domainWithStat.avgPosition = keywords.length ? Math.round(keywordPositions / keywords.length) : 0;
 
       // Then Load the SC File and read the stats and calculate the Last 7 days stats
       const localSCData = await readLocalSCData(domain.domain);


### PR DESCRIPTION
## Summary
- key domain and domains fetch hooks by slug/withStats for better caching
- handle empty keyword stats with avg position 0 and remove stray logs
- add regression test for domains without keywords

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fb143988832ab0e5e8259cbffc86