### PR TITLE
refactor: streamline docker build and ci caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,25 +1,50 @@
-
-Dockerfile
-.dockerignore
-node_modules
-npm-debug.log
-README.md
-.next
+# Git metadata
 .git
+.gitignore
+
+# Docker and compose files
+Dockerfile
+Dockerfile.*
+docker-compose*.yml
+
+# Node dependencies and caches
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.eslintcache
+.next
+.next/cache
+
+# Tests and mocks
+**/__tests__/
+**/__mocks__/
+
+# Logs and coverage
+*.log
+logs
+coverage
+.nyc_output
+coverage.lcov
+
+# Environment files
+.env
+.env.*
+.env*
+
+# Documentation
+*.md
+
+# Tooling and configs
 .github
 .vscode
-.env
-coverage
-logs
 fly.toml
 TODO
+jest.config.js
+jest.setup.js
+
+# App data that should not be baked into the image
 data/database.sqlite
 data/settings.json
 data/failed_queue.json
-__tests__
-__mocks__
-jest.config.js
-jest.setup.js
-*.log
-.nyc_output
-coverage.lcov

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,3 +47,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file. See [standa
 * Reordered AdWords API test imports to comply with lint-enforced grouping rules.
 * Normalised cron schedule environment variables so surrounding quotes and whitespace no longer break Croner parsing.
 * Refreshed the Docker Compose example to run the published image with updated defaults and cron configuration guidance.
+* Rebuilt the multi-stage Dockerfile to preserve `/app/data`, reuse build caches, and move cron start-up logic into the entrypoint.
+* Enabled GitHub Actions build cache exports for Docker image publishing.
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,37 @@
-FROM node:22.11.0-alpine3.20 AS deps
-ENV NPM_VERSION=11.6.0
-ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm install -g npm@"${NPM_VERSION}"
+FROM node:22.11.0-alpine3.20 AS base
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NPM_VERSION=11.6.0
 WORKDIR /app
+RUN npm install -g npm@"${NPM_VERSION}"
 
+FROM base AS deps
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci
 COPY . .
 
-
-FROM node:22.11.0-alpine3.20 AS builder
-WORKDIR /app
-ENV NPM_VERSION=11.6.0
-ENV NEXT_TELEMETRY_DISABLED=1
+FROM base AS builder
 COPY --from=deps /app ./
-RUN rm -rf /app/data /app/__tests__ /app/__mocks__
-RUN npm run build
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/app/.next/cache \
+    sh -c "rm -rf __tests__ __mocks__ && npm run build && chmod +x entrypoint.sh"
 
-
-FROM node:22.11.0-alpine3.20 AS runner
-WORKDIR /app
-ENV NEXT_TELEMETRY_DISABLED=1
+FROM base AS runner
 ENV NODE_ENV=production
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-RUN set -xe && mkdir -p /app/data && chown nextjs:nodejs /app/data
+RUN addgroup --system --gid 1001 nodejs \
+    && adduser --system --uid 1001 nextjs \
+    && mkdir -p /app/data
 
-# Copy built application files
-COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-# Setup the cron and database
-COPY --from=builder --chown=nextjs:nodejs /app/cron.js ./
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/cron.js ./cron.js
 COPY --from=builder --chown=nextjs:nodejs /app/email ./email
 COPY --from=builder --chown=nextjs:nodejs /app/database ./database
+COPY --from=builder --chown=nextjs:nodejs /app/data ./data
 COPY --from=builder --chown=nextjs:nodejs /app/.sequelizerc ./.sequelizerc
 COPY --from=builder --chown=nextjs:nodejs /app/entrypoint.sh ./entrypoint.sh
 
-# Copy production package files and install only production dependencies
-COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
-COPY --from=builder --chown=nextjs:nodejs /app/package-lock.json ./package-lock.json
-RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
-
-# Install concurrently globally for the runtime
-RUN npm install -g npm@11.6.0 concurrently@7.6.0
-RUN chmod +x /app/entrypoint.sh
-
 USER nextjs
-
 EXPOSE 3000
-
 ENTRYPOINT ["/app/entrypoint.sh"]
-CMD ["concurrently","node server.js", "node cron.js"]
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ Cron expressions are automatically normalized at runtime, so surrounding quotes 
 
 The bundled `docker-compose.yml` runs the published `vontainment/v-serpbear` image with sensible defaults, persistent storage, and the environment variables listed above. Override the values in that file (or via `.env`) to match your credentials, and adjust the published port if `3030` clashes with another service on your host.
 
+#### Container runtime behaviour
+
+The Docker image now bakes the production build output produced by `npm run build` directly into `/app` and relies on the standalone Next.js server bundle. At runtime the container:
+
+- sets `NODE_ENV=production` and runs as the unprivileged `nextjs` user,
+- runs pending database migrations before launching the API,
+- starts the cron worker in the background from the entrypoint, and
+- exposes port `3000` by default while still persisting `/app/data` for SQLite storage.
+
+If you need to seed or snapshot the SQLite database before running the container, populate the `data/` directory locally—those files are now copied into the runtime image without being deleted during the build.
+
 #### SerpBear Integrates with popular SERP scraping services
 
 If you don't want to use proxies, you can use third party Scraping services to scrape Google Search results.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,53 @@
 #!/bin/sh
-npx sequelize-cli db:migrate --env production
+set -eu
+set -o pipefail 2>/dev/null || true
+
+prepare_data_dir() {
+  mkdir -p ./data
+}
+
+run_migrations() {
+  echo "Running database migrations..."
+  node <<'NODE'
+const { Sequelize } = require('sequelize');
+const { Umzug, SequelizeStorage } = require('umzug');
+
+async function run() {
+  const sequelize = new Sequelize({
+    dialect: 'sqlite',
+    storage: './data/database.sqlite',
+    logging: false,
+  });
+
+  try {
+    const umzug = new Umzug({
+      migrations: { glob: 'database/migrations/*.js' },
+      context: sequelize.getQueryInterface(),
+      storage: new SequelizeStorage({ sequelize }),
+      logger: undefined,
+    });
+
+    await umzug.up();
+  } finally {
+    await sequelize.close();
+  }
+}
+
+run().catch((error) => {
+  console.error('Database migration failed:', error);
+  process.exit(1);
+});
+NODE
+}
+
+start_cron() {
+  echo "Starting background cron worker..."
+  node ./cron.js &
+}
+
+prepare_data_dir
+run_migrations
+start_cron
+
+echo "Starting application: $*"
 exec "$@"


### PR DESCRIPTION
## Summary
- refactor the Dockerfile to share a common base layer, preserve /app/data, and copy only the runtime assets needed by the standalone server
- teach the entrypoint to prepare storage, run migrations, and launch the cron worker before exec-ing the app while expanding the dockerignore set
- document the container/runtime changes, and enable Buildx cache export/import in the Docker image workflow

## Testing
- npm run lint
- npm run lint:css
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce65171148832aa4b06b8b87f795c6