### PR TITLE
Remove package manifests from runtime Docker image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.sh text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.css text eol=lf
+Dockerfile text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. See [standa
 * Rebuilt the multi-stage Dockerfile to preserve `/app/data`, reuse build caches, and move cron start-up logic into the entrypoint.
 * Enabled GitHub Actions build cache exports for Docker image publishing.
 * Upgraded `google-auth-library` to `^10.3.0`, pulling in `gaxios@7`/`node-fetch@3` to silence Node.js 22 `fetch()` deprecation warnings and keep Google Ads integrations working on current LTS releases.
+* Removed package manifests from the runtime container layer, relying on the standalone server bundle and production dependencies that ship with the image.
 
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ RUN addgroup --system --gid 1001 nodejs \
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
-COPY --from=builder --chown=nextjs:nodejs /app/package-lock.json ./package-lock.json
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/cron.js ./cron.js
 COPY --from=builder --chown=nextjs:nodejs /app/email ./email

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The Docker image now bakes the production build output produced by `npm run buil
 - runs pending database migrations before launching the API,
 - starts the cron worker in the background from the entrypoint,
 - ships a pruned `node_modules/` directory with only production dependencies so cron jobs and migrations can `require()` their helpers,
+- omits build-time manifests such as `package.json` and `package-lock.json` to reduce attack surface and shrink the final layer,
 - exposes port `3000` by default while still persisting `/app/data` for SQLite storage.
 
 If you need to seed or snapshot the SQLite database before running the container, populate the `data/` directory locally—those files are now copied into the runtime image without being deleted during the build.


### PR DESCRIPTION
## Summary
- stop copying package.json and package-lock.json into the runtime Docker layer so only the standalone bundle and production deps ship in the final image
- document the leaner container layout in the README and changelog
- add a project .gitattributes to enforce LF endings for scripts and configs

## Testing
- npm run lint
- npm run lint:css
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ce76200d90832a85b180edf11c5acc