### PR TITLE
Improve scraper settings handling and slug-aware Search Console hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   actions: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
+* Settings now reload the window only when enabling a scraper from the previous `'none'` state, and the scraper modal has Jest coverage to verify the behaviour.
+* Search Console hooks key their queries by the active domain slug, skip fetches without a slug, and include tests that confirm refetching when switching domains.
+* Domain settings accept `null` domains, short-circuit the lookup fetch when closed, and continue guarding destructive actions behind a non-null domain selection.
+* Domain validation no longer reuses global regex instances and has dedicated tests for multi-label inputs alongside common invalid examples.
+* GitHub Actions workflows run inside concurrency groups with `cancel-in-progress: true` so superseded CI or Docker builds automatically stop when newer commits arrive.
 * Domain settings now request `/api/domain` with the canonical host so decrypted Search Console credentials hydrate the modal fields as soon as it opens.
 * Consolidated scraper and refresh error serialization into a shared helper used across utilities and covered it with dedicated Jest tests.
 * Added a global clamp-based body gutter, widened the `max-w-*` wrappers to a shared 105rem layout, and refreshed the TopBar/domains views to consume the new spacing helpers.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Email Notification:** Get notified of your keyword position changes daily/weekly/monthly through email.
 - **SERP API:** SerpBear comes with built-in API that you can use for your marketing & data reporting tools.
 - **Keyword Research:** Ability to research keywords and auto-generate keyword ideas from your tracked website's content by integrating your Google Ads test account.
-- **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically once per cron day based on the configured timezone, can be manually refreshed from settings, and falls back to global credentials when domain-level credentials aren't configured.
+- **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically once per cron day based on the configured timezone, can be manually refreshed from settings, and falls back to global credentials when domain-level credentials aren't configured. Dashboards now automatically refetch when switching between domains thanks to slug-keyed queries, ensuring the Search Console view and insight reports stay aligned with the active property.
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
 - **Robust Error Handling:** Improved input validation, safer JSON parsing, and a shared error-serialization helper that keeps scraper and refresh logs consistent.
@@ -39,6 +39,8 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 ### Continuous Integration
 
 Every pull request and all pushes to the `main` and `dev` branches run through a GitHub Actions workflow defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml). The pipeline installs dependencies with `npm ci`, executes both JavaScript and CSS linting, runs the Jest test suite via `npm run test:ci`, and builds the production bundle. The workflow also provisions a minimal `.env.local` file so environment validation passes and restores a cache for `.next/cache` to speed up subsequent builds.
+
+All workflows now run inside concurrency groups with `cancel-in-progress: true`, so a fresh push or pull request update automatically stops any in-flight CI or Docker image builds before starting the latest run.
 
 #### Screenshot capture configuration
 

