### PR TITLE
Initialize AdWords keyword idea response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
+* Pre-initialize Google Ads keyword idea responses so parse failures can still surface diagnostic snippets instead of tripping TypeScript's definite assignment checks.
 * Retained server-side logging in the production bundle by gating Next.js `compiler.removeConsole` behind the `NEXT_REMOVE_CONSOLE` environment flag.
 * Settings now reload the window only when enabling a scraper from the previous `'none'` state, and the scraper modal has Jest coverage to verify the behaviour.
 * Search Console hooks key their queries by the active domain slug, skip fetches without a slug, and include tests that confirm refetching when switching domains.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
 - **Robust Error Handling:** Improved input validation, safer JSON parsing, and a shared error-serialization helper that keeps scraper and refresh logs consistent.
+- **Defensive Google Ads Parsing:** Keyword idea fetches pre-initialize response buffers so error logs retain the upstream text even when parsing fails.
 - **Canonical Domain Settings Fetch:** The domain settings modal now loads decrypted Search Console credentials by requesting `/api/domain` with the tracked site's canonical host, so credential fields update as soon as the modal opens.
 - **Resilient Settings API:** `/api/settings` now tolerates missing runtime configuration and still returns version metadata when available.
 - **Defaulted Configuration:** Settings API responses merge persisted values with safe defaults so required fields like scraper selection and notifications never disappear.

--- a/__tests__/utils/adwordsKeywordIdeas.test.ts
+++ b/__tests__/utils/adwordsKeywordIdeas.test.ts
@@ -65,7 +65,7 @@ describe('getAdwordsKeywordIdeas', () => {
   it('sends correct payload format to Google Ads API', async () => {
     const mockFetch = jest.fn().mockResolvedValue({
       json: async () => ({ results: [] }),
-      text: async () => 'response text',
+      text: async () => '{"results":[]}',
       status: 200,
       headers: {
         get: jest.fn().mockReturnValue('application/json'),

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -70,23 +70,21 @@ const seedKeywordsFromSearchConsole = async ({
       return seedKeywords;
    }
 
-   const updatedKeywords = [...seedKeywords];
    const domainSCData = await readLocalSCData(domainUrl);
-   if (!domainSCData) {
-      return updatedKeywords;
+   if (!domainSCData || !Array.isArray(domainSCData.thirtyDays)) {
+      return seedKeywords;
    }
 
-   const { thirtyDays } = domainSCData;
-   if (Array.isArray(thirtyDays)) {
-      const sortedSCKeywords = thirtyDays.sort((a, b) => (b.impressions > a.impressions ? 1 : -1));
-      sortedSCKeywords.slice(0, 100).forEach((sckeywrd) => {
-         if (sckeywrd.keyword && !updatedKeywords.includes(sckeywrd.keyword)) {
-            updatedKeywords.push(sckeywrd.keyword);
-         }
-      });
-   }
+   const keywordSet = new Set(seedKeywords);
+   const sortedSCKeywords = [...domainSCData.thirtyDays].sort((a, b) => b.impressions - a.impressions);
 
-   return updatedKeywords;
+   sortedSCKeywords.slice(0, 100).forEach((sckeywrd) => {
+      if (sckeywrd.keyword) {
+         keywordSet.add(sckeywrd.keyword);
+      }
+   });
+
+   return Array.from(keywordSet);
 };
 
 const seedKeywordsFromTracking = async ({


### PR DESCRIPTION
## Summary
- pre-initialize Google Ads response text handling and extract search console/tracking keyword seeding helpers to keep complexity within lint limits
- update the AdWords keyword ideas unit test to supply JSON text and document the defensive parsing behaviour in the changelog and README

## Testing
- npm run lint
- npm run lint:css
- CI=1 npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d129ac1d28832a86b4fc4d76903d97