### PR TITLE
Ensure Docker runtime includes production dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### Unreleased
 
 ### Changed
+* Pruned Docker runtime image to copy production `node_modules` so cron jobs and migrations keep their dependencies at runtime.
 * Bundled `sequelize-cli` as a production dependency so database migration scripts work without manual CLI installs.
 * Added configurable cron timezone and schedule environment variables for scraping, retries, and notification jobs.
 * Google Search Console email summaries reuse cached data for the active cron day to avoid redundant refreshes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM base AS builder
 COPY --from=deps /app ./
 RUN --mount=type=cache,target=/root/.npm \
     --mount=type=cache,target=/app/.next/cache \
-    sh -c "rm -rf __tests__ __mocks__ && npm run build && chmod +x entrypoint.sh"
+    sh -c "rm -rf __tests__ __mocks__ && npm run build && npm prune --omit=dev && chmod +x entrypoint.sh"
 
 FROM base AS runner
 ENV NODE_ENV=production
@@ -24,6 +24,9 @@ RUN addgroup --system --gid 1001 nodejs \
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
+COPY --from=builder --chown=nextjs:nodejs /app/package-lock.json ./package-lock.json
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/cron.js ./cron.js
 COPY --from=builder --chown=nextjs:nodejs /app/email ./email
 COPY --from=builder --chown=nextjs:nodejs /app/database ./database

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The Docker image now bakes the production build output produced by `npm run buil
 
 - sets `NODE_ENV=production` and runs as the unprivileged `nextjs` user,
 - runs pending database migrations before launching the API,
-- starts the cron worker in the background from the entrypoint, and
+- starts the cron worker in the background from the entrypoint,
+- ships a pruned `node_modules/` directory with only production dependencies so cron jobs and migrations can `require()` their helpers,
 - exposes port `3000` by default while still persisting `/app/data` for SQLite storage.
 
 If you need to seed or snapshot the SQLite database before running the container, populate the `data/` directory locally—those files are now copied into the runtime image without being deleted during the build.


### PR DESCRIPTION
## Summary
- prune dev packages from the builder stage so only runtime dependencies remain in /app/node_modules
- copy the pruned node_modules, package.json, and package-lock.json into the runtime image beside the standalone Next.js bundle
- document the runtime dependency layout in README and changelog

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7058ab8c832ab1c7c3bd3a2e10a8