### PR TITLE
chore: retain server logging in standalone build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
+* Retained server-side logging in the production bundle by gating Next.js `compiler.removeConsole` behind the `NEXT_REMOVE_CONSOLE` environment flag.
 * Settings now reload the window only when enabling a scraper from the previous `'none'` state, and the scraper modal has Jest coverage to verify the behaviour.
 * Search Console hooks key their queries by the active domain slug, skip fetches without a slug, and include tests that confirm refetching when switching domains.
 * Domain settings accept `null` domains, short-circuit the lookup fetch when closed, and continue guarding destructive actions behind a non-null domain selection.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The Docker image now bakes the production build output produced by `npm run buil
 - omits build-time manifests such as `package.json` and `package-lock.json` to reduce attack surface and shrink the final layer,
 - exposes port `3000` by default while still persisting `/app/data` for SQLite storage.
 - reports container health by explicitly loading Node's built-in `http` module before probing `http://localhost:3000/api/domains`, keeping the runtime health check compatible with stricter execution environments.
+- retains server-side `console.*` logging so API traffic, scraper activity, and error diagnostics surface in container logs; set `NEXT_REMOVE_CONSOLE=true` if you need to strip non-error output for bespoke deployments.
 
 If you need to seed or snapshot the SQLite database before running the container, populate the `data/` directory locally—those files are now copied into the runtime image without being deleted during the build.
 

--- a/next.config.js
+++ b/next.config.js
@@ -15,9 +15,13 @@ const nextConfig = {
   
   // Compiler optimizations
   compiler: {
-    removeConsole: process.env.NODE_ENV === 'production' ? {
-      exclude: ['error']
-    } : false,
+    // Preserve server logging by default; opt-in via NEXT_REMOVE_CONSOLE
+    removeConsole:
+      process.env.NEXT_REMOVE_CONSOLE === 'true'
+        ? {
+            exclude: ['error'],
+          }
+        : false,
   },
   
   // Bundle analyzer (enable with ANALYZE=true)


### PR DESCRIPTION
## Summary
- default the Next.js compiler to keep server console output unless `NEXT_REMOVE_CONSOLE=true`
- document the new environment toggle in the deployment guidance and changelog

## Testing
- CI=1 SCREENSHOT_API=dummy SECRET=secret APIKEY=test npm run build
- SCREENSHOT_API=dummy SECRET=secret APIKEY=test LOG_LEVEL=VERBOSE node .next/standalone/server.js
- curl -i http://86dc4d885727:3000/api/keywords?domain=example.com
- curl -i -X POST http://86dc4d885727:3000/api/refresh?id=1
- npm run lint
- npm run lint:css
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d11825ae3c832a9fa3d26fa429f087