### PR TITLE
Harden validation and JSON parsing across APIs and scrapers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file. See [standa
 * Automatically refreshes Search Console data and falls back to global credentials when domain-specific credentials are unavailable.
 * Added manual refresh button for Search Console data.
 
+### Bug Fixes
+* Hardened API ID validation and corrected domain responses.
+* Added default empty strings for domain-related model fields.
+* Wrapped scraper and keyword JSON parsing with error handling.
+* Removed stray console logs and simplified Jest polyfills.
+
 ### [2.0.8](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v2.0.8) (2025-08-12)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically, can be manually refreshed from settings, and falls back to global credentials when domain-level credentials aren't configured.
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
+- **Robust Error Handling:** Improved input validation and safer JSON parsing across the app.
 
 #### How it Works
 

--- a/database/models/domain.ts
+++ b/database/models/domain.ts
@@ -11,11 +11,11 @@ class Domain extends Model {
    ID!: number;
 
    @Unique
-   @Column({ type: DataType.STRING, allowNull: false, defaultValue: true, unique: true })
+   @Column({ type: DataType.STRING, allowNull: false, defaultValue: '', unique: true })
    domain!: string;
 
    @Unique
-   @Column({ type: DataType.STRING, allowNull: false, defaultValue: true, unique: true })
+   @Column({ type: DataType.STRING, allowNull: false, defaultValue: '', unique: true })
    slug!: string;
 
    @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 0 })

