### PR TITLE
Fix migration imports and sqlite fallback handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
+* Updated migration error handling tests to require Umzug migration modules without explicit `.js` extensions so Node's resolver stays compatible with both ESM-aware loaders and Jest.
 * Hardened the settings API to tolerate absent Next.js runtime config while still returning version metadata when available.
 * Added a least-privilege GitHub Actions CodeQL workflow that scans pushes, pull requests, and a weekly schedule for JavaScript/TypeScript vulnerabilities.
 * Updated API settings tests to strip `SCREENSHOT_API` when exercising missing-configuration flows so CI secrets can no longer mask the expected failures.

--- a/README.md
+++ b/README.md
@@ -153,3 +153,4 @@ The Scraping Robot integration now explicitly sends both Google locale parameter
 - The sqlite dialect suite now includes a regression test verifying the mocked `better-sqlite3` driver preserves single `?` placeholder bindings end-to-end.
 - Use `npm run test:cv -- --runInBand` to generate coverage serially, which avoids intermittent jsdom worker crashes during long-running suites.
 - API settings integration tests now explicitly remove `SCREENSHOT_API` when simulating misconfigurations so failures surface even if local shells export the key.
+- Migration error handling coverage requires Umzug migrations without `.js` extensions, matching how the runtime loader resolves extensionless module specifiers.

--- a/__tests__/database/migration-error-handling.test.ts
+++ b/__tests__/database/migration-error-handling.test.ts
@@ -22,7 +22,7 @@ describe('Migration Error Handling', () => {
 
   test('migration functions should re-throw errors after logging', async () => {
     // Test that migration error handling works correctly by importing and testing a migration
-    const migration = require('../../database/migrations/1710000000000-add-keyword-state-field.js');
+    const migration = require('../../database/migrations/1710000000000-add-keyword-state-field');
     
     // Create a mock queryInterface that will fail
     const mockQueryInterface = {
@@ -51,7 +51,7 @@ describe('Migration Error Handling', () => {
   });
 
   test('migration down function should also re-throw errors', async () => {
-    const migration = require('../../database/migrations/1735640000000-add-database-indexes.js');
+    const migration = require('../../database/migrations/1735640000000-add-database-indexes');
     
     // Create a mock queryInterface that will fail
     const mockQueryInterface = {
@@ -79,7 +79,7 @@ describe('Migration Error Handling', () => {
   });
 
   test('successful migrations should not throw errors', async () => {
-    const migration = require('../../database/migrations/1710000000000-add-keyword-state-field.js');
+    const migration = require('../../database/migrations/1710000000000-add-keyword-state-field');
     const { DataTypes } = require('sequelize');
     
     // Create a mock queryInterface that succeeds

--- a/database/sqlite-dialect.js
+++ b/database/sqlite-dialect.js
@@ -210,24 +210,8 @@ class Database extends EventEmitter {
     try {
       const statement = this.driver.prepare(sql);
       let result;
-      if (method === 'run') {
-        fallbackToRun();
-      } else if (method === 'all' || method === 'get') {
-        try {
-          result = applyStatement(statement, method, preparedBindings);
-          if (method === 'all') {
-            context.changes = Array.isArray(result) ? result.length : 0;
-          } else {
-            context.changes = result ? 1 : 0;
-          }
-        } catch (err) {
-          if (shouldFallback(err)) {
-            fallbackToRun();
-            result = method === 'all' ? [] : undefined;
-          } else {
-            throw err;
-          }
-        }
+      if (method === 'run' || method === 'all' || method === 'get') {
+        result = applyStatementWithFallback(statement, method, preparedBindings, context);
       } else {
         result = applyStatement(statement, method, preparedBindings);
       }


### PR DESCRIPTION
## Summary
- remove explicit `.js` suffix from migration error handling test imports so they match Node's extensionless resolution
- note the extensionless requires in the README and changelog for future contributors
- reuse the sqlite dialect's shared fallback helper during execution to restore the migration tests

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef43081a4832aa1e4c4e8ca857aa2