--- a/__tests__/components/Settings.test.tsx
+++ b/__tests__/components/Settings.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import Settings, { defaultSettings } from '../../components/settings/Settings';
+import { useClearFailedQueue, useFetchSettings, useUpdateSettings } from '../../services/settings';
+
+jest.mock('../../services/settings');
+
+const useFetchSettingsMock = useFetchSettings as jest.Mock;
+const useUpdateSettingsMock = useUpdateSettings as jest.Mock;
+const useClearFailedQueueMock = useClearFailedQueue as jest.Mock;
+
+describe('Settings scraper reload behaviour', () => {
+   const closeSettings = jest.fn();
+   let queryClient: QueryClient;
+   const renderComponent = () => {
+      return render(
+         <QueryClientProvider client={queryClient}>
+            <Settings closeSettings={closeSettings} />
+         </QueryClientProvider>,
+      );
+   };
+
+   beforeEach(() => {
+      queryClient = new QueryClient();
+      const settingsData: SettingsType = {
+         ...defaultSettings,
+         notification_interval: 'never',
+         available_scapers: [{ label: 'Proxy', value: 'proxy' }],
+         scraper_type: 'none',
+      };
+
+      useFetchSettingsMock.mockReturnValue({ data: { settings: settingsData }, isLoading: false });
+      useClearFailedQueueMock.mockReturnValue({ mutate: jest.fn(), isLoading: false });
+   });
+
+   afterEach(() => {
+      jest.clearAllMocks();
+   });
+
+   it('reloads the page when enabling a scraper from the disabled state', async () => {
+      const mutateAsync = jest.fn().mockResolvedValue({});
+      useUpdateSettingsMock.mockReturnValue({ mutateAsync, isLoading: false });
+
+      const reloadSpy = jest.spyOn(window.location, 'reload').mockImplementation(() => undefined);
+
+      try {
+         const { container } = renderComponent();
+         const scraperSelect = container.querySelector('.settings__section__select .selected') as HTMLElement | null;
+         if (!scraperSelect) {
+            throw new Error('Could not locate scraper selector');
+         }
+         fireEvent.click(scraperSelect);
+
+         const proxyOption = await screen.findByText('Proxy');
+         fireEvent.click(proxyOption);
+
+         const updateButton = container.querySelector('button.bg-blue-700') as HTMLElement | null;
+         if (!updateButton) {
+            throw new Error('Could not locate update button');
+         }
+         fireEvent.click(updateButton);
+
+         await waitFor(() => {
+            expect(mutateAsync).toHaveBeenCalled();
+            expect(reloadSpy).toHaveBeenCalled();
+         });
+
+         const payload = mutateAsync.mock.calls[0][0] as SettingsType;
+         expect(payload.scraper_type).toBe('proxy');
+      } finally {
+         reloadSpy.mockRestore();
+      }
+   });
+});

