### PR TITLE
fix: support umzug v3 migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file. See [standa
 * Upgraded ESLint and related tooling to v9 flat config (`eslint.config.mjs`) and refreshed linting instructions.
 * Pruned Docker runtime image to copy production `node_modules` so cron jobs and migrations keep their dependencies at runtime.
 * Bundled `sequelize-cli` as a production dependency so database migration scripts work without manual CLI installs.
+* Migrated legacy Sequelize migrations to Umzug v3’s object signature while keeping `sequelize-cli` compatibility by normalising the received parameters.
+* Updated the custom SQLite dialect to call `run()` for non-reader statements invoked through `.all()`, allowing Umzug’s Sequelize storage to create metadata tables with `better-sqlite3`.
 * Added configurable cron timezone and schedule environment variables for scraping, retries, and notification jobs.
 * Google Search Console email summaries reuse cached data for the active cron day to avoid redundant refreshes.
 * Hardened `/api/notify` to require authentication before sending notification emails.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Local and self-hosted installs can apply schema changes with the bundled npm scr
 
 The project now ships `sequelize-cli` as a production dependency, so the migration scripts work out of the box without manually installing the CLI or adding it globally.
 
+Migrations now conform to Umzug v3’s object signature, which means the Docker entrypoint and `/api/dbmigrate` endpoint can run them directly. The legacy `sequelize-cli` workflow still works because each migration normalises its parameters before calling the query interface. On a brand-new database, start the app once (or run a short script that calls `sequelize.sync()`) before invoking the migration scripts so the base `domain` and `keyword` tables exist.
+
 ### SQLite driver upgrade
 
 - **Why:** The legacy `sqlite3` native module depended on deprecated `node-gyp` glue. The project now ships a lightweight wrapper around `better-sqlite3`, which bundles modern tooling and offers prebuilt binaries for current Node.js releases.

--- a/database/migrations/1707068556345-add-new-keyword-fields.js
+++ b/database/migrations/1707068556345-add-new-keyword-fields.js
@@ -2,19 +2,39 @@
 
 // CLI Migration
 module.exports = {
-   up: async (queryInterface, Sequelize) => {
+   up: async function up(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib = params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');
             if (keywordTableDefinition) {
                if (!keywordTableDefinition.city) {
-                  await queryInterface.addColumn('keyword', 'city', { type: Sequelize.DataTypes.STRING }, { transaction: t });
+                  await queryInterface.addColumn(
+                     'keyword',
+                     'city',
+                     { type: SequelizeLib.DataTypes.STRING },
+                     { transaction: t }
+                  );
                }
                if (!keywordTableDefinition.latlong) {
-                  await queryInterface.addColumn('keyword', 'latlong', { type: Sequelize.DataTypes.STRING }, { transaction: t });
+                  await queryInterface.addColumn(
+                     'keyword',
+                     'latlong',
+                     { type: SequelizeLib.DataTypes.STRING },
+                     { transaction: t }
+                  );
                }
                if (!keywordTableDefinition.settings) {
-                  await queryInterface.addColumn('keyword', 'settings', { type: Sequelize.DataTypes.STRING }, { transaction: t });
+                  await queryInterface.addColumn(
+                     'keyword',
+                     'settings',
+                     { type: SequelizeLib.DataTypes.STRING },
+                     { transaction: t }
+                  );
                }
             }
          } catch (error) {
@@ -22,7 +42,8 @@ module.exports = {
          }
       });
    },
-   down: (queryInterface) => {
+   down: async function down(params = {}) {
+      const queryInterface = params?.context ?? params;
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');

--- a/database/migrations/1707233039698-add-domain-searchconsole-field.js
+++ b/database/migrations/1707233039698-add-domain-searchconsole-field.js
@@ -2,19 +2,30 @@
 
 // CLI Migration
 module.exports = {
-   up: (queryInterface, Sequelize) => {
+   up: async function up(params = {}, legacySequelize) {
+     const queryInterface = params?.context ?? params;
+     const SequelizeLib = params?.Sequelize
+        ?? legacySequelize
+        ?? queryInterface?.sequelize?.constructor
+        ?? require('sequelize');
      return queryInterface.sequelize.transaction(async (t) => {
       try {
          const domainTableDefinition = await queryInterface.describeTable('domain');
          if (domainTableDefinition && !domainTableDefinition.search_console) {
-            await queryInterface.addColumn('domain', 'search_console', { type: Sequelize.DataTypes.STRING }, { transaction: t });
+            await queryInterface.addColumn(
+               'domain',
+               'search_console',
+               { type: SequelizeLib.DataTypes.STRING },
+               { transaction: t }
+            );
          }
       } catch (error) {
          console.log('error :', error);
       }
      });
    },
-   down: (queryInterface) => {
+   down: async function down(params = {}) {
+      const queryInterface = params?.context ?? params;
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             const domainTableDefinition = await queryInterface.describeTable('domain');

--- a/database/migrations/1709217223856-add-keyword-volume-field.js
+++ b/database/migrations/1709217223856-add-keyword-volume-field.js
@@ -2,15 +2,20 @@
 
 // CLI Migration
 module.exports = {
-   up: async (queryInterface, Sequelize) => {
+   up: async function up(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib = params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');
             if (keywordTableDefinition) {
                if (!keywordTableDefinition.volume) {
                   await queryInterface.addColumn('keyword', 'volume', {
-                      type: Sequelize.DataTypes.STRING, allowNull: false, defaultValue: 0,
-                  }, { transaction: t });
+                     type: SequelizeLib.DataTypes.STRING, allowNull: false, defaultValue: 0,
+                 }, { transaction: t });
                }
             }
          } catch (error) {
@@ -18,7 +23,8 @@ module.exports = {
          }
       });
    },
-   down: (queryInterface) => {
+   down: async function down(params = {}) {
+      const queryInterface = params?.context ?? params;
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');

--- a/database/migrations/1710000000000-add-keyword-state-field.js
+++ b/database/migrations/1710000000000-add-keyword-state-field.js
@@ -2,19 +2,30 @@
 
 // CLI Migration
 module.exports = {
-   up: async (queryInterface, Sequelize) => {
+   up: async function up(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib = params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');
             if (keywordTableDefinition && !keywordTableDefinition.state) {
-               await queryInterface.addColumn('keyword', 'state', { type: Sequelize.DataTypes.STRING }, { transaction: t });
+               await queryInterface.addColumn(
+                  'keyword',
+                  'state',
+                  { type: SequelizeLib.DataTypes.STRING },
+                  { transaction: t }
+               );
             }
          } catch (error) {
             console.log('error :', error);
          }
       });
    },
-   down: (queryInterface) => {
+   down: async function down(params = {}) {
+      const queryInterface = params?.context ?? params;
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');

--- a/database/migrations/1735640000000-add-database-indexes.js
+++ b/database/migrations/1735640000000-add-database-indexes.js
@@ -1,7 +1,8 @@
 // Migration: Add database indexes for better query performance
 
 module.exports = {
-   up: async (queryInterface, Sequelize) => {
+   up: async function up(params = {}) {
+      const queryInterface = params?.context ?? params;
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             // Add index on keyword.domain for faster domain-based queries
@@ -41,7 +42,8 @@ module.exports = {
       });
    },
 
-   down: async (queryInterface) => {
+   down: async function down(params = {}) {
+      const queryInterface = params?.context ?? params;
       return queryInterface.sequelize.transaction(async (t) => {
          try {
             await queryInterface.removeIndex('keyword', 'keyword_domain_idx', { transaction: t });


### PR DESCRIPTION
## Summary
- normalise the legacy Sequelize migrations to accept Umzug v3's `{ context }` payload while remaining callable from `sequelize-cli`
- teach the custom SQLite dialect to retry `.all()`/`.get()` invocations that hit non-reader statements so Umzug's SequelizeStorage can create its metadata table
- document the new migration workflow and changelog the runtime compatibility fixes

## Testing
- `npm run lint`
- `npm run lint:css`
- `npm run test`
- Manual: executed the Umzug migration helper script against a fresh SQLite database (schema sync + `umzug.up()`)


------
https://chatgpt.com/codex/tasks/task_e_68ceb1d13820832a821d7a393ad2b521