### PR TITLE
Add repository editorconfig and document formatting workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.yaml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 * Aligned keyword and settings API response typings with their JSON payloads by adding the optional `details` error field so TypeScript stays consistent with runtime responses.
 * Taught ESLint and Git attributes to ignore generated `.next` chunks so build artifacts no longer trigger enormous lint failures after running the production build.
+* Added a root `.editorconfig` so editors consistently write UTF-8, LF line endings, and two-space indentation (with overrides for structured data).
 * Preserved explicit SQLite `null` bindings so prepared statements receive them during execution instead of stripping them alongside optional callbacks.
 * Downgraded ESLint to `^8.57.1` to keep the flat config workflow compatible with `eslint-config-airbnb-base@15` while preserving existing lint rules.
 * Updated `stylelint-config-standard` to `^34.0.0` so `npm install` succeeds without relying on `--legacy-peer-deps`.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The Scraping Robot integration now explicitly sends both Google locale parameter
 - Run `npm run lint` before committing. ESLint 9's native flat configuration (`eslint.config.mjs`) layers Next.js core web vitals, React, accessibility, and import presets, and the run fails if any custom rules are violated.
 - Use `npm run lint -- --fix` to auto-fix issues where possible; re-run the command to confirm the codebase is clean.
 - Continue running `npm run lint:css` for Stylelint checks when you update global CSS.
+- Editors should respect the root `.editorconfig` (two-space indentation, UTF-8, LF endings, and final newlines) to match repository formatting; JSON, YAML, and other structured data continue to use two spaces as well.
 - Stylelint is now bundled locally; run `npm install` after pulling so `npm run lint:css` remains available. The dependency graph resolves without `--legacy-peer-deps`.
 - The ESLint flat config now ignores the `.next` build output so running `npm run build` before `npm run lint` no longer floods the linter with errors from generated chunks.
 


### PR DESCRIPTION
## Summary
- add a root `.editorconfig` so editors enforce two-space indentation, LF line endings, UTF-8 encoding, and final newlines, with overrides for structured data files
- document the new formatting standard in the README and capture it in the unreleased changelog notes

## Testing
- npm run lint -- --fix
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cea4a3e49c832aa0a8da1016e543cf