--- a/__tests__/services/searchConsole.test.ts
+++ b/__tests__/services/searchConsole.test.ts
@@ -1,0 +1,154 @@
+import { useQuery } from 'react-query';
+import {
+   fetchSCInsight,
+   fetchSCKeywords,
+   useFetchSCInsight,
+   useFetchSCKeywords,
+} from '../../services/searchConsole';
+
+jest.mock('react-query', () => ({
+   useQuery: jest.fn(),
+}));
+
+describe('Search Console hooks', () => {
+   const mockUseQuery = useQuery as unknown as jest.Mock;
+   const originalFetch = global.fetch;
+   const baseRouter = { push: jest.fn() } as any;
+
+   beforeEach(() => {
+      mockUseQuery.mockClear();
+      (global as any).fetch = jest.fn().mockResolvedValue({
+         status: 200,
+         json: jest.fn().mockResolvedValue({ data: [] }),
+      });
+   });
+
+   afterEach(() => {
+      (global as any).fetch = originalFetch;
+   });
+
+   it('includes the slug in the Search Console keywords query key', () => {
+      const routerWithSlug = { ...baseRouter, query: { slug: 'first-slug' } };
+
+      useFetchSCKeywords(routerWithSlug, true);
+
+      expect(mockUseQuery).toHaveBeenCalledTimes(1);
+      expect(mockUseQuery).toHaveBeenCalledWith(
+         ['sckeywords', 'first-slug'],
+         expect.any(Function),
+         expect.objectContaining({ enabled: true }),
+      );
+
+      mockUseQuery.mockClear();
+      const routerWithoutSlug = { ...baseRouter, query: {} };
+
+      useFetchSCKeywords(routerWithoutSlug, true);
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+         ['sckeywords', ''],
+         expect.any(Function),
+         expect.objectContaining({ enabled: false }),
+      );
+   });
+
+   it('includes the slug in the Search Console insight query key', () => {
+      const routerWithSlug = { ...baseRouter, query: { slug: 'insight-slug' } };
+
+      useFetchSCInsight(routerWithSlug, true);
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+         ['scinsight', 'insight-slug'],
+         expect.any(Function),
+         expect.objectContaining({ enabled: true }),
+      );
+
+      mockUseQuery.mockClear();
+      const routerWithoutSlug = { ...baseRouter, query: {} };
+
+      useFetchSCInsight(routerWithoutSlug, true);
+
+      expect(mockUseQuery).toHaveBeenCalledWith(
+         ['scinsight', ''],
+         expect.any(Function),
+         expect.objectContaining({ enabled: false }),
+      );
+   });
+
+   it('refetches when the slug changes between invocations', () => {
+      const firstRouter = { ...baseRouter, query: { slug: 'first' } };
+      const secondRouter = { ...baseRouter, query: { slug: 'second' } };
+
+      useFetchSCKeywords(firstRouter, true);
+      useFetchSCKeywords(secondRouter, true);
+
+      expect(mockUseQuery).toHaveBeenNthCalledWith(
+         1,
+         ['sckeywords', 'first'],
+         expect.any(Function),
+         expect.objectContaining({ enabled: true }),
+      );
+      expect(mockUseQuery).toHaveBeenNthCalledWith(
+         2,
+         ['sckeywords', 'second'],
+         expect.any(Function),
+         expect.objectContaining({ enabled: true }),
+      );
+   });
+
+   it('refetches insight data when the slug changes', () => {
+      const firstRouter = { ...baseRouter, query: { slug: 'alpha' } };
+      const secondRouter = { ...baseRouter, query: { slug: 'beta' } };
+
+      useFetchSCInsight(firstRouter, true);
+      useFetchSCInsight(secondRouter, true);
+
+      expect(mockUseQuery).toHaveBeenNthCalledWith(
+         1,
+         ['scinsight', 'alpha'],
+         expect.any(Function),
+         expect.objectContaining({ enabled: true }),
+      );
+      expect(mockUseQuery).toHaveBeenNthCalledWith(
+         2,
+         ['scinsight', 'beta'],
+         expect.any(Function),
+         expect.objectContaining({ enabled: true }),
+      );
+   });
+
+   it('skips fetch when slug is absent for keywords', async () => {
+      const routerWithoutSlug = { ...baseRouter, query: {} };
+
+      const result = await fetchSCKeywords(routerWithoutSlug);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+   });
+
+   it('skips fetch when slug is absent for insight', async () => {
+      const routerWithoutSlug = { ...baseRouter, query: {} };
+
+      const result = await fetchSCInsight(routerWithoutSlug);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+   });
+
+   it('passes the slug to fetchers when present', async () => {
+      const routerWithSlug = { ...baseRouter, query: { slug: 'live-slug' } };
+
+      await fetchSCKeywords(routerWithSlug);
+      await fetchSCInsight(routerWithSlug);
+
+      expect(global.fetch).toHaveBeenNthCalledWith(
+         1,
+         expect.stringContaining('domain=live-slug'),
+         { method: 'GET' },
+      );
+      expect(global.fetch).toHaveBeenNthCalledWith(
+         2,
+         expect.stringContaining('domain=live-slug'),
+         { method: 'GET' },
+      );
+   });
+});

--- a/__tests__/utils/client/validators.test.ts
+++ b/__tests__/utils/client/validators.test.ts
@@ -1,0 +1,22 @@
+import { isValidDomain } from '../../../utils/client/validators';
+
+describe('isValidDomain', () => {
+   it('accepts common multi-label domains', () => {
+      expect(isValidDomain('example.com')).toBe(true);
+      expect(isValidDomain('foo.bar.co.uk')).toBe(true);
+   });
+
+   it('rejects known invalid inputs', () => {
+      expect(isValidDomain('invalid_domain')).toBe(false);
+      expect(isValidDomain('-leadingdash.com')).toBe(false);
+      expect(isValidDomain('example..com')).toBe(false);
+      expect(isValidDomain('')).toBe(false);
+   });
+
+   it('returns consistent results across repeated calls', () => {
+      const value = 'repeat.example';
+      expect(isValidDomain(value)).toBe(true);
+      expect(isValidDomain(value)).toBe(true);
+      expect(isValidDomain(value)).toBe(true);
+   });
+});

--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -7,7 +7,7 @@ import InputField from '../common/InputField';
 import SelectField from '../common/SelectField';
 
 type DomainSettingsProps = {
-   domain:DomainType|false,
+   domain:DomainType|null,
    closeModal: Function
 }
 
