### PR TITLE
Protect notify API with authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### Changed
 * Added configurable cron timezone and schedule environment variables for scraping, retries, and notification jobs.
 * Google Search Console email summaries reuse cached data for the active cron day to avoid redundant refreshes.
+* Hardened `/api/notify` to require authentication before sending notification emails.
 
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
 - **Robust Error Handling:** Improved input validation and safer JSON parsing across the app.
+- **API Hardening:** Notification email endpoint now enforces authentication for both UI and API key access.
 
 #### How it Works
 

--- a/__tests__/api/notify.test.ts
+++ b/__tests__/api/notify.test.ts
@@ -1,0 +1,155 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../../pages/api/notify';
+import db from '../../database/database';
+import Domain from '../../database/models/domain';
+import Keyword from '../../database/models/keyword';
+import verifyUser from '../../utils/verifyUser';
+import parseKeywords from '../../utils/parseKeywords';
+import generateEmail from '../../utils/generateEmail';
+import nodeMailer from 'nodemailer';
+import { getAppSettings } from '../../pages/api/settings';
+
+jest.mock('../../database/database', () => ({
+  __esModule: true,
+  default: { sync: jest.fn() },
+}));
+
+jest.mock('../../database/models/domain', () => ({
+  __esModule: true,
+  default: { findAll: jest.fn(), findOne: jest.fn() },
+}));
+
+jest.mock('../../database/models/keyword', () => ({
+  __esModule: true,
+  default: { findAll: jest.fn() },
+}));
+
+jest.mock('../../utils/verifyUser');
+jest.mock('../../utils/parseKeywords');
+jest.mock('../../utils/generateEmail');
+
+jest.mock('nodemailer', () => ({
+  __esModule: true,
+  default: { createTransport: jest.fn() },
+}));
+
+jest.mock('../../pages/api/settings', () => ({
+  __esModule: true,
+  getAppSettings: jest.fn(),
+}));
+
+type MockedResponse = Partial<NextApiResponse> & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+describe('/api/notify - authentication', () => {
+  let req: Partial<NextApiRequest>;
+  let res: MockedResponse;
+  let sendMailMock: jest.Mock;
+
+  beforeEach(() => {
+    req = {
+      method: 'POST',
+      query: {},
+      headers: {},
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as MockedResponse;
+
+    jest.clearAllMocks();
+
+    sendMailMock = jest.fn().mockResolvedValue(undefined);
+    (nodeMailer.createTransport as jest.Mock).mockReturnValue({ sendMail: sendMailMock });
+    (db.sync as jest.Mock).mockResolvedValue(undefined);
+    (parseKeywords as jest.Mock).mockImplementation((keywords) => keywords);
+    (generateEmail as jest.Mock).mockResolvedValue('<html></html>');
+    (getAppSettings as jest.Mock).mockResolvedValue({
+      smtp_server: 'smtp.test',
+      smtp_port: '587',
+      smtp_username: '',
+      smtp_password: '',
+      notification_email: 'notify@example.com',
+      notification_email_from: '',
+      notification_email_from_name: 'SerpBear',
+    });
+  });
+
+  it('returns 401 when verification fails', async () => {
+    (verifyUser as jest.Mock).mockReturnValue('Not authorized');
+
+    await handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(verifyUser).toHaveBeenCalledWith(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Not authorized' });
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+
+  it('sends notifications when authorized via API key header', async () => {
+    req.headers = {
+      authorization: 'Bearer valid-key',
+    };
+
+    (verifyUser as jest.Mock).mockImplementation((incomingReq: NextApiRequest) => (
+      incomingReq.headers?.authorization === 'Bearer valid-key'
+        ? 'authorized'
+        : 'Invalid API Key Provided.'
+    ));
+
+    const domainRecord = {
+      get: () => ({
+        domain: 'example.com',
+        notification: true,
+        notification_emails: 'custom@example.com',
+      }),
+    };
+
+    const keywordRecord = {
+      get: () => ({
+        keyword: 'rank tracker',
+        history: '{}',
+        tags: '[]',
+        lastResult: '[]',
+        lastUpdateError: 'false',
+        position: 5,
+        country: 'US',
+        device: 'desktop',
+        city: '',
+        state: '',
+        lastUpdated: new Date().toISOString(),
+      }),
+    };
+
+    (Domain.findAll as jest.Mock).mockResolvedValue([domainRecord]);
+    (Keyword.findAll as jest.Mock).mockResolvedValue([keywordRecord]);
+    (parseKeywords as jest.Mock).mockReturnValue([
+      {
+        keyword: 'rank tracker',
+        history: {},
+        tags: [],
+        lastResult: [],
+        lastUpdateError: false,
+        position: 5,
+        country: 'US',
+        device: 'desktop',
+        city: '',
+        state: '',
+        lastUpdated: new Date().toISOString(),
+      },
+    ]);
+
+    await handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(verifyUser).toHaveBeenCalledWith(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true, error: null });
+    expect(Domain.findAll).toHaveBeenCalledTimes(1);
+    expect(Keyword.findAll).toHaveBeenCalledWith({ where: { domain: 'example.com' } });
+    expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({
+      to: 'custom@example.com',
+    }));
+  });
+});

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -5,6 +5,7 @@ import Domain from '../../database/models/domain';
 import Keyword from '../../database/models/keyword';
 import generateEmail from '../../utils/generateEmail';
 import parseKeywords from '../../utils/parseKeywords';
+import verifyUser from '../../utils/verifyUser';
 import { getAppSettings } from './settings';
 
 type NotifyResponse = {
@@ -13,8 +14,12 @@ type NotifyResponse = {
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+   await db.sync();
+   const authorized = verifyUser(req, res);
+   if (authorized !== 'authorized') {
+      return res.status(401).json({ success: false, error: authorized });
+   }
    if (req.method === 'POST') {
-      await db.sync();
       return notify(req, res);
    }
    return res.status(401).json({ success: false, error: 'Invalid Method' });


### PR DESCRIPTION
## Summary
- enforce authentication in `/api/notify` by verifying the user before sending emails
- add Jest coverage for authorized and unauthorized notification API requests, including API key access
- document the hardened notification endpoint in the changelog and README

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cddab5c658832a86ddc9fe68609f57