### PR TITLE
Fix session cookie expiry and harden integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to this project will be documented in this file. See [standa
 * Added manual refresh button for Search Console data.
 
 ### Bug Fixes
+* Fixed session cookie expiry handling so configured durations are respected and logout immediately clears authentication cookies.
+* Hardened Google Ads refresh-token retrieval when error payloads omit an `error` string.
+* Prevented Search Console cache filenames for hyphenated domains from colliding with dotted domains.
 * Hardened API ID validation and corrected domain responses.
 * Added default empty strings for domain-related model fields.
 * Wrapped scraper and keyword JSON parsing with error handling.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
 - **Robust Error Handling:** Improved input validation and safer JSON parsing across the app.
+- **Reliable Sessions:** Configurable login durations now persist correctly and logging out clears authentication cookies immediately.
 - **API Hardening:** Notification email endpoint now enforces authentication for both UI and API key access.
+- **Safer Integrations:** Google Ads refresh-token retrieval handles incomplete error payloads and Search Console storage differentiates hyphenated and dotted domains.
 
 #### How it Works
 

--- a/__tests__/api/adwords.test.ts
+++ b/__tests__/api/adwords.test.ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../../pages/api/adwords';
+import db from '../../database/database';
+import verifyUser from '../../utils/verifyUser';
+import { readFile } from 'fs/promises';
+import { OAuth2Client } from 'google-auth-library';
+
+type MutableEnv = NodeJS.ProcessEnv & {
+   SECRET?: string;
+};
+
+jest.mock('../../database/database', () => ({
+   __esModule: true,
+   default: { sync: jest.fn() },
+}));
+
+jest.mock('../../utils/verifyUser', () => ({
+   __esModule: true,
+   default: jest.fn(),
+}));
+
+jest.mock('fs/promises', () => ({
+   readFile: jest.fn(),
+   writeFile: jest.fn(),
+}));
+
+const decryptMock = jest.fn();
+const encryptMock = jest.fn();
+
+jest.mock('cryptr', () => ({
+   __esModule: true,
+   default: jest.fn().mockImplementation(() => ({
+      decrypt: decryptMock,
+      encrypt: encryptMock,
+   })),
+}));
+
+const getTokenMock = jest.fn();
+
+jest.mock('google-auth-library', () => ({
+   OAuth2Client: jest.fn().mockImplementation(() => ({
+      getToken: getTokenMock,
+   })),
+}));
+
+jest.mock('@googleapis/searchconsole', () => ({
+   auth: { GoogleAuth: jest.fn() },
+   searchconsole_v1: {
+      Searchconsole: jest.fn().mockImplementation(() => ({
+         searchanalytics: { query: jest.fn() },
+      })),
+   },
+}));
+
+describe('GET /api/adwords - refresh token retrieval', () => {
+   const originalEnv = process.env;
+
+   beforeEach(() => {
+      (process.env as MutableEnv) = { ...originalEnv, SECRET: 'secret' };
+      (db.sync as jest.Mock).mockResolvedValue(undefined);
+      (verifyUser as jest.Mock).mockReturnValue('authorized');
+      (readFile as jest.Mock).mockResolvedValue('{}');
+      decryptMock.mockReturnValue('client-value');
+      encryptMock.mockImplementation((value: string) => value);
+      getTokenMock.mockRejectedValue({ response: { data: {} } });
+   });
+
+   afterEach(() => {
+      jest.resetAllMocks();
+      process.env = originalEnv;
+   });
+
+   it('logs a default error message when the Google API response lacks an error string', async () => {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+      const req = {
+         method: 'GET',
+         query: { code: 'auth-code' },
+         headers: { host: 'localhost:3000' },
+      } as unknown as NextApiRequest;
+
+      const res = {
+         status: jest.fn().mockReturnThis(),
+         json: jest.fn(),
+      } as unknown as NextApiResponse;
+
+      await handler(req, res);
+
+      expect(db.sync).toHaveBeenCalled();
+      expect(verifyUser).toHaveBeenCalledWith(req, res);
+      expect(readFile).toHaveBeenCalled();
+      expect(OAuth2Client).toHaveBeenCalled();
+      expect(getTokenMock).toHaveBeenCalledWith('auth-code');
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Error Saving the Google Ads Refresh Token. Please Try Again!' });
+      expect(logSpy).toHaveBeenCalledWith('[Error] Getting Google Ads Refresh Token! Reason: ', 'Unknown error retrieving Google Ads refresh token.');
+
+      logSpy.mockRestore();
+   });
+});

--- a/__tests__/api/login.test.ts
+++ b/__tests__/api/login.test.ts
@@ -1,0 +1,117 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import loginHandler from '../../pages/api/login';
+import logoutHandler from '../../pages/api/logout';
+import verifyUser from '../../utils/verifyUser';
+
+type MutableEnv = NodeJS.ProcessEnv & {
+   USER?: string;
+   USER_NAME?: string;
+   PASSWORD?: string;
+   SECRET?: string;
+   SESSION_DURATION?: string;
+};
+
+const setCookieMock = jest.fn();
+
+jest.mock('cookies', () => ({
+   __esModule: true,
+   default: jest.fn(() => ({ set: setCookieMock })),
+}));
+
+jest.mock('../../utils/verifyUser', () => ({
+   __esModule: true,
+   default: jest.fn(),
+}));
+
+describe('Authentication cookie handling', () => {
+   const originalEnv = process.env;
+
+   const createResponse = () => {
+      const res = {
+         status: jest.fn().mockReturnThis(),
+         json: jest.fn(),
+      } as unknown as NextApiResponse;
+      return res;
+   };
+
+   beforeEach(() => {
+      (process.env as MutableEnv) = { ...originalEnv };
+      (process.env as MutableEnv).USER = 'admin';
+      (process.env as MutableEnv).PASSWORD = 'password';
+      (process.env as MutableEnv).SECRET = 'shhh';
+      (verifyUser as jest.Mock).mockReturnValue('authorized');
+      setCookieMock.mockClear();
+   });
+
+   afterEach(() => {
+      jest.useRealTimers();
+      process.env = originalEnv;
+   });
+
+   it('sets the cookie maxAge and expires based on the configured session duration', async () => {
+      (process.env as MutableEnv).SESSION_DURATION = '12';
+      const baseTime = new Date('2024-01-01T00:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(baseTime);
+
+      const req = {
+         method: 'POST',
+         body: { username: 'admin', password: 'password' },
+      } as Partial<NextApiRequest>;
+
+      const res = createResponse();
+
+      await loginHandler(req as NextApiRequest, res);
+
+      expect(setCookieMock).toHaveBeenCalledTimes(1);
+      const [, , options] = setCookieMock.mock.calls[0];
+      expect(options).toMatchObject({
+         httpOnly: true,
+         sameSite: 'lax',
+         maxAge: 12 * 60 * 60 * 1000,
+      });
+      expect(options.expires).toEqual(new Date(baseTime.getTime() + (12 * 60 * 60 * 1000)));
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ success: true, error: null });
+   });
+
+   it('defaults to a 24 hour session when SESSION_DURATION is missing or invalid', async () => {
+      (process.env as MutableEnv).SESSION_DURATION = 'not-a-number';
+      const baseTime = new Date('2024-01-01T00:00:00.000Z');
+      jest.useFakeTimers().setSystemTime(baseTime);
+
+      const req = {
+         method: 'POST',
+         body: { username: 'admin', password: 'password' },
+      } as Partial<NextApiRequest>;
+
+      const res = createResponse();
+
+      await loginHandler(req as NextApiRequest, res);
+
+      expect(setCookieMock).toHaveBeenCalledTimes(1);
+      const [, , options] = setCookieMock.mock.calls[0];
+      expect(options.maxAge).toBe(24 * 60 * 60 * 1000);
+      expect(options.expires).toEqual(new Date(baseTime.getTime() + (24 * 60 * 60 * 1000)));
+   });
+
+   it('clears the authentication cookie on logout', async () => {
+      const req = {
+         method: 'POST',
+         headers: {},
+      } as Partial<NextApiRequest>;
+
+      const res = createResponse();
+
+      await logoutHandler(req as NextApiRequest, res);
+
+      expect(verifyUser).toHaveBeenCalledWith(req, res);
+      expect(setCookieMock).toHaveBeenCalledWith('token', null, expect.objectContaining({
+         httpOnly: true,
+         sameSite: 'lax',
+         maxAge: 0,
+         expires: new Date(0),
+      }));
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ success: true, error: null });
+   });
+});

