### PR TITLE
feat: refresh search console cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 
+### [2.0.9](https://github.com/djav1985/v-serpbear/compare/v2.0.8...v2.0.9) (2025-09-12)
+
+### Features
+* Automatically refreshes Search Console data and falls back to global credentials when domain-specific credentials are unavailable.
+
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Email Notification:** Get notified of your keyword position changes daily/weekly/monthly through email.
 - **SERP API:** SerpBear comes with built-in API that you can use for your marketing & data reporting tools.
 - **Keyword Research:** Ability to research keywords and auto-generate keyword ideas from your tracked website's content by integrating your Google Ads test account.
-- **Google Search Console Integration:** Get the actual visit count, impressions & more for Each keyword.
+- **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically and falls back to global credentials when domain-level credentials aren't configured.
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
 

--- a/__tests__/api/searchconsole.test.ts
+++ b/__tests__/api/searchconsole.test.ts
@@ -86,10 +86,12 @@ describe('/api/searchconsole - CRON functionality', () => {
         client_email: 'test@example.com',
         private_key: 'mock-private-key',
       })
+      .mockResolvedValueOnce({ client_email: '', private_key: '' })
       .mockResolvedValueOnce({
         client_email: 'test2@example.com',
         private_key: 'mock-private-key-2',
-      });
+      })
+      .mockResolvedValueOnce({ client_email: '', private_key: '' });
 
     // Mock successful data fetching
     mockFetchDomainSCData.mockResolvedValue(mockSCDataResponse);
@@ -111,6 +113,10 @@ describe('/api/searchconsole - CRON functionality', () => {
         client_email: 'test@example.com',
         private_key: 'mock-private-key',
       },
+      {
+        client_email: '',
+        private_key: '',
+      },
     );
     expect(mockFetchDomainSCData).toHaveBeenNthCalledWith(
       2,
@@ -124,6 +130,10 @@ describe('/api/searchconsole - CRON functionality', () => {
       {
         client_email: 'test2@example.com',
         private_key: 'mock-private-key-2',
+      },
+      {
+        client_email: '',
+        private_key: '',
       },
     );
 
@@ -145,10 +155,9 @@ describe('/api/searchconsole - CRON functionality', () => {
     mockDomainFindAll.mockResolvedValue(mockDomains as any);
 
     // Mock no API credentials found
-    mockGetSearchConsoleApiInfo.mockResolvedValue({
-      client_email: '',
-      private_key: '',
-    });
+    mockGetSearchConsoleApiInfo
+      .mockResolvedValueOnce({ client_email: '', private_key: '' })
+      .mockResolvedValueOnce({ client_email: '', private_key: '' });
 
     await handler(req as NextApiRequest, res as NextApiResponse);
 
@@ -187,10 +196,12 @@ describe('/api/searchconsole - CRON functionality', () => {
         client_email: 'error@example.com',
         private_key: 'error-key',
       })
+      .mockResolvedValueOnce({ client_email: '', private_key: '' })
       .mockResolvedValueOnce({
         client_email: 'success@example.com',
         private_key: 'success-key',
-      });
+      })
+      .mockResolvedValueOnce({ client_email: '', private_key: '' });
 
     // Mock error for first domain, success for second
     mockFetchDomainSCData

--- a/__tests__/utils/generateEmail.test.ts
+++ b/__tests__/utils/generateEmail.test.ts
@@ -36,7 +36,7 @@ describe('generateEmail', () => {
 
     const settings = { search_console_client_email: '', search_console_private_key: '', keywordsColumns: [] } as any;
 
-    const html = await generateEmail('example.com', keywords, settings);
+    const html = await generateEmail({ domain: 'example.com' } as any, keywords, settings);
     expect(html).toContain('(Berlin, Berlin State)');
   });
 });

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -54,7 +54,7 @@ const notify = async (req: NextApiRequest, res: NextApiResponse<NotifyResponse>)
    }
 };
 
-const sendNotificationEmail = async (domain: Domain, settings: SettingsType) => {
+const sendNotificationEmail = async (domain: DomainType | Domain, settings: SettingsType) => {
    const {
       smtp_server = '',
       smtp_port = '',
@@ -73,12 +73,13 @@ const sendNotificationEmail = async (domain: Domain, settings: SettingsType) => 
       if (smtp_password) mailerSettings.auth.pass = smtp_password;
    }
    const transporter = nodeMailer.createTransport(mailerSettings);
-   const domainName = domain.domain;
+   const domainObj: DomainType = (domain as any).get ? (domain as any).get({ plain: true }) : domain as DomainType;
+   const domainName = domainObj.domain;
    const query = { where: { domain: domainName } };
    const domainKeywords:Keyword[] = await Keyword.findAll(query);
    const keywordsArray = domainKeywords.map((el) => el.get({ plain: true }));
    const keywords: KeywordType[] = parseKeywords(keywordsArray);
-   const emailHTML = await generateEmail(domainName, keywords, settings);
+   const emailHTML = await generateEmail(domainObj, keywords, settings);
    await transporter.sendMail({
       from: fromEmail,
       to: domain.notification_emails || notification_email,


### PR DESCRIPTION
## Summary
- refresh Search Console data only when cache is stale, using domain or global credentials
- refresh daily email stats when cache is empty or stale
- preserve previous fetch times and note automatic refresh behavior in docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c49a2ac908832aad57c1793cdd6f79