### PR TITLE
chore: reorder adwords test imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. See [standa
 * Google Search Console email summaries reuse cached data for the active cron day to avoid redundant refreshes.
 * Hardened `/api/notify` to require authentication before sending notification emails.
 * Search Console email generation now tolerates missing or invalid cached data, preventing Docker builds from failing during type checks.
+* Reordered AdWords API test imports to comply with lint-enforced grouping rules.
 
 
 

--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ If you don't want to use proxies, you can use third party Scraping services to s
 
 - Next.js for Frontend & Backend.
 - Sqlite for Database.
+
+### Development Practices
+
+- Group external dependencies before relative paths and keep imports alphabetized in test files to satisfy lint requirements.

--- a/__tests__/api/adwords.test.ts
+++ b/__tests__/api/adwords.test.ts
@@ -1,9 +1,9 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import handler from '../../pages/api/adwords';
-import db from '../../database/database';
-import verifyUser from '../../utils/verifyUser';
 import { readFile } from 'fs/promises';
 import { OAuth2Client } from 'google-auth-library';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import db from '../../database/database';
+import handler from '../../pages/api/adwords';
+import verifyUser from '../../utils/verifyUser';
 
 type MutableEnv = NodeJS.ProcessEnv & {
    SECRET?: string;


### PR DESCRIPTION
## Summary
- reorder the AdWords API test imports so external dependencies precede relative modules
- document the lint grouping rule in the README and changelog

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce5508c650832aa60bea92fa0620d2