### PR TITLE
test: isolate screenshot env for settings suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### Changed
 
 * Added a least-privilege GitHub Actions CodeQL workflow that scans pushes, pull requests, and a weekly schedule for JavaScript/TypeScript vulnerabilities.
+* Updated API settings tests to strip `SCREENSHOT_API` when exercising missing-configuration flows so CI secrets can no longer mask the expected failures.
 * Aligned keyword and settings API response typings with their JSON payloads by adding the optional `details` error field so TypeScript stays consistent with runtime responses.
 * Taught ESLint and Git attributes to ignore generated `.next` chunks so build artifacts no longer trigger enormous lint failures after running the production build.
 * Added a root `.editorconfig` so editors consistently write UTF-8, LF line endings, and two-space indentation (with overrides for structured data).

--- a/README.md
+++ b/README.md
@@ -149,3 +149,4 @@ The Scraping Robot integration now explicitly sends both Google locale parameter
 - `npm test` runs the unit and integration suites in Node's default worker mode.
 - The sqlite dialect suite now includes a regression test verifying the mocked `better-sqlite3` driver preserves single `?` placeholder bindings end-to-end.
 - Use `npm run test:cv -- --runInBand` to generate coverage serially, which avoids intermittent jsdom worker crashes during long-running suites.
+- API settings integration tests now explicitly remove `SCREENSHOT_API` when simulating misconfigurations so failures surface even if local shells export the key.

--- a/__tests__/api/settings.test.ts
+++ b/__tests__/api/settings.test.ts
@@ -24,6 +24,10 @@ const readFileMock = readFile as unknown as jest.Mock;
 const verifyUserMock = verifyUser as unknown as jest.Mock;
 const writeFileMock = writeFile as unknown as jest.Mock;
 const originalEnv = process.env;
+const getEnvWithoutScreenshot = () => {
+  const { SCREENSHOT_API: _ignored, ...envWithoutScreenshot } = { ...originalEnv };
+  return envWithoutScreenshot;
+};
 
 jest.mock('cryptr', () => ({
   __esModule: true,
@@ -103,7 +107,8 @@ describe('GET /api/settings and configuration requirements', () => {
   });
 
   it('returns 500 when loading settings fails', async () => {
-    process.env = { ...originalEnv, SECRET: 'secret' };
+    const envWithoutScreenshot = getEnvWithoutScreenshot();
+    process.env = { ...envWithoutScreenshot, SECRET: 'secret' };
 
     const req = {
       method: 'GET',
@@ -127,7 +132,8 @@ describe('GET /api/settings and configuration requirements', () => {
   });
 
   it('throws when SCREENSHOT_API is not configured', async () => {
-    process.env = { ...originalEnv, SECRET: 'secret' };
+    const envWithoutScreenshot = getEnvWithoutScreenshot();
+    process.env = { ...envWithoutScreenshot, SECRET: 'secret' };
 
     await expect(settingsApi.getAppSettings()).rejects.toThrow('SCREENSHOT_API environment variable is required');
   });


### PR DESCRIPTION
## Summary
- make the API settings suite explicitly strip SCREENSHOT_API when validating misconfigured environments
- document the new environment handling expectations for contributors

## Testing
- npm run lint
- npm run lint:css
- npm run test -- --runInBand __tests__/api

------
https://chatgpt.com/codex/tasks/task_e_68cead738748832a86f00a4492aaf389