### PR TITLE
Ensure Docker healthcheck loads HTTP module explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to this project will be documented in this file. See [standa
 * Enabled GitHub Actions build cache exports for Docker image publishing.
 * Upgraded `google-auth-library` to `^10.3.0`, pulling in `gaxios@7`/`node-fetch@3` to silence Node.js 22 `fetch()` deprecation warnings and keep Google Ads integrations working on current LTS releases.
 * Removed package manifests from the runtime container layer, relying on the standalone server bundle and production dependencies that ship with the image.
+* Updated the Docker health check to `require('http')` before calling `.get()` so Node always loads the built-in module when probing the domains API endpoint.
 - Raised ESLint to `^9.15.0`, replaced the Airbnb preset with native flat-config presets, and wired the Next.js 15 core web vitals runner directly into `eslint.config.mjs`.
 - Preserved explicit SQLite `null` bindings so prepared statements receive them during execution instead of stripping them alongside optional callbacks.
 - Downgraded ESLint to `^8.57.1` to keep the flat config workflow compatible with `eslint-config-airbnb-base@15` while preserving existing lint rules.

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ EXPOSE 3000
 
 # Health check for container monitoring
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-  CMD node -e "http.get('http://localhost:3000/api/domains', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))" || exit 1
+  CMD node -e "require('http').get('http://localhost:3000/api/domains', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))" || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The Docker image now bakes the production build output produced by `npm run buil
 - ships a pruned `node_modules/` directory with only production dependencies so cron jobs and migrations can `require()` their helpers,
 - omits build-time manifests such as `package.json` and `package-lock.json` to reduce attack surface and shrink the final layer,
 - exposes port `3000` by default while still persisting `/app/data` for SQLite storage.
+- reports container health by explicitly loading Node's built-in `http` module before probing `http://localhost:3000/api/domains`, keeping the runtime health check compatible with stricter execution environments.
 
 If you need to seed or snapshot the SQLite database before running the container, populate the `data/` directory locally—those files are now copied into the runtime image without being deleted during the build.
 


### PR DESCRIPTION
## Summary
- update the Docker health check to require Node's built-in `http` module before probing the domains API
- document the health check adjustment in both README and CHANGELOG for deployers

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2cd4e8ec832a84def8e36a3c82b6