### PR TITLE
Handle undefined sqlite callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 * Replaced the legacy `sqlite3` dependency with a `better-sqlite3`-powered dialect wrapper so builds no longer rely on deprecated `node-gyp` tooling and prebuilt binaries are downloaded during installation.
+* Trim trailing `undefined`/`null` arguments in the SQLite shim so optional callbacks are ignored instead of being treated as extra positional bindings.
 * Upgraded ESLint and related tooling to v9 flat config (`eslint.config.mjs`) and refreshed linting instructions.
 * Pruned Docker runtime image to copy production `node_modules` so cron jobs and migrations keep their dependencies at runtime.
 * Bundled `sequelize-cli` as a production dependency so database migration scripts work without manual CLI installs.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The project now ships `sequelize-cli` as a production dependency, so the migrati
 - **Why:** The legacy `sqlite3` native module depended on deprecated `node-gyp` glue. The project now ships a lightweight wrapper around `better-sqlite3`, which bundles modern tooling and offers prebuilt binaries for current Node.js releases.
 - **What to do after pulling:** Run `npm install` (or `npm ci` in CI) so the new dependency and its lockfile updates are applied. If your environment lacks the prerequisites for native compilation, install Python 3 and a C/C++ toolchain before retrying the install.
 - **Verifying the upgrade:** Run `npm run db:migrate` locally to confirm Sequelize can still open the database, and rerun your Docker/CI builds to ensure no scripts depend on `node-gyp` anymore.
+- **API parity:** Trailing `undefined` or `null` arguments are now discarded before executing statements, so `db.run(sql, params, undefined)` behaves the same as omitting the optional callback entirely.
 
 #### Docker Compose deployment
 

--- a/__tests__/database/sqlite-dialect.test.ts
+++ b/__tests__/database/sqlite-dialect.test.ts
@@ -97,7 +97,7 @@ describe('sqlite dialect wrapper', () => {
                   expect(this.lastID).toBe(1);
                   expect(this.changes).toBe(1);
                   res();
-                }
+                },
               );
             });
 
@@ -113,7 +113,7 @@ describe('sqlite dialect wrapper', () => {
                   }
                   expect(row).toEqual({ score: 99 });
                   res();
-                }
+                },
               );
             });
 
@@ -129,7 +129,7 @@ describe('sqlite dialect wrapper', () => {
                   }
                   expect(rows).toEqual([{ name: 'variadic-entry' }]);
                   res();
-                }
+                },
               );
             });
 