--- a/database/models/keyword.ts
+++ b/database/models/keyword.ts
@@ -28,7 +28,7 @@ class Keyword extends Model {
    @Column({ type: DataType.STRING, allowNull: true, defaultValue: '' })
    latlong!: string;
 
-   @Column({ type: DataType.STRING, allowNull: false, defaultValue: '{}' })
+   @Column({ type: DataType.STRING, allowNull: false, defaultValue: '' })
    domain!: string;
 
    // @ForeignKey(() => Domain)

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -24,37 +24,33 @@ window.matchMedia = (query) => ({
 global.ResizeObserver = require('resize-observer-polyfill');
 
 // polyfill TextEncoder/TextDecoder for msw
-if (typeof global.TextEncoder === 'undefined') {
-   global.TextEncoder = TextEncoder;
-   global.TextDecoder = TextDecoder;
-}
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
 
 // polyfill BroadcastChannel for msw
-if (typeof global.BroadcastChannel === 'undefined') {
-   class BroadcastChannelMock {
-      constructor(name) {
-         this.name = name;
-         this.messages = [];
-      }
-
-      postMessage(message) {
-         this.messages.push(message);
-      }
-
-      close() {
-         this.messages = [];
-      }
-
-      addEventListener() {
-         return this;
-      }
-
-      removeEventListener() {
-         return this;
-      }
+class BroadcastChannelMock {
+   constructor(name) {
+      this.name = name;
+      this.messages = [];
    }
-   global.BroadcastChannel = BroadcastChannelMock;
+
+   postMessage(message) {
+      this.messages.push(message);
+   }
+
+   close() {
+      this.messages = [];
+   }
+
+   addEventListener() {
+      return this;
+   }
+
+   removeEventListener() {
+      return this;
+   }
 }
+global.BroadcastChannel = BroadcastChannelMock;
 
 // Enable Fetch Mocking
 enableFetchMocks();

--- a/pages/api/domains.ts
+++ b/pages/api/domains.ts
@@ -61,7 +61,7 @@ export const getDomains = async (req: NextApiRequest, res: NextApiResponse<Domai
          const searchConsoleData = scData ? { ...scData, client_email: client_email ? 'true' : '', private_key: private_key ? 'true' : '' } : {};
          return { ...domainItem, search_console: JSON.stringify(searchConsoleData) };
       });
-      const theDomains: DomainType[] = withStats ? await getdomainStats(formattedDomains) : allDomains;
+      const theDomains: DomainType[] = withStats ? await getdomainStats(formattedDomains) : formattedDomains;
       return res.status(200).json({ domains: theDomains });
    } catch (error) {
       return res.status(400).json({ domains: [], error: 'Error Getting Domains.' });

--- a/pages/api/keyword.ts
+++ b/pages/api/keyword.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 const getKeyword = async (req: NextApiRequest, res: NextApiResponse<KeywordGetResponse>) => {
-   if (!req.query.id && typeof req.query.id !== 'string') {
+   if (!req.query.id || typeof req.query.id !== 'string') {
        return res.status(400).json({ error: 'Keyword ID is Required!' });
    }
 

--- a/pages/api/keywords.ts
+++ b/pages/api/keywords.ts
@@ -132,7 +132,7 @@ const addKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsGet
 };
 
 const deleteKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsDeleteRes>) => {
-   if (!req.query.id && typeof req.query.id !== 'string') {
+   if (!req.query.id || typeof req.query.id !== 'string') {
       return res.status(400).json({ error: 'keyword ID is Required!' });
    }
    console.log('req.query.id: ', req.query.id);
@@ -149,7 +149,7 @@ const deleteKeywords = async (req: NextApiRequest, res: NextApiResponse<Keywords
 };
 
 const updateKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsGetResponse>) => {
-   if (!req.query.id && typeof req.query.id !== 'string') {
+   if (!req.query.id || typeof req.query.id !== 'string') {
       return res.status(400).json({ error: 'keyword ID is Required!' });
    }
    if (req.body.sticky === undefined && req.body.tags === undefined) {

--- a/pages/api/refresh.ts
+++ b/pages/api/refresh.ts
@@ -39,7 +39,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 }
 
 const refreshTheKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsRefreshRes>) => {
-   if (!req.query.id && typeof req.query.id !== 'string') {
+   if (!req.query.id || typeof req.query.id !== 'string') {
       return res.status(400).json({ error: 'keyword ID is Required!' });
    }
    if (req.query.id === 'all' && !req.query.domain) {

--- a/scrapers/services/hasdata.ts
+++ b/scrapers/services/hasdata.ts
@@ -27,7 +27,16 @@ const hasdata:ScraperSettings = {
    resultObjectKey: 'organicResults',
    serpExtractor: (content) => {
       const extractedResult = [];
-      const results: HasDataResult[] = (typeof content === 'string') ? JSON.parse(content) : content as HasDataResult[];
+      let results: HasDataResult[];
+      if (typeof content === 'string') {
+         try {
+            results = JSON.parse(content) as HasDataResult[];
+         } catch (error) {
+            throw new Error(`Invalid JSON response for HasData: ${error instanceof Error ? error.message : error}`);
+         }
+      } else {
+         results = content as HasDataResult[];
+      }
 
       for (const { link, title, position } of results) {
          if (title && link) {

--- a/scrapers/services/searchapi.ts
+++ b/scrapers/services/searchapi.ts
@@ -27,7 +27,16 @@ const searchapi:ScraperSettings = {
   resultObjectKey: 'organic_results',
   serpExtractor: (content) => {
      const extractedResult = [];
-     const results: SearchApiResult[] = (typeof content === 'string') ? JSON.parse(content) : content as SearchApiResult[];
+     let results: SearchApiResult[];
+     if (typeof content === 'string') {
+        try {
+           results = JSON.parse(content) as SearchApiResult[];
+        } catch (error) {
+           throw new Error(`Invalid JSON response for SearchApi.io: ${error instanceof Error ? error.message : error}`);
+        }
+     } else {
+        results = content as SearchApiResult[];
+     }
 
      for (const { link, title, position } of results) {
         if (title && link) {

--- a/scrapers/services/serpapi.ts
+++ b/scrapers/services/serpapi.ts
@@ -26,7 +26,16 @@ const serpapi:ScraperSettings = {
    resultObjectKey: 'organic_results',
    serpExtractor: (content) => {
       const extractedResult = [];
-      const results: SerpApiResult[] = (typeof content === 'string') ? JSON.parse(content) : content as SerpApiResult[];
+      let results: SerpApiResult[];
+      if (typeof content === 'string') {
+         try {
+            results = JSON.parse(content) as SerpApiResult[];
+         } catch (error) {
+            throw new Error(`Invalid JSON response for SerpApi.com: ${error instanceof Error ? error.message : error}`);
+         }
+      } else {
+         results = content as SerpApiResult[];
+      }
 
       for (const { link, title, position } of results) {
          if (title && link) {

--- a/scrapers/services/serper.ts
+++ b/scrapers/services/serper.ts
@@ -18,7 +18,16 @@ const serper:ScraperSettings = {
    resultObjectKey: 'organic',
    serpExtractor: (content) => {
       const extractedResult = [];
-      const results: SerperResult[] = (typeof content === 'string') ? JSON.parse(content) : content as SerperResult[];
+      let results: SerperResult[];
+      if (typeof content === 'string') {
+         try {
+            results = JSON.parse(content) as SerperResult[];
+         } catch (error) {
+            throw new Error(`Invalid JSON response for Serper.dev: ${error instanceof Error ? error.message : error}`);
+         }
+      } else {
+         results = content as SerperResult[];
+      }
 
       for (const { link, title, position } of results) {
          if (title && link) {

--- a/scrapers/services/serply.ts
+++ b/scrapers/services/serply.ts
@@ -25,7 +25,16 @@ const serply:ScraperSettings = {
    resultObjectKey: 'result',
    serpExtractor: (content) => {
       const extractedResult = [];
-      const results: SerplyResult[] = (typeof content === 'string') ? JSON.parse(content) : content as SerplyResult[];
+      let results: SerplyResult[];
+      if (typeof content === 'string') {
+         try {
+            results = JSON.parse(content) as SerplyResult[];
+         } catch (error) {
+            throw new Error(`Invalid JSON response for Serply: ${error instanceof Error ? error.message : error}`);
+         }
+      } else {
+         results = content as SerplyResult[];
+      }
       for (const result of results) {
          if (result.title && result.link) {
             extractedResult.push({

--- a/scrapers/services/spaceserp.ts
+++ b/scrapers/services/spaceserp.ts
@@ -24,7 +24,16 @@ const spaceSerp:ScraperSettings = {
    resultObjectKey: 'organic_results',
    serpExtractor: (content) => {
       const extractedResult = [];
-      const results: SpaceSerpResult[] = (typeof content === 'string') ? JSON.parse(content) : content as SpaceSerpResult[];
+      let results: SpaceSerpResult[];
+      if (typeof content === 'string') {
+         try {
+            results = JSON.parse(content) as SpaceSerpResult[];
+         } catch (error) {
+            throw new Error(`Invalid JSON response for Space Serp: ${error instanceof Error ? error.message : error}`);
+         }
+      } else {
+         results = content as SpaceSerpResult[];
+      }
       for (const result of results) {
          if (result.title && result.link) {
             extractedResult.push({

--- a/scrapers/services/valueserp.ts
+++ b/scrapers/services/valueserp.ts
@@ -25,7 +25,16 @@ const valueSerp:ScraperSettings = {
    resultObjectKey: 'organic_results',
    serpExtractor: (content) => {
       const extractedResult = [];
-      const results: ValueSerpResult[] = (typeof content === 'string') ? JSON.parse(content) : content as ValueSerpResult[];
+      let results: ValueSerpResult[];
+      if (typeof content === 'string') {
+         try {
+            results = JSON.parse(content) as ValueSerpResult[];
+         } catch (error) {
+            throw new Error(`Invalid JSON response for Value Serp: ${error instanceof Error ? error.message : error}`);
+         }
+      } else {
+         results = content as ValueSerpResult[];
+      }
       for (const result of results) {
          if (result.title && result.link) {
             extractedResult.push({

--- a/utils/client/exportcsv.ts
+++ b/utils/client/exportcsv.ts
@@ -13,8 +13,6 @@ const exportCSV = (keywords: KeywordType[] | SCKeywordType[], domain:string, scD
    let csvBody = '';
    let fileName = `${domain}-keywords_serp.csv`;
 
-   console.log(keywords[0]);
-   console.log('isSCKeywords:', isSCKeywords);
 
    if (isSCKeywords) {
       csvHeader = 'ID,Keyword,Position,Impressions,Clicks,CTR,Country,Device\r\n';

--- a/utils/parseKeywords.ts
+++ b/utils/parseKeywords.ts
@@ -6,13 +6,29 @@ import Keyword from '../database/models/keyword';
  * @returns {KeywordType[]}
  */
 const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
-   const parsedItems = allKeywords.map((keywrd:Keyword) => ({
+   const parsedItems = allKeywords.map((keywrd:Keyword) => {
+      let history: KeywordHistory = {};
+      try { history = JSON.parse(keywrd.history); } catch { history = {}; }
+
+      let tags: string[] = [];
+      try { tags = JSON.parse(keywrd.tags); } catch { tags = []; }
+
+      let lastResult: any[] = [];
+      try { lastResult = JSON.parse(keywrd.lastResult); } catch { lastResult = []; }
+
+      let lastUpdateError: any = false;
+      if (keywrd.lastUpdateError !== 'false' && keywrd.lastUpdateError.includes('{')) {
+         try { lastUpdateError = JSON.parse(keywrd.lastUpdateError); } catch { lastUpdateError = {}; }
+      }
+
+      return {
          ...keywrd,
-         history: JSON.parse(keywrd.history),
-         tags: JSON.parse(keywrd.tags),
-         lastResult: JSON.parse(keywrd.lastResult),
-         lastUpdateError: keywrd.lastUpdateError !== 'false' && keywrd.lastUpdateError.includes('{') ? JSON.parse(keywrd.lastUpdateError) : false,
-      }));
+         history,
+         tags,
+         lastResult,
+         lastUpdateError,
+      };
+   });
    return parsedItems;
 };
 

--- a/utils/scraper.ts
+++ b/utils/scraper.ts
@@ -325,7 +325,7 @@ export const getSerp = (domainURL:string, result:SearchResult[]) : SERPObject =>
  * @returns {void}
  */
 export const retryScrape = async (keywordID: number) : Promise<void> => {
-   if (!keywordID && !Number.isInteger(keywordID)) { return; }
+   if (!keywordID || !Number.isInteger(keywordID)) { return; }
    let currentQueue: number[] = [];
 
    const filePath = `${process.cwd()}/data/failed_queue.json`;
@@ -345,7 +345,7 @@ export const retryScrape = async (keywordID: number) : Promise<void> => {
  * @returns {void}
  */
 export const removeFromRetryQueue = async (keywordID: number) : Promise<void> => {
-   if (!keywordID && !Number.isInteger(keywordID)) { return; }
+   if (!keywordID || !Number.isInteger(keywordID)) { return; }
    let currentQueue: number[] = [];
 
    const filePath = `${process.cwd()}/data/failed_queue.json`;


### PR DESCRIPTION
## Summary
- validate API query ids with strict string checks
- return formatted domains when stats aren't requested
- set default empty strings for domain and keyword models
- wrap JSON parsing in scrapers and keyword utilities
- simplify jest polyfills and remove stray console logs

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4a536a814832ab58ab23b9f43de7c