### PR TITLE
Handle variadic sqlite bindings

### DIFF
--- a/__tests__/database/sqlite-dialect.test.ts
+++ b/__tests__/database/sqlite-dialect.test.ts
@@ -62,4 +62,90 @@ describe('sqlite dialect wrapper', () => {
       });
     });
   });
+
+  it('supports variadic parameter bindings across sqlite APIs', async () => {
+    await new Promise<void>((resolve, reject) => {
+      const sqliteFlags = sqlite.OPEN_READWRITE + sqlite.OPEN_CREATE;
+      const db = new sqlite.Database(':memory:', sqliteFlags, (err) => {
+        if (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+          return;
+        }
+
+        db.serialize(async () => {
+          try {
+            await new Promise<void>((res, rej) => {
+              db.run('CREATE TABLE sample_variadic (id INTEGER PRIMARY KEY, name TEXT, score INTEGER)', (createErr) => {
+                if (createErr) {
+                  rej(createErr instanceof Error ? createErr : new Error(String(createErr)));
+                  return;
+                }
+                res();
+              });
+            });
+
+            await new Promise<void>((res, rej) => {
+              db.run(
+                'INSERT INTO sample_variadic (name, score) VALUES (?, ?)',
+                'variadic-entry',
+                99,
+                function insertCallback(insertErr) {
+                  if (insertErr) {
+                    rej(insertErr instanceof Error ? insertErr : new Error(String(insertErr)));
+                    return;
+                  }
+                  expect(this.lastID).toBe(1);
+                  expect(this.changes).toBe(1);
+                  res();
+                }
+              );
+            });
+
+            await new Promise<void>((res, rej) => {
+              db.get<{ score: number }>(
+                'SELECT score FROM sample_variadic WHERE name = ? AND score = ?',
+                'variadic-entry',
+                99,
+                (queryErr, row) => {
+                  if (queryErr) {
+                    rej(queryErr instanceof Error ? queryErr : new Error(String(queryErr)));
+                    return;
+                  }
+                  expect(row).toEqual({ score: 99 });
+                  res();
+                }
+              );
+            });
+
+            await new Promise<void>((res, rej) => {
+              db.all<{ name: string }>(
+                'SELECT name FROM sample_variadic WHERE name IN (?, ?)',
+                'variadic-entry',
+                'not-a-match',
+                (queryErr, rows) => {
+                  if (queryErr) {
+                    rej(queryErr instanceof Error ? queryErr : new Error(String(queryErr)));
+                    return;
+                  }
+                  expect(rows).toEqual([{ name: 'variadic-entry' }]);
+                  res();
+                }
+              );
+            });
+
+            db.close((closeErr) => {
+              if (closeErr) {
+                reject(closeErr instanceof Error ? closeErr : new Error(String(closeErr)));
+                return;
+              }
+              resolve();
+            });
+          } catch (error) {
+            const wrappedError = error instanceof Error ? error : new Error(String(error));
+            reject(wrappedError);
+          }
+        });
+      });
+    });
+  });
 });

--- a/database/sqlite-dialect.js
+++ b/database/sqlite-dialect.js
@@ -107,16 +107,16 @@ class Database extends EventEmitter {
     return this;
   }
 
-  run(sql, params, callback) {
-    return this.executeInternal('run', sql, params, callback);
+  run(sql, ...params) {
+    return this.executeInternal('run', sql, ...params);
   }
 
-  all(sql, params, callback) {
-    return this.executeInternal('all', sql, params, callback);
+  all(sql, ...params) {
+    return this.executeInternal('all', sql, ...params);
   }
 
-  get(sql, params, callback) {
-    return this.executeInternal('get', sql, params, callback);
+  get(sql, ...params) {
+    return this.executeInternal('get', sql, ...params);
   }
 
   exec(sql, callback) {
@@ -144,13 +144,18 @@ class Database extends EventEmitter {
     return this;
   }
 
-  executeInternal(method, sql, params, callback) {
-    let bindings = params;
-    let cb = callback;
-    if (typeof bindings === 'function') {
-      cb = bindings;
-      bindings = undefined;
+  executeInternal(method, sql, ...args) {
+    let cb;
+    if (args.length > 0 && typeof args[args.length - 1] === 'function') {
+      cb = args.pop();
     }
+    let bindings;
+    if (args.length === 1) {
+      [bindings] = args;
+    } else if (args.length > 1) {
+      bindings = args;
+    }
+
     const finalCallback = normalizeCallback(cb);
     const preparedBindings = normalizeNamedBindings(bindings);
     const context = {


### PR DESCRIPTION
## Summary
- allow the sqlite shim to accept variadic positional bindings before callbacks
- normalize the captured arguments when delegating to better-sqlite3 statements
- add a regression test exercising run/get/all with positional binding arguments

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce7a1f0ed0832aba118ee135506797