@@ -143,6 +143,116 @@ describe('sqlite dialect wrapper', () => {
           } catch (error) {
             const wrappedError = error instanceof Error ? error : new Error(String(error));
             reject(wrappedError);
+          }
+        });
+      });
+    });
+  });
+
+  it('ignores trailing undefined callbacks when deriving sqlite bindings', async () => {
+    await new Promise<void>((resolve, reject) => {
+      const sqliteFlags = sqlite.OPEN_READWRITE + sqlite.OPEN_CREATE;
+      const db = new sqlite.Database(':memory:', sqliteFlags, (err) => {
+        if (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+          return;
+        }
+
+        db.serialize(async () => {
+          type TrackedMethod = 'run' | 'get' | 'all';
+          const recordedCalls: Array<{ sql: string; method: TrackedMethod; args: unknown[] }> = [];
+          const trackedMethods = new Set<TrackedMethod>(['run', 'get', 'all']);
+          const originalPrepare = db.driver.prepare.bind(db.driver);
+          const prepareSpy = jest.spyOn(db.driver, 'prepare');
+          prepareSpy.mockImplementation((sql: string, ...prepareArgs: unknown[]) => {
+            const statement = originalPrepare(sql, ...prepareArgs);
+            return new Proxy(statement, {
+              get(target, prop, receiver) {
+                const value = Reflect.get(target, prop, receiver);
+                if (
+                  typeof prop === 'string'
+                  && trackedMethods.has(prop as TrackedMethod)
+                  && typeof value === 'function'
+                ) {
+                  const method = prop as TrackedMethod;
+                  return (...methodArgs: unknown[]) => {
+                    recordedCalls.push({ sql, method, args: methodArgs });
+                    return value.apply(target, methodArgs);
+                  };
+                }
+                if (typeof value === 'function') {
+                  return value.bind(target);
+                }
+                return value;
+              },
+            });
+          });
+
+          const insertSql = 'INSERT INTO sample_optional (name) VALUES ($name)';
+          const getSql = 'SELECT name FROM sample_optional WHERE name = $name /* undefined callback */';
+          const allSql = 'SELECT name FROM sample_optional WHERE name = ? /* undefined callback */';
+          const sentinelValue = 'optional-callback-row';
+
+          try {
+            await new Promise<void>((res, rej) => {
+              db.run('CREATE TABLE sample_optional (id INTEGER PRIMARY KEY, name TEXT)', (createErr) => {
+                if (createErr) {
+                  rej(createErr instanceof Error ? createErr : new Error(String(createErr)));
+                  return;
+                }
+                res();
+              });
+            });
+
+            db.run(insertSql, { $name: sentinelValue }, undefined);
+            db.get(getSql, { $name: sentinelValue }, undefined);
+            db.all(allSql, sentinelValue, undefined);
+
+            await new Promise<void>((res, rej) => {
+              db.get(
+                'SELECT name FROM sample_optional WHERE name = $name',
+                { $name: sentinelValue },
+                (queryErr, row) => {
+                  if (queryErr) {
+                    rej(queryErr instanceof Error ? queryErr : new Error(String(queryErr)));
+                    return;
+                  }
+                  expect(row).toEqual({ name: sentinelValue });
+                  res();
+                },
+              );
+            });
+
+            const runCall = recordedCalls.find(
+              (call) => call.method === 'run' && call.sql === insertSql,
+            );
+            expect(runCall).toBeDefined();
+            expect(runCall?.args).toEqual([{ name: sentinelValue }]);
+
+            const getCall = recordedCalls.find(
+              (call) => call.method === 'get' && call.sql === getSql,
+            );
+            expect(getCall).toBeDefined();
+            expect(getCall?.args).toEqual([{ name: sentinelValue }]);
+
+            const allCall = recordedCalls.find(
+              (call) => call.method === 'all' && call.sql === allSql,
+            );
+            expect(allCall).toBeDefined();
+            expect(allCall?.args).toEqual([sentinelValue]);
+
+            db.close((closeErr) => {
+              if (closeErr) {
+                reject(closeErr instanceof Error ? closeErr : new Error(String(closeErr)));
+                return;
+              }
+              resolve();
+            });
+          } catch (error) {
+            const wrappedError = error instanceof Error ? error : new Error(String(error));
+            reject(wrappedError);
+          } finally {
+            prepareSpy.mockRestore();
           }
         });
       });

--- a/database/sqlite-dialect.js
+++ b/database/sqlite-dialect.js
@@ -149,6 +149,9 @@ class Database extends EventEmitter {
     if (args.length > 0 && typeof args[args.length - 1] === 'function') {
       cb = args.pop();
     }
+    while (args.length > 0 && (args[args.length - 1] === undefined || args[args.length - 1] === null)) {
+      args.pop();
+    }
     let bindings;
     if (args.length === 1) {
       [bindings] = args;


### PR DESCRIPTION
## Summary
- stop treating trailing nullish arguments as parameter bindings in the sqlite shim so optional callbacks no longer consume slots
- teach the better-sqlite3 Jest mock to forward variadic arguments and map positional bindings so existing tests continue to pass
- add a regression test that exercises db.run/get/all with an explicit undefined callback and document the behaviour in the README/CHANGELOG

## Testing
- npm run lint
- npm run lint:css
- npm test
- npm run test:cv

------
https://chatgpt.com/codex/tasks/task_e_68ce7c61df5c832aba71d2b073230ffa