### PR TITLE
Align layout gutters across dashboard views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
+* Added a global clamp-based body gutter, widened the `max-w-*` wrappers to a shared 105rem layout, and refreshed the TopBar/domains views to consume the new spacing helpers.
 * Removed the in-app changelog panel and related GitHub release polling; the footer now only displays the installed version label.
 * Updated migration error handling tests to require Umzug migration modules without explicit `.js` extensions so Node's resolver stays compatible with both ESM-aware loaders and Jest.
 * Hardened the settings API to tolerate absent Next.js runtime config while still returning version metadata when available.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Stable Search Console Emails:** Email summaries gracefully skip Search Console stats when cached data is unavailable, keeping Docker builds and cron runs healthy.
 - **Automated Security Scans:** GitHub CodeQL now reviews every push, pull request, and weekly schedule for vulnerabilities across the JavaScript/TypeScript codebase.
 - **Simplified Footer:** The in-app changelog drawer has been removed; the footer now only shows the installed version without fetching GitHub releases on load.
+- **Consistent Layout Gutters:** A shared clamp-based body padding now aligns the TopBar back button and domain dashboards across breakpoints while widening the large content containers.
 
 ### Requirements
 

--- a/__tests__/components/Topbar.test.tsx
+++ b/__tests__/components/Topbar.test.tsx
@@ -4,6 +4,7 @@ import TopBar from '../../components/common/TopBar';
 jest.mock('next/router', () => ({
    useRouter: () => ({
       pathname: '/',
+      asPath: '/',
    }),
 }));
 
@@ -13,5 +14,12 @@ describe('TopBar Component', () => {
        expect(
            await screen.findByText('SerpBear'),
        ).toBeInTheDocument();
+   });
+
+   it('aligns the back button with the topbar gutter helper', () => {
+      const { container } = render(<TopBar showSettings={jest.fn} showAddModal={jest.fn} />);
+      const backLink = container.querySelector('.topbar__back');
+      expect(backLink).toBeInTheDocument();
+      expect(backLink).toHaveClass('topbar__back');
    });
 });

--- a/__tests__/pages/domain.test.tsx
+++ b/__tests__/pages/domain.test.tsx
@@ -58,6 +58,13 @@ describe('SingleDomain Page', () => {
       render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
       expect(screen.getByTestId('domain-header')).toBeInTheDocument();
    });
+
+   it('applies gutter spacing between the sidebar and content area', () => {
+      const { container } = render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
+      const layoutWrapper = container.querySelector('.max-w-8xl');
+      expect(layoutWrapper).toBeInTheDocument();
+      expect(layoutWrapper).toHaveClass('gap-6');
+   });
    it('Should Call the useFetchDomains hook on render.', async () => {
       render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
       expect(useFetchDomains).toHaveBeenCalled();

--- a/__tests__/pages/domains.test.tsx
+++ b/__tests__/pages/domains.test.tsx
@@ -67,6 +67,17 @@ describe('Domains Page', () => {
       );
       expect(container.querySelector('.domItem')).toBeInTheDocument();
    });
+
+   it('wraps page content with the shared body gutter', () => {
+      const { container } = render(
+          <QueryClientProvider client={queryClient}>
+              <Domains />
+          </QueryClientProvider>,
+      );
+      const layoutWrapper = container.querySelector('.max-w-8xl');
+      expect(layoutWrapper).toBeInTheDocument();
+      expect(layoutWrapper).toHaveClass('py-6');
+   });
    it('Should Display Add Domain Modal on relveant Button Click.', async () => {
       render(<QueryClientProvider client={queryClient}><Domains /></QueryClientProvider>);
       const button = screen.getByTestId('addDomainButton');

--- a/components/common/TopBar.tsx
+++ b/components/common/TopBar.tsx
@@ -38,8 +38,11 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
             <button className='px-3 py-1 font-bold text-blue-700  lg:hidden ml-3 text-lg' onClick={() => showAddModal()}>+</button>
          </h3>
          {!isDomainsPage && router.asPath !== '/research' && (
-            <Link href={'/domains'} className=' right-14 top-4 px-2 py-1 cursor-pointer bg-[#ecf2ff] hover:bg-indigo-100 transition-all
-               absolute lg:top-4 lg:right-auto lg:left-8 lg:px-3 lg:py-2 rounded-full'>
+            <Link
+               href={'/domains'}
+               className='topbar__back right-14 top-4 px-2 py-1 cursor-pointer bg-[#ecf2ff] hover:bg-indigo-100 transition-all
+               absolute lg:top-4 lg:right-auto lg:px-3 lg:py-2 rounded-full'
+            >
                <Icon type="caret-left" size={16} title="Go Back" />
             </Link>
          )}

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -60,9 +60,9 @@ const SingleDomain: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
-            <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
+            <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain
                ? <DomainHeader
                   domain={activDomain}

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -95,9 +95,9 @@ const DiscoverPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
-            <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
+            <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain
                ? <DomainHeader
                   domain={activDomain}

--- a/pages/domain/ideas/[slug]/index.tsx
+++ b/pages/domain/ideas/[slug]/index.tsx
@@ -53,9 +53,9 @@ const DiscoverPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
-            <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
+            <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain ? (
                   <DomainHeader
                   domain={activDomain}

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -53,9 +53,9 @@ const InsightPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto">
+         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
-            <div className="domain_kewywords px-5 pt-10 lg:px-0 lg:pt-8 w-full">
+            <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain
                ? <DomainHeader
                   domain={activDomain}

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -112,7 +112,7 @@ const Domains: NextPage = () => {
          </Head>
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
 
-         <div className="flex flex-col w-full max-w-8xl mx-auto p-6 lg:mt-24 lg:p-0">
+         <div className="flex flex-col w-full max-w-8xl mx-auto py-6 lg:mt-24">
             <div className='flex justify-between mb-2 items-center'>
                <div className=' text-sm text-gray-600'>
                   {domainsData?.domains?.length || 0} Domains <span className=' text-gray-300 ml-1 mr-1'>|</span> {totalKeywords} keywords

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,16 +4,34 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+   --layout-inline: clamp(1.5rem, 5vw, 10rem);
+}
+
 body {
    background-color: #f8f9ff;
+   padding-inline: var(--layout-inline);
 }
 
-.max-w-7xl {
-   max-width: 90rem;
-}
-
+.max-w-5xl,
+.max-w-7xl,
 .max-w-8xl {
    max-width: 105rem;
+}
+
+.topbar {
+   position: relative;
+}
+
+.topbar__back {
+   position: absolute;
+}
+
+@media (min-width: 1024px) {
+   .topbar__back {
+      left: var(--layout-inline);
+      right: auto;
+   }
 }
 
 .domKeywords {


### PR DESCRIPTION
## Summary
- add a clamp-based body gutter variable and override the large max-width helpers to 105rem
- realign the TopBar back link and domain layouts to use the shared gutter spacing
- extend TopBar and domain page tests to cover the new helper classes

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf389bfe90832a9a99477e492e2128