--- a/__tests__/domain-conversion.test.ts
+++ b/__tests__/domain-conversion.test.ts
@@ -4,7 +4,7 @@
  */
 
 // Import the functions we need to test
-import { getSafeSCDataFilePath } from '../utils/searchConsole';
+import { getSafeSCDataFilePath, resolveDomainIdentifier } from '../utils/searchConsole';
 
 // Mock the path module with more realistic behavior
 jest.mock('path', () => {
@@ -27,51 +27,52 @@ Object.defineProperty(process, 'cwd', {
 });
 
 describe('Domain Conversion Fixes', () => {
+   describe('resolveDomainIdentifier', () => {
+      it('should convert slugs back to proper domains', () => {
+         expect(resolveDomainIdentifier('vontainment-com')).toBe('vontainment.com');
+         expect(resolveDomainIdentifier('example-org')).toBe('example.org');
+         expect(resolveDomainIdentifier('my-test-domain-com')).toBe('my.test.domain.com');
+         expect(resolveDomainIdentifier('my_site-com')).toBe('my-site.com');
+         expect(resolveDomainIdentifier('research')).toBe('research');
+      });
+
+      it('should preserve domains that already contain dots and hyphens', () => {
+         expect(resolveDomainIdentifier('my-site.com')).toBe('my-site.com');
+         expect(resolveDomainIdentifier('my.site.com')).toBe('my.site.com');
+      });
+   });
+
    describe('Search Console File Path Generation', () => {
-      it('should convert domain slug to proper SC file path', () => {
-         // Test the main case from the issue
+      it('should convert domain identifiers to distinct file paths', () => {
+         const hyphenatedDomainPath = getSafeSCDataFilePath('my-site.com');
+         const dottedDomainPath = getSafeSCDataFilePath('my.site.com');
+         const hyphenSlugPath = getSafeSCDataFilePath('my_site-com');
+         const dottedSlugPath = getSafeSCDataFilePath('my-site-com');
+
+         expect(hyphenatedDomainPath).toBe('/test/data/SC_my-site.com.json');
+         expect(dottedDomainPath).toBe('/test/data/SC_my.site.com.json');
+         expect(hyphenSlugPath).toBe('/test/data/SC_my-site.com.json');
+         expect(dottedSlugPath).toBe('/test/data/SC_my.site.com.json');
+         expect(hyphenatedDomainPath).not.toBe(dottedDomainPath);
+      });
+
+      it('should convert historical slugs to proper SC file paths', () => {
          const result1 = getSafeSCDataFilePath('vontainment-com');
          expect(result1).toBe('/test/data/SC_vontainment.com.json');
 
-         // Test other domain formats
          const result2 = getSafeSCDataFilePath('example-org');
          expect(result2).toBe('/test/data/SC_example.org.json');
 
          const result3 = getSafeSCDataFilePath('my-test-domain-co-uk');
          expect(result3).toBe('/test/data/SC_my.test.domain.co.uk.json');
 
-         // Test research domain (special case)
          const result4 = getSafeSCDataFilePath('research');
          expect(result4).toBe('/test/data/SC_research.json');
       });
 
       it('should handle invalid characters safely', () => {
-         const result = getSafeSCDataFilePath('test@domain-com');
-         expect(result).toBe('/test/data/SC_test_domain.com.json');
-      });
-   });
-
-   describe('Domain slug to domain conversion for keywords', () => {
-      it('should convert domain slug back to domain format', () => {
-         const convertSlugToDomain = (slug: string) => slug.replace(/-/g, '.');
-
-         // Test the main case from the issue
-         expect(convertSlugToDomain('vontainment-com')).toBe('vontainment.com');
-
-         // Test other formats
-         expect(convertSlugToDomain('example-org')).toBe('example.org');
-         expect(convertSlugToDomain('my-test-domain-com')).toBe('my.test.domain.com');
-
-         // Test research domain (special case - no conversion needed)
-         expect(convertSlugToDomain('research')).toBe('research');
-      });
-   });
-
-   describe('File path security', () => {
-      it('should sanitize dangerous characters', () => {
-         // Test that dangerous characters are replaced with underscores
          const result = getSafeSCDataFilePath('test@domain#with$special-chars');
-         expect(result).toBe('/test/data/SC_test_domain_with_special.chars.json');
+         expect(result).toBe('/test/data/SC_test_domain_with_special-chars.json');
       });
    });
 });

--- a/pages/api/adwords.ts
+++ b/pages/api/adwords.ts
@@ -49,7 +49,9 @@ const getAdwordsRefreshToken = async (req: NextApiRequest, res: NextApiResponse)
             return res.status(400).json({ error: 'Error Getting the Google Ads Refresh Token. Please Try Again!' });
          } catch (error:any) {
             let errorMsg = error?.response?.data?.error;
-            if (errorMsg.includes('redirect_uri_mismatch')) {
+            if (typeof errorMsg !== 'string' || !errorMsg) {
+               errorMsg = 'Unknown error retrieving Google Ads refresh token.';
+            } else if (errorMsg.includes('redirect_uri_mismatch')) {
                errorMsg += ` Redirected URL: ${redirectURL}`;
             }
             console.log('[Error] Getting Google Ads Refresh Token! Reason: ', errorMsg);

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -20,6 +20,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 const logout = async (req: NextApiRequest, res: NextApiResponse<logoutResponse>) => {
    const cookies = new Cookies(req, res);
-   cookies.set('token', null, { maxAge: new Date().getTime() });
+   cookies.set('token', null, {
+      httpOnly: true,
+      sameSite: 'lax',
+      maxAge: 0,
+      expires: new Date(0),
+   });
    return res.status(200).json({ success: true, error: null });
 };

--- a/pages/api/searchconsole.ts
+++ b/pages/api/searchconsole.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import db from '../../database/database';
 import Domain from '../../database/models/domain';
-import { fetchDomainSCData, getSearchConsoleApiInfo, readLocalSCData } from '../../utils/searchConsole';
+import { fetchDomainSCData, getSearchConsoleApiInfo, readLocalSCData, resolveDomainIdentifier } from '../../utils/searchConsole';
 import verifyUser from '../../utils/verifyUser';
 
 type searchConsoleRes = {
@@ -31,7 +31,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 const getDomainSearchConsoleData = async (req: NextApiRequest, res: NextApiResponse<searchConsoleRes>) => {
    if (!req.query.domain || typeof req.query.domain !== 'string') return res.status(400).json({ data: null, error: 'Domain is Missing.' });
-   const domainname = (req.query.domain as string).replaceAll('-', '.').replaceAll('_', '-');
+   const domainname = resolveDomainIdentifier(req.query.domain as string);
+   if (!domainname) {
+      return res.status(400).json({ data: null, error: 'Domain is Missing.' });
+   }
    const localSCData = await readLocalSCData(domainname);
    const isFresh = localSCData && localSCData.threeDays && localSCData.threeDays.length
       && localSCData.sevenDays && localSCData.sevenDays.length


### PR DESCRIPTION
## Summary
- ensure login cookies honour the configured session duration, clear the token on logout, and cover the behaviour with Jest tests
- guard Google Ads refresh token retrieval against missing error strings and exercise the fallback in a unit test
- normalise Search Console domain identifiers so hyphenated domains no longer collide with dotted ones and update the related documentation

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cddd917c20832a893fc0a351a3155d