### PR TITLE
feat: add manual search console refresh button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 * Automatically refreshes Search Console data and falls back to global credentials when domain-specific credentials are unavailable.
+* Added manual refresh button for Search Console data.
 
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Email Notification:** Get notified of your keyword position changes daily/weekly/monthly through email.
 - **SERP API:** SerpBear comes with built-in API that you can use for your marketing & data reporting tools.
 - **Keyword Research:** Ability to research keywords and auto-generate keyword ideas from your tracked website's content by integrating your Google Ads test account.
-- **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically and falls back to global credentials when domain-level credentials aren't configured.
+- **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically, can be manually refreshed from settings, and falls back to global credentials when domain-level credentials aren't configured.
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
 
@@ -27,6 +27,7 @@ The App uses third party website scrapers like ScrapingAnt, ScrapingRobot, Searc
 The Keyword Research and keyword generation feature works by integrating your Google Ads test accounts into SerpBear. You can also view the added keyword's monthly search volume data once you [integrate Google Ads](https://docs.serpbear.com/miscellaneous/integrate-google-ads).
 
 When you [integrate Google Search Console](https://docs.serpbear.com/miscellaneous/integrate-google-search-console), the app shows actual search visits for each tracked keywords. You can also discover new keywords, and find the most performing keywords, countries, pages.you will be able to view the actual visits count from Google Search for the tracked keywords.
+You can also manually refresh Search Console data anytime from the Settings page.
 
 #### Getting Started
 

--- a/__tests__/components/SearchConsoleSettings.test.tsx
+++ b/__tests__/components/SearchConsoleSettings.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import SearchConsoleSettings from '../../components/settings/SearchConsoleSettings';
+import { dummySettings } from '../../__mocks__/data';
+import { refreshSearchConsoleData } from '../../services/searchConsole';
+
+jest.mock('../../services/searchConsole', () => ({
+   refreshSearchConsoleData: jest.fn(),
+}));
+
+describe('SearchConsoleSettings Component', () => {
+   it('renders refresh button and calls refreshSearchConsoleData', async () => {
+      const settings = { ...dummySettings, search_console_client_email: '', search_console_private_key: '' } as any;
+      const updateSettings = jest.fn();
+      render(<SearchConsoleSettings settings={settings} settingsError={null} updateSettings={updateSettings} />);
+      const button = screen.getByRole('button', { name: /refresh search console data/i });
+      expect(button).toBeInTheDocument();
+      fireEvent.click(button);
+      await waitFor(() => expect(refreshSearchConsoleData).toHaveBeenCalled());
+   });
+});

--- a/components/settings/SearchConsoleSettings.tsx
+++ b/components/settings/SearchConsoleSettings.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import InputField from '../common/InputField';
+import Icon from '../common/Icon';
+import { refreshSearchConsoleData } from '../../services/searchConsole';
 
 type SearchConsoleSettingsProps = {
    settings: SettingsType,
@@ -11,6 +13,17 @@ type SearchConsoleSettingsProps = {
 }
 
 const SearchConsoleSettings = ({ settings, settingsError, updateSettings }:SearchConsoleSettingsProps) => {
+   const [refreshing, setRefreshing] = useState(false);
+
+   const handleRefresh = async () => {
+      setRefreshing(true);
+      try {
+         await refreshSearchConsoleData();
+      } finally {
+         setRefreshing(false);
+      }
+   };
+
    return (
       <div>
       <div>
@@ -33,12 +46,22 @@ const SearchConsoleSettings = ({ settings, settingsError, updateSettings }:Searc
          <div className="settings__section__input mb-4 flex flex-col justify-between items-center w-full">
             <label className='mb-2 font-semibold block text-sm text-gray-700 capitalize w-full'>Search Console Private Key</label>
             <textarea
-               className={`w-full p-2 border border-gray-200 rounded mb-3 text-xs 
+               className={`w-full p-2 border border-gray-200 rounded mb-3 text-xs
                focus:outline-none h-[100px] focus:border-blue-200`}
                value={settings.search_console_private_key}
                placeholder={'-----BEGIN PRIVATE KEY-----/ssssaswdkihad....'}
                onChange={(event) => updateSettings('search_console_private_key', event.target.value)}
             />
+         </div>
+         <div className="settings__section__input mb-5">
+            <button
+               onClick={handleRefresh}
+               disabled={refreshing}
+               className={`py-3 px-5 w-full rounded cursor-pointer bg-gray-100 text-gray-800 font-semibold text-sm hover:bg-gray-200
+               disabled:opacity-50 disabled:cursor-not-allowed`}
+            >
+               {refreshing && <Icon type="loading" size={14} />} Refresh Search Console Data
+            </button>
          </div>
       </div>
    </div>

--- a/services/searchConsole.ts
+++ b/services/searchConsole.ts
@@ -1,4 +1,5 @@
 import { NextRouter } from 'next/router';
+import toast from 'react-hot-toast';
 import { useQuery } from 'react-query';
 
 export async function fetchSCKeywords(router: NextRouter) {
@@ -36,3 +37,18 @@ export function useFetchSCInsight(router: NextRouter, domainLoaded: boolean = fa
    // console.log('ROUTER: ', router);
    return useQuery('scinsight', () => router.query.slug && fetchSCInsight(router), { enabled: domainLoaded });
 }
+
+export const refreshSearchConsoleData = async () => {
+   try {
+      const res = await fetch(`${window.location.origin}/api/searchconsole`, { method: 'POST' });
+      if (res.status >= 400 && res.status < 600) {
+         throw new Error('Bad response from server');
+      }
+      toast('Search Console Data Refreshed!', { icon: '✔️' });
+      return res.json();
+   } catch (error) {
+      console.log('Error Refreshing Search Console Data!!!', error);
+      toast('Error Refreshing Search Console Data', { icon: '⚠️' });
+      throw error;
+   }
+};


### PR DESCRIPTION
## Summary
- add service to manually refresh Search Console data with toast notifications
- expose refresh button in Search Console settings
- document new manual refresh capability and changelog entry
- test Search Console settings refresh button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c49c477a84832abca870883d6d4965