@@ -22,9 +22,9 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
    const [showRemoveDomain, setShowRemoveDomain] = useState<boolean>(false);
    const [settingsError, setSettingsError] = useState<DomainSettingsError>({ type: '', msg: '' });
    const [domainSettings, setDomainSettings] = useState<DomainSettings>(() => ({
-      notification_interval: domain && domain.notification_interval ? domain.notification_interval : 'never',
-      notification_emails: domain && domain.notification_emails ? domain.notification_emails : '',
-      search_console: domain && domain.search_console ? JSON.parse(domain.search_console) : {
+      notification_interval: domain?.notification_interval ?? 'never',
+      notification_emails: domain?.notification_emails ?? '',
+      search_console: domain?.search_console ? JSON.parse(domain.search_console) : {
          property_type: 'domain', url: '', client_email: '', private_key: '',
       },
    }));
@@ -33,7 +33,7 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
    const { mutate: deleteMutate } = useDeleteDomain(() => { closeModal(false); router.push('/domains'); });
 
    // Get the Full Domain Data along with the Search Console API Data.
-   useFetchDomain(router, (domain && domain.domain) || '', (domainObj:DomainType) => {
+   useFetchDomain(router, domain?.domain || '', (domainObj:DomainType) => {
       const currentSearchConsoleSettings = domainObj.search_console && JSON.parse(domainObj.search_console);
       setDomainSettings(prevSettings => ({ ...prevSettings, search_console: currentSearchConsoleSettings || prevSettings.search_console }));
    });
@@ -55,8 +55,8 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
             setSettingsError({ type: '', msg: '' });
          }, 3000);
       } else if (domain) {
-            updateMutate({ domainSettings, domain });
-         }
+         updateMutate({ domainSettings, domain });
+      }
    };
 
    const tabStyle = `inline-block px-4 py-2 rounded-md mr-3 cursor-pointer text-sm select-none z-10

--- a/components/settings/Settings.tsx
+++ b/components/settings/Settings.tsx
@@ -82,9 +82,10 @@ const Settings = ({ closeSettings }:SettingsProps) => {
          setTimeout(() => { setSettingsError(null); }, 3000);
       } else {
          // Perform Update
+         const previousScraperType = appSettings?.settings?.scraper_type;
          await updateMutateAsync(settings);
-         // If Scraper is updated, refresh the page.
-         if (appSettings.settings === 'none' && scraper_type !== 'none') {
+         // If Scraper is updated, refresh the page when enabling from a disabled state.
+         if (previousScraperType === 'none' && scraper_type !== 'none') {
             window.location.reload();
          }
       }

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -91,7 +91,7 @@ const SingleDomain: NextPage = () => {
 
          <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
             <DomainSettings
-            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : false}
+            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -125,7 +125,7 @@ const DiscoverPage: NextPage = () => {
 
          <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
             <DomainSettings
-            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : false}
+            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>

--- a/pages/domain/ideas/[slug]/index.tsx
+++ b/pages/domain/ideas/[slug]/index.tsx
@@ -85,7 +85,7 @@ const DiscoverPage: NextPage = () => {
 
          <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
             <DomainSettings
-            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : false}
+            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -83,7 +83,7 @@ const InsightPage: NextPage = () => {
 
          <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
             <DomainSettings
-            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : false}
+            domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>

--- a/services/domains.tsx
+++ b/services/domains.tsx
@@ -69,10 +69,12 @@ export function useFetchDomains(router: NextRouter, withStats:boolean = false) {
 
 export function useFetchDomain(router: NextRouter, domainName:string, onSuccess: Function) {
    return useQuery(['domain', domainName], () => fetchDomain(router, domainName), {
+      enabled: !!domainName,
       onSuccess: async (data) => {
          console.log('Domain Loaded!!!', data.domain);
          onSuccess(data.domain);
-      } });
+      },
+   });
 }
 
 export function useAddDomain(onSuccess:Function) {

--- a/services/searchConsole.ts
+++ b/services/searchConsole.ts
@@ -2,9 +2,21 @@ import { NextRouter } from 'next/router';
 import toast from 'react-hot-toast';
 import { useQuery } from 'react-query';
 
-export async function fetchSCKeywords(router: NextRouter) {
+const getActiveSlug = (router: NextRouter): string | undefined => {
+   const slugParam = router?.query?.slug;
+   if (Array.isArray(slugParam)) {
+      return slugParam[0];
+   }
+   return slugParam;
+};
+
+export async function fetchSCKeywords(router: NextRouter, slugOverride?: string) {
    // if (!router.query.slug) { throw new Error('Invalid Domain Name'); }
-   const res = await fetch(`${window.location.origin}/api/searchconsole?domain=${router.query.slug}`, { method: 'GET' });
+   const slug = slugOverride ?? getActiveSlug(router);
+   if (!slug) {
+      return null;
+   }
+   const res = await fetch(`${window.location.origin}/api/searchconsole?domain=${slug}`, { method: 'GET' });
    if (res.status >= 400 && res.status < 600) {
       if (res.status === 401) {
          console.log('Unauthorized!!');
@@ -17,12 +29,17 @@ export async function fetchSCKeywords(router: NextRouter) {
 
 export function useFetchSCKeywords(router: NextRouter, domainLoaded: boolean = false) {
    // console.log('ROUTER: ', router);
-   return useQuery('sckeywords', () => router.query.slug && fetchSCKeywords(router), { enabled: domainLoaded });
+   const slug = getActiveSlug(router) || '';
+   return useQuery(['sckeywords', slug], () => fetchSCKeywords(router, slug), { enabled: domainLoaded && !!slug });
 }
 
-export async function fetchSCInsight(router: NextRouter) {
+export async function fetchSCInsight(router: NextRouter, slugOverride?: string) {
    // if (!router.query.slug) { throw new Error('Invalid Domain Name'); }
-   const res = await fetch(`${window.location.origin}/api/insight?domain=${router.query.slug}`, { method: 'GET' });
+   const slug = slugOverride ?? getActiveSlug(router);
+   if (!slug) {
+      return null;
+   }
+   const res = await fetch(`${window.location.origin}/api/insight?domain=${slug}`, { method: 'GET' });
    if (res.status >= 400 && res.status < 600) {
       if (res.status === 401) {
          console.log('Unauthorized!!');
@@ -35,7 +52,8 @@ export async function fetchSCInsight(router: NextRouter) {
 
 export function useFetchSCInsight(router: NextRouter, domainLoaded: boolean = false) {
    // console.log('ROUTER: ', router);
-   return useQuery('scinsight', () => router.query.slug && fetchSCInsight(router), { enabled: domainLoaded });
+   const slug = getActiveSlug(router) || '';
+   return useQuery(['scinsight', slug], () => fetchSCInsight(router, slug), { enabled: domainLoaded && !!slug });
 }
 
 export const refreshSearchConsoleData = async () => {

--- a/utils/client/validators.ts
+++ b/utils/client/validators.ts
@@ -2,7 +2,7 @@ export const isValidDomain = (domain:string): boolean => {
    if (typeof domain !== 'string') return false;
    if (!domain.includes('.')) return false;
    let value = domain;
-   const validHostnameChars = /^[a-zA-Z0-9-.]{1,253}\.?$/g;
+   const validHostnameChars = /^[a-zA-Z0-9-.]{1,253}\.?$/;
    if (!validHostnameChars.test(value)) {
      return false;
    }
@@ -18,7 +18,7 @@ export const isValidDomain = (domain:string): boolean => {
    const labels = value.split('.');
 
    const isValid = labels.every((label) => {
-     const validLabelChars = /^([a-zA-Z0-9-]+)$/g;
+     const validLabelChars = /^([a-zA-Z0-9-]+)$/;
 
      const validLabel = (
        validLabelChars.test(label)


### PR DESCRIPTION
## Summary
- only reload the app when enabling a scraper from the disabled state and add coverage for the settings modal
- key Search Console queries by the active domain slug, skip fetches without one, and add regression tests for the hooks
- let DomainSettings accept null, update domain pages, validators, documentation, and workflows (including concurrency safeguards)

## Testing
- npm run lint
- npm run lint:css
- npm run test
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b27ace78832a83a7c20099eb95a8