### PR TITLE
Potential fix for code scanning alert no. 15: Inefficient regular expression

### DIFF
--- a/utils/security.ts
+++ b/utils/security.ts
@@ -53,7 +53,7 @@ export const sanitizeDomain = (domain: string): { isValid: boolean; sanitized: s
    }
    
    const sanitized = domain.trim().toLowerCase().substring(0, 253); // RFC 1035 limit
-   const domainRegex = /^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]?(\.[a-z0-9][a-z0-9-]{0,61}[a-z0-9]?)*$/;
+   const domainRegex = /^([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$/;
    
    return {
       isValid: domainRegex.test(sanitized),


### PR DESCRIPTION
Potential fix for [https://github.com/djav1985/v-serpbear/security/code-scanning/15](https://github.com/djav1985/v-serpbear/security/code-scanning/15)

To fix this issue, we should rewrite the domain validation regular expression to remove the ambiguity that arises from the overlapping between `[a-z0-9-]{0,61}` and the optional `[a-z0-9]?`. One well-known robust approach for domain validation is to require each label to start and end with an alphanumeric character, allowing hyphens only in the middle, with length limits as defined in RFC 1035. 

The label pattern should be: `[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?` (so, 1-63 chars, no leading/trailing hyphen).  
Thus, the new domain regex could look like:  
`/^([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(\.([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$/`  
This avoids ambiguous alternation/quantifiers and aligns with DNS rules.

We only need to update the domainRegex on line 56, in `utils/security.ts`. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
