### PR TITLE
Add domain toggles, Ads OAuth callback, and chart bounds improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ SESSION_DURATION=24
 
 # Application Settings
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_SCREENSHOTS=true
 
 # Screenshot API (Required for keyword screenshots)
 # Get your API key from one of the supported providers
@@ -55,3 +56,4 @@ CRON_EMAIL_SCHEDULE=0 0 6 * * *
 # Monitoring & Logging (Optional)
 # LOG_LEVEL=info
 # SENTRY_DSN=your_sentry_dsn_for_error_monitoring
+# NEXT_REMOVE_CONSOLE=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
+* Added per-domain `scrape_enabled`/`notify_enabled` toggles with database migration, cached UI updates, and API/cron guards so paused domains skip scraping and email runs.
+* Introduced dynamic chart bounds and a shared client helper so SERP line charts and sparklines zoom to the observed rank range instead of hard-coding 1–100.
+* Honoured the `NEXT_PUBLIC_SCREENSHOTS` environment flag in services and the dashboard so deployments can opt out of screenshot fetches and rely on favicons without UI clutter.
+* Returned an HTML OAuth callback from `/api/adwords` that posts an `adwordsIntegrated` message, accepted empty keyword-idea validation responses, and surfaced upstream errors in the settings toast listener.
+* Hardened `/api/refresh` error handling by rejecting empty ID lists with HTTP 400, serialising scraper failures, and short-circuiting toggled-off domains.
+* Documented the new screenshot and console logging environment flags in `.env.example`, the README, and integration tests.
 * Encoded the nested Google Search request passed to ScrapingRobot so locale parameters stay bundled within the delegated `url` query parameter.
 * Retained server-side logging in the production bundle by gating Next.js `compiler.removeConsole` behind the `NEXT_REMOVE_CONSOLE` environment flag.
 * Settings now reload the window only when enabling a scraper from the previous `'none'` state, and the scraper modal has Jest coverage to verify the behaviour.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Email Notification:** Get notified of your keyword position changes daily/weekly/monthly through email.
 - **SERP API:** SerpBear comes with built-in API that you can use for your marketing & data reporting tools.
 - **Keyword Research:** Ability to research keywords and auto-generate keyword ideas from your tracked website's content by integrating your Google Ads test account.
+- **Domain-level toggles:** Pause scraping or notification email delivery per domain; UI switches update instantly and API/cron jobs skip disabled domains.
+- **Auto-zooming charts:** Rank trend charts now compute dynamic min/max bounds so sparkline and full charts focus on the captured data instead of the entire 1–100 range.
 - **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically once per cron day based on the configured timezone, can be manually refreshed from settings, and falls back to global credentials when domain-level credentials aren't configured. Dashboards now automatically refetch when switching between domains thanks to slug-keyed queries, ensuring the Search Console view and insight reports stay aligned with the active property.
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.
 - **Zero Cost to RUN:** Run the App on mogenius.com or Fly.io for free.
@@ -27,6 +29,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Reliable Sessions:** Configurable login durations now persist correctly and logging out clears authentication cookies immediately.
 - **API Hardening:** Notification email endpoint now enforces authentication for both UI and API key access.
 - **Safer Integrations:** Google Ads refresh-token retrieval handles incomplete error payloads and Search Console storage differentiates hyphenated and dotted domains.
+- **Polished Google Ads OAuth flow:** The `/api/adwords` callback now returns a lightweight HTML page that posts an `adwordsIntegrated` message back to the settings view, accepts empty keyword validation responses, and surfaces upstream error text directly in the toast feedback.
 - **Stable Search Console Emails:** Email summaries gracefully skip Search Console stats when cached data is unavailable, keeping Docker builds and cron runs healthy.
 - **Automated Security Scans:** GitHub CodeQL now reviews every push, pull request, and weekly schedule for vulnerabilities across the JavaScript/TypeScript codebase.
 - **Simplified Footer:** The in-app changelog drawer has been removed; the footer now only shows the installed version without fetching GitHub releases on load.
@@ -46,6 +49,7 @@ All workflows now run inside concurrency groups with `cancel-in-progress: true`,
 #### Screenshot capture configuration
 
 - **`SCREENSHOT_API` is now mandatory:** Set this environment variable to the API key provided by your screenshot vendor (for example [ScreenshotOne](https://screenshotone.com/)). The server refuses to load settings or queue screenshot jobs when the key is missing, returning 500-series API responses that explain the misconfiguration. Add the key to `.env.local`, your Docker secrets, or your deployment platform before launching the app.
+- **`NEXT_PUBLIC_SCREENSHOTS` toggles UI thumbnails:** Set this public flag to `false` if you want to skip requesting page screenshots. When disabled, the dashboard falls back to favicons, hides the reload button, and the thumbnail cache stays untouched on the client.
 
 #### How it Works
 

--- a/__mocks__/data.ts
+++ b/__mocks__/data.ts
@@ -7,6 +7,8 @@ export const dummyDomain = {
    lastUpdated: '2022-11-11T10:00:32.243',
    added: '2022-11-11T10:00:32.244',
    tags: '',
+   scrape_enabled: true,
+   notify_enabled: true,
    notification: true,
    notification_interval: 'daily',
    notification_emails: '',

--- a/__tests__/api/cron.test.ts
+++ b/__tests__/api/cron.test.ts
@@ -1,0 +1,91 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../../pages/api/cron';
+import db from '../../database/database';
+import Domain from '../../database/models/domain';
+import Keyword from '../../database/models/keyword';
+import verifyUser from '../../utils/verifyUser';
+import refreshAndUpdateKeywords from '../../utils/refresh';
+import { getAppSettings } from '../../pages/api/settings';
+
+jest.mock('../../database/database', () => ({
+  __esModule: true,
+  default: { sync: jest.fn() },
+}));
+
+jest.mock('../../database/models/domain', () => ({
+  __esModule: true,
+  default: { findAll: jest.fn() },
+}));
+
+jest.mock('../../database/models/keyword', () => ({
+  __esModule: true,
+  default: { update: jest.fn(), findAll: jest.fn() },
+}));
+
+jest.mock('../../utils/verifyUser');
+
+jest.mock('../../pages/api/settings', () => ({
+  __esModule: true,
+  getAppSettings: jest.fn(),
+}));
+
+jest.mock('../../utils/refresh', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+type MockedResponse = Partial<NextApiResponse> & {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+describe('/api/cron', () => {
+  const req = { method: 'POST', headers: {} } as unknown as NextApiRequest;
+  let res: MockedResponse;
+
+  beforeEach(() => {
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as MockedResponse;
+
+    jest.clearAllMocks();
+
+    (db.sync as jest.Mock).mockResolvedValue(undefined);
+    (verifyUser as jest.Mock).mockReturnValue('authorized');
+    (getAppSettings as jest.Mock).mockResolvedValue({ scraper_type: 'serpapi' });
+    (Keyword.update as jest.Mock).mockResolvedValue([1]);
+  });
+
+  it('only refreshes keywords for domains with scraping enabled', async () => {
+    (Domain.findAll as jest.Mock).mockResolvedValue([
+      { get: () => ({ domain: 'enabled.com', scrape_enabled: true }) },
+      { get: () => ({ domain: 'disabled.com', scrape_enabled: false }) },
+    ]);
+
+    const keywordRecord = { domain: 'enabled.com' };
+    (Keyword.findAll as jest.Mock).mockResolvedValue([keywordRecord]);
+
+    await handler(req, res as NextApiResponse);
+
+    expect(Keyword.update).toHaveBeenCalledWith({ updating: true }, { where: { domain: ['enabled.com'] } });
+    expect(Keyword.findAll).toHaveBeenCalledWith({ where: { domain: ['enabled.com'] } });
+    expect(refreshAndUpdateKeywords).toHaveBeenCalledWith([keywordRecord], { scraper_type: 'serpapi' });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ started: true });
+  });
+
+  it('returns early when no domains have scraping enabled', async () => {
+    (Domain.findAll as jest.Mock).mockResolvedValue([
+      { get: () => ({ domain: 'disabled.com', scrape_enabled: false }) },
+    ]);
+
+    await handler(req, res as NextApiResponse);
+
+    expect(Keyword.update).not.toHaveBeenCalled();
+    expect(Keyword.findAll).not.toHaveBeenCalled();
+    expect(refreshAndUpdateKeywords).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ started: false, error: 'No domains have scraping enabled.' });
+  });
+});

--- a/__tests__/api/notify.test.ts
+++ b/__tests__/api/notify.test.ts
@@ -156,4 +156,25 @@ describe('/api/notify - authentication', () => {
       to: 'custom@example.com',
     }));
   });
+
+  it('skips domains with notifications disabled', async () => {
+    (verifyUser as jest.Mock).mockReturnValue('authorized');
+
+    const domainRecord = {
+      get: () => ({
+        domain: 'example.com',
+        notification: false,
+        notify_enabled: false,
+        notification_emails: 'custom@example.com',
+      }),
+    };
+
+    (Domain.findAll as jest.Mock).mockResolvedValue([domainRecord]);
+
+    await handler(req as NextApiRequest, res as NextApiResponse);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true, error: null });
+    expect(nodeMailer.createTransport).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/api/refresh.test.ts
+++ b/__tests__/api/refresh.test.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../../pages/api/refresh';
+import db from '../../database/database';
+import Keyword from '../../database/models/keyword';
+import Domain from '../../database/models/domain';
+import verifyUser from '../../utils/verifyUser';
+import refreshAndUpdateKeywords from '../../utils/refresh';
+import { getAppSettings } from '../../pages/api/settings';
+
+jest.mock('../../database/database', () => ({
+  __esModule: true,
+  default: { sync: jest.fn() },
+}));
+
+jest.mock('../../database/models/keyword', () => ({
+  __esModule: true,
+  default: { findAll: jest.fn(), update: jest.fn() },
+}));
+
+jest.mock('../../database/models/domain', () => ({
+  __esModule: true,
+  default: { findAll: jest.fn() },
+}));
+
+jest.mock('../../utils/verifyUser');
+
+jest.mock('../../pages/api/settings', () => ({
+  __esModule: true,
+  getAppSettings: jest.fn(),
+}));
+
+jest.mock('../../utils/refresh', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../utils/scraper', () => ({
+  scrapeKeywordFromGoogle: jest.fn(),
+  retryScrape: jest.fn(),
+  removeFromRetryQueue: jest.fn(),
+}));
+
+describe('/api/refresh', () => {
+  const req = { method: 'POST', query: {}, headers: {} } as unknown as NextApiRequest;
+  let res: NextApiResponse;
+
+  beforeEach(() => {
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as NextApiResponse;
+
+    jest.clearAllMocks();
+
+    (db.sync as jest.Mock).mockResolvedValue(undefined);
+    (verifyUser as jest.Mock).mockReturnValue('authorized');
+    (getAppSettings as jest.Mock).mockResolvedValue({ scraper_type: 'serpapi' });
+    (Keyword.update as jest.Mock).mockResolvedValue([1]);
+  });
+
+  it('rejects requests with no valid keyword IDs', async () => {
+    req.query = { id: 'abc,NaN' };
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'No valid keyword IDs provided' });
+    expect(Keyword.findAll).not.toHaveBeenCalled();
+  });
+
+  it('returns serialized scraper errors from refreshAndUpdateKeywords', async () => {
+    req.query = { id: '1', domain: 'example.com' };
+
+    const keywordRecord = { ID: 1, domain: 'example.com' };
+    (Keyword.findAll as jest.Mock).mockResolvedValue([keywordRecord]);
+    (Domain.findAll as jest.Mock).mockResolvedValue([
+      { get: () => ({ domain: 'example.com', scrape_enabled: true }) },
+    ]);
+
+    (refreshAndUpdateKeywords as jest.Mock).mockRejectedValue(new Error('scraper failed'));
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'scraper failed' });
+  });
+});

--- a/__tests__/components/AdWordsSettings.test.tsx
+++ b/__tests__/components/AdWordsSettings.test.tsx
@@ -1,0 +1,80 @@
+import { act, render, waitFor } from '@testing-library/react';
+import AdWordsSettings from '../../components/settings/AdWordsSettings';
+
+const toastMock = jest.fn();
+
+jest.mock('react-hot-toast', () => ({
+   __esModule: true,
+   default: (...args: unknown[]) => toastMock(...args),
+}));
+
+const mutateMock = jest.fn();
+
+jest.mock('../../services/adwords', () => ({
+   useTestAdwordsIntegration: jest.fn(() => ({ mutate: mutateMock, isLoading: false })),
+   useMutateKeywordsVolume: jest.fn(() => ({ mutate: mutateMock, isLoading: false })),
+}));
+
+describe('AdWordsSettings postMessage integration', () => {
+   const baseSettings = {
+      adwords_client_id: 'client',
+      adwords_client_secret: 'secret',
+      adwords_developer_token: 'dev',
+      adwords_account_id: '123-456-7890',
+      adwords_refresh_token: 'token',
+      keywordsColumns: [],
+   } as any;
+
+   const noop = () => undefined;
+
+   beforeEach(() => {
+      jest.clearAllMocks();
+   });
+
+   it('handles successful integration messages', async () => {
+      const performUpdate = jest.fn().mockResolvedValue(undefined);
+      render(
+         <AdWordsSettings
+            settings={baseSettings}
+            settingsError={null}
+            updateSettings={noop}
+            performUpdate={performUpdate}
+            closeSettings={noop}
+         />,
+      );
+
+      await act(async () => {
+         window.dispatchEvent(new MessageEvent('message', {
+            origin: window.location.origin,
+            data: { type: 'adwordsIntegrated', status: 'success' },
+         }));
+      });
+
+      await waitFor(() => {
+         expect(performUpdate).toHaveBeenCalled();
+      });
+      expect(toastMock).toHaveBeenCalledWith('Google Ads has been integrated successfully!', { icon: '✔️' });
+   });
+
+   it('shows the upstream error message when integration fails', async () => {
+      render(
+         <AdWordsSettings
+            settings={baseSettings}
+            settingsError={null}
+            updateSettings={noop}
+            performUpdate={noop}
+            closeSettings={noop}
+         />,
+      );
+
+      const detail = 'Custom integration error';
+      await act(async () => {
+         window.dispatchEvent(new MessageEvent('message', {
+            origin: window.location.origin,
+            data: { type: 'adwordsIntegrated', status: 'error', message: detail },
+         }));
+      });
+
+      expect(toastMock).toHaveBeenCalledWith(detail, { icon: '⚠️' });
+   });
+});

--- a/__tests__/components/DomainItem.test.tsx
+++ b/__tests__/components/DomainItem.test.tsx
@@ -1,35 +1,87 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import DomainItem from '../../components/domains/DomainItem';
 import { dummyDomain } from '../../__mocks__/data';
 
+const toggleMutationMock = jest.fn();
 const updateThumbMock = jest.fn();
-const domainItemProps = {
+
+jest.mock('../../services/domains', () => ({
+   useUpdateDomainToggles: jest.fn(() => ({
+      mutateAsync: toggleMutationMock,
+      isLoading: false,
+   })),
+}));
+
+jest.mock('react-hot-toast', () => ({
+   __esModule: true,
+   default: jest.fn(),
+}));
+
+const defaultProps = {
    domain: dummyDomain,
    selected: false,
    isConsoleIntegrated: false,
    thumb: '',
    updateThumb: updateThumbMock,
+   screenshotsEnabled: true,
 };
 
 describe('DomainItem Component', () => {
+   beforeEach(() => {
+      jest.clearAllMocks();
+   });
+
    it('renders without crashing', async () => {
-      const { container } = render(<DomainItem {...domainItemProps} />);
+      const { container } = render(<DomainItem {...defaultProps} />);
       expect(container.querySelector('.domItem')).toBeInTheDocument();
    });
-   it('renders keywords count', async () => {
-      const { container } = render(<DomainItem {...domainItemProps} />);
-      const domStatskeywords = container.querySelector('.dom_stats div:nth-child(1)');
-      expect(domStatskeywords?.textContent).toBe('Keywords10');
-   });
-   it('renders avg position', async () => {
-      const { container } = render(<DomainItem {...domainItemProps} />);
+
+   it('renders keywords and average position stats', async () => {
+      const { container } = render(<DomainItem {...defaultProps} />);
+      const domStatsKeywords = container.querySelector('.dom_stats div:nth-child(1)');
       const domStatsAvg = container.querySelector('.dom_stats div:nth-child(2)');
+      expect(domStatsKeywords?.textContent).toBe('Keywords10');
       expect(domStatsAvg?.textContent).toBe('Avg position24');
    });
-   it('updates domain thumbnail on relevant button click', async () => {
-      const { container } = render(<DomainItem {...domainItemProps} />);
-      const reloadThumbbBtn = container.querySelector('.domain_thumb button');
-      if (reloadThumbbBtn) fireEvent.click(reloadThumbbBtn);
+
+   it('updates domain thumbnail when reload button is clicked', async () => {
+      const { container } = render(<DomainItem {...defaultProps} />);
+      const reloadThumbBtn = container.querySelector('.domain_thumb button');
+      expect(reloadThumbBtn).toBeInTheDocument();
+      if (reloadThumbBtn) {
+         fireEvent.click(reloadThumbBtn);
+      }
       expect(updateThumbMock).toHaveBeenCalledWith(dummyDomain.domain);
+   });
+
+   it('hides screenshot reload button when screenshots are disabled', () => {
+      const { container } = render(<DomainItem {...defaultProps} screenshotsEnabled={false} />);
+      expect(container.querySelector('.domain_thumb button')).not.toBeInTheDocument();
+   });
+
+   it('optimistically toggles tracking state', async () => {
+      toggleMutationMock.mockResolvedValueOnce(undefined);
+      render(<DomainItem {...defaultProps} />);
+
+      const toggle = screen.getByLabelText('Track keyword positions');
+      fireEvent.click(toggle);
+
+      expect(toggleMutationMock).toHaveBeenCalledWith({
+         domain: dummyDomain,
+         domainSettings: { scrape_enabled: false },
+      });
+   });
+
+   it('optimistically toggles notifications state', async () => {
+      toggleMutationMock.mockResolvedValueOnce(undefined);
+      render(<DomainItem {...defaultProps} />);
+
+      const toggle = screen.getByLabelText('Send notification emails');
+      fireEvent.click(toggle);
+
+      expect(toggleMutationMock).toHaveBeenCalledWith({
+         domain: dummyDomain,
+         domainSettings: { notify_enabled: false },
+      });
    });
 });

--- a/__tests__/services/domains.env.test.ts
+++ b/__tests__/services/domains.env.test.ts
@@ -1,0 +1,44 @@
+type FetchDomainScreenshot = (domain: string, forceFetch?: boolean) => Promise<string | false>;
+
+describe('domains service environment toggle', () => {
+   const originalEnv = process.env;
+
+   afterEach(() => {
+      process.env = { ...originalEnv };
+      jest.resetModules();
+   });
+
+   it('enables screenshots by default', () => {
+      let screenshotsEnabled: boolean | undefined;
+      jest.isolateModules(() => {
+         const mod = require('../../services/domains');
+         screenshotsEnabled = mod.SCREENSHOTS_ENABLED;
+      });
+      expect(screenshotsEnabled).toBe(true);
+   });
+
+   it('disables screenshot fetching when NEXT_PUBLIC_SCREENSHOTS is false', async () => {
+      process.env = { ...originalEnv, NEXT_PUBLIC_SCREENSHOTS: 'false' };
+      jest.resetModules();
+
+      let fetchDomainScreenshot: FetchDomainScreenshot | undefined;
+      jest.isolateModules(() => {
+         const mod = require('../../services/domains');
+         expect(mod.SCREENSHOTS_ENABLED).toBe(false);
+         fetchDomainScreenshot = mod.fetchDomainScreenshot;
+      });
+
+      const originalFetch = global.fetch;
+      if (!originalFetch) {
+         (global as typeof globalThis & { fetch: jest.Mock }).fetch = jest.fn();
+      }
+      const fetchSpy = jest.spyOn(global, 'fetch');
+      const result = await (fetchDomainScreenshot as FetchDomainScreenshot)('example.com');
+      expect(result).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+      if (!originalFetch) {
+         delete (global as typeof globalThis & { fetch?: jest.Mock }).fetch;
+      }
+   });
+});

--- a/__tests__/utils/client/chartBounds.test.ts
+++ b/__tests__/utils/client/chartBounds.test.ts
@@ -1,0 +1,23 @@
+import { calculateChartBounds } from '../../../utils/client/chartBounds';
+
+describe('calculateChartBounds', () => {
+   it('returns default bounds when no valid points are provided', () => {
+      expect(calculateChartBounds([0, 111, NaN])).toEqual({ min: 1, max: 100 });
+   });
+
+   it('applies padding around the min and max values for rank charts', () => {
+      const bounds = calculateChartBounds([10, 20, 30]);
+      expect(bounds).toEqual({ min: 8, max: 32 });
+   });
+
+   it('ensures min and max differ when all values are identical', () => {
+      const bounds = calculateChartBounds([5, 5, 5]);
+      expect(bounds.min).toBeLessThan(bounds.max as number);
+      expect(bounds).toEqual({ min: 4, max: 6 });
+   });
+
+   it('supports forward charts without enforcing a 100 ceiling', () => {
+      const bounds = calculateChartBounds([50, 75, 90], { reverse: false, noMaxLimit: true });
+      expect(bounds).toEqual({ min: 46, max: 94 });
+   });
+});

--- a/components/common/Chart.tsx
+++ b/components/common/Chart.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend } from 'chart.js';
 import { Line } from 'react-chartjs-2';
+import { calculateChartBounds } from '../../utils/client/chartBounds';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
-type ChartProps ={
-   labels: string[],
-   series: number[],
-   reverse? : boolean,
-   noMaxLimit?: boolean
-}
+type ChartProps = {
+   labels: string[];
+   series: number[];
+   reverse?: boolean;
+   noMaxLimit?: boolean;
+};
 
-const Chart = ({ labels, series, reverse = true, noMaxLimit = false }:ChartProps) => {
+const Chart = ({ labels, series, reverse = true, noMaxLimit = false }: ChartProps) => {
+   const { min, max } = calculateChartBounds(series, { reverse, noMaxLimit });
    const options = {
       responsive: true,
       maintainAspectRatio: false,
@@ -19,21 +21,22 @@ const Chart = ({ labels, series, reverse = true, noMaxLimit = false }:ChartProps
       scales: {
          y: {
             reverse,
-            min: 1,
-            max: !noMaxLimit && reverse ? 100 : undefined,
+            min,
+            max,
          },
       },
       plugins: {
          legend: {
-             display: false,
+            display: false,
          },
-     },
+      },
    };
 
-   return <Line
-            datasetIdKey='XXX'
-            options={options}
-            data={{
+   return (
+      <Line
+         datasetIdKey="XXX"
+         options={options}
+         data={{
             labels,
             datasets: [
                {
@@ -43,8 +46,9 @@ const Chart = ({ labels, series, reverse = true, noMaxLimit = false }:ChartProps
                   backgroundColor: 'rgba(31, 205, 176, 0.5)',
                },
             ],
-            }}
-         />;
+         }}
+      />
+   );
 };
 
 export default Chart;

--- a/components/common/ChartSlim.tsx
+++ b/components/common/ChartSlim.tsx
@@ -1,17 +1,19 @@
 import React from 'react';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler } from 'chart.js';
 import { Line } from 'react-chartjs-2';
+import { calculateChartBounds } from '../../utils/client/chartBounds';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Filler, Title, Tooltip, Legend);
 
-type ChartProps ={
-   labels: string[],
-   series: number[],
-   noMaxLimit?: boolean,
-   reverse?: boolean
-}
+type ChartProps = {
+   labels: string[];
+   series: number[];
+   noMaxLimit?: boolean;
+   reverse?: boolean;
+};
 
-const ChartSlim = ({ labels, series, noMaxLimit = false, reverse = true }:ChartProps) => {
+const ChartSlim = ({ labels, series, noMaxLimit = false, reverse = true }: ChartProps) => {
+   const { min, max } = calculateChartBounds(series, { reverse, noMaxLimit });
    const options = {
       responsive: true,
       maintainAspectRatio: false,
@@ -20,8 +22,8 @@ const ChartSlim = ({ labels, series, noMaxLimit = false, reverse = true }:ChartP
          y: {
             display: false,
             reverse,
-            min: 1,
-            max: noMaxLimit ? undefined : 100,
+            min,
+            max,
          },
          x: {
             display: false,
@@ -32,30 +34,32 @@ const ChartSlim = ({ labels, series, noMaxLimit = false, reverse = true }:ChartP
             enabled: false,
          },
          legend: {
-             display: false,
+            display: false,
          },
-     },
+      },
    };
 
-   return <div className='w-[80px] h-[30px] rounded border border-gray-200'>
+   return (
+      <div className="w-[80px] h-[30px] rounded border border-gray-200">
          <Line
-            datasetIdKey='XXX'
+            datasetIdKey="XXX"
             options={options}
             data={{
-            labels,
-            datasets: [
-               {
-                  fill: 'start',
-                  showLine: false,
-                  data: series,
-                  pointRadius: 0,
-                  borderColor: 'rgb(31, 205, 176)',
-                  backgroundColor: 'rgba(31, 205, 176, 0.5)',
-               },
-            ],
+               labels,
+               datasets: [
+                  {
+                     fill: 'start',
+                     showLine: false,
+                     data: series,
+                     pointRadius: 0,
+                     borderColor: 'rgb(31, 205, 176)',
+                     backgroundColor: 'rgba(31, 205, 176, 0.5)',
+                  },
+               ],
             }}
          />
-         </div>;
+      </div>
+   );
 };
 
 export default ChartSlim;

--- a/components/common/ToggleField.tsx
+++ b/components/common/ToggleField.tsx
@@ -1,11 +1,35 @@
+import React from 'react';
+
 type ToggleFieldProps = {
    label: string;
    value: boolean;
    onChange: (bool:boolean) => void ;
    classNames?: string;
+   disabled?: boolean;
+   stopPropagation?: boolean;
 }
 
-const ToggleField = ({ label = '', value = false, onChange, classNames = '' }: ToggleFieldProps) => {
+const ToggleField = ({
+   label = '',
+   value = false,
+   onChange,
+   classNames = '',
+   disabled = false,
+   stopPropagation = false,
+}: ToggleFieldProps) => {
+   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (disabled) {
+         event.preventDefault();
+         event.stopPropagation();
+         return;
+      }
+      if (stopPropagation) {
+         event.preventDefault();
+         event.stopPropagation();
+      }
+      onChange(!value);
+   };
+
    return (
       <div className={`field--toggle w-full relative ${classNames}`}>
          <label className="relative inline-flex items-center cursor-pointer w-full justify-between">
@@ -15,7 +39,8 @@ const ToggleField = ({ label = '', value = false, onChange, classNames = '' }: T
             value={value.toString()}
             checked={!!value}
             className="sr-only peer"
-            onChange={() => onChange(!value)}
+            onChange={handleChange}
+            disabled={disabled}
             />
             <div className="relative rounded-3xl w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4
             peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800rounded-full peer dark:bg-gray-700

--- a/components/domains/DomainItem.tsx
+++ b/components/domains/DomainItem.tsx
@@ -4,7 +4,10 @@
 import TimeAgo from 'react-timeago';
 import dayjs from 'dayjs';
 import Link from 'next/link';
+import toast from 'react-hot-toast';
 import Icon from '../common/Icon';
+import ToggleField from '../common/ToggleField';
+import { useUpdateDomainToggles } from '../../services/domains';
 
 type DomainItemProps = {
    domain: DomainType,
@@ -12,10 +15,32 @@ type DomainItemProps = {
    isConsoleIntegrated: boolean,
    thumb: string,
    updateThumb: Function,
+   screenshotsEnabled?: boolean,
 }
 
-const DomainItem = ({ domain, selected, isConsoleIntegrated = false, thumb, updateThumb }: DomainItemProps) => {
+const DomainItem = ({
+   domain,
+   selected,
+   isConsoleIntegrated = false,
+   thumb,
+   updateThumb,
+   screenshotsEnabled = true,
+}: DomainItemProps) => {
    const { keywordsUpdated, slug, keywordCount = 0, avgPosition = 0, scVisits = 0, scImpressions = 0, scPosition = 0 } = domain;
+   const { mutateAsync: updateDomainToggle, isLoading: isToggleUpdating } = useUpdateDomainToggles();
+
+   const handleToggle = async (field: 'scrape_enabled' | 'notify_enabled', value: boolean) => {
+      const payload = { [field]: value } as Partial<DomainSettings>;
+      try {
+         await updateDomainToggle({ domain, domainSettings: payload });
+         const message = field === 'scrape_enabled'
+            ? `${domain.domain} tracking ${value ? 'enabled' : 'paused'}.`
+            : `${domain.domain} notifications ${value ? 'enabled' : 'paused'}.`;
+         toast(message, { icon: '✔️' });
+      } catch (error) {
+         console.log('Error updating domain toggle', error);
+      }
+   };
    // const router = useRouter();
    return (
       <div className={`domItem bg-white border rounded w-full text-sm mb-10 hover:border-indigo-200 ${selected ? '' : ''}`}>
@@ -23,14 +48,16 @@ const DomainItem = ({ domain, selected, isConsoleIntegrated = false, thumb, upda
             <div className={`flex-1 p-6 flex ${!isConsoleIntegrated ? 'basis-1/3' : ''}`}>
                <div className="group domain_thumb w-20 h-20 mr-6 bg-slate-100 rounded
                   border border-gray-200 overflow-hidden flex justify-center relative">
-                  <button
-                     className=' absolute right-1 top-0 text-gray-400 p-1 transition-all
-                     invisible opacity-0 group-hover:visible group-hover:opacity-100 hover:text-gray-600 z-10'
-                     title='Reload Website Screenshot'
-                     onClick={(e) => { e.preventDefault(); e.stopPropagation(); updateThumb(domain.domain); }}
-                  >
-                     <Icon type="reload" size={12} />
-                  </button>
+                  {screenshotsEnabled && (
+                     <button
+                        className=' absolute right-1 top-0 text-gray-400 p-1 transition-all
+                        invisible opacity-0 group-hover:visible group-hover:opacity-100 hover:text-gray-600 z-10'
+                        title='Reload Website Screenshot'
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); updateThumb(domain.domain); }}
+                     >
+                        <Icon type="reload" size={12} />
+                     </button>
+                  )}
                   <img
                   className={`self-center ${!thumb ? 'max-w-[50px]' : ''}`}
                   src={thumb || `https://www.google.com/s2/favicons?domain=${domain.domain}&sz=128`} alt={domain.domain}
@@ -56,6 +83,22 @@ const DomainItem = ({ domain, selected, isConsoleIntegrated = false, thumb, upda
                   <div className="flex-1 relative">
                      <span className='block text-xs lg:text-sm text-gray-500 mb-1'>Avg position</span>{avgPosition}
                   </div>
+               </div>
+               <div className='mt-4 flex flex-col gap-3 text-xs'>
+                  <ToggleField
+                     label='Track keyword positions'
+                     value={domain.scrape_enabled !== false}
+                     onChange={(next) => handleToggle('scrape_enabled', next)}
+                     disabled={isToggleUpdating}
+                     stopPropagation
+                  />
+                  <ToggleField
+                     label='Send notification emails'
+                     value={domain.notify_enabled !== false && domain.notification !== false}
+                     onChange={(next) => handleToggle('notify_enabled', next)}
+                     disabled={isToggleUpdating}
+                     stopPropagation
+                  />
                </div>
             </div>
             {isConsoleIntegrated && (

--- a/components/keywords/AddKeywords.tsx
+++ b/components/keywords/AddKeywords.tsx
@@ -198,7 +198,7 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
                      outline-none focus:border-indigo-300 ${!allowsCity ? ' cursor-not-allowed' : ''} `}
                      disabled={!allowsCity}
                      title={!allowsCity ? `Your scraper ${scraperName} doesn't have city level scraping feature.` : ''}
-                     placeholder={`State (Optional)${!allowsCity ? `. Not available for ${scraperName}.` : ''}`}
+                     placeholder={`State (Optional${!allowsCity ? ` — not available for ${scraperName}` : ''})`}
                      value={newKeywordsData.state}
                      onChange={(e) => setNewKeywordsData({ ...newKeywordsData, state: e.target.value })}
                   />
@@ -210,7 +210,7 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
                      outline-none focus:border-indigo-300 ${!allowsCity ? ' cursor-not-allowed' : ''} `}
                      disabled={!allowsCity}
                      title={!allowsCity ? `Your scraper ${scraperName} doesn't have city level scraping feature.` : ''}
-                     placeholder={`City (Optional)${!allowsCity ? `. Not available for ${scraperName}.` : ''}`}
+                     placeholder={`City (Optional${!allowsCity ? ` — not available for ${scraperName}` : ''})`}
                      value={newKeywordsData.city}
                      onChange={(e) => setNewKeywordsData({ ...newKeywordsData, city: e.target.value })}
                   />

--- a/database/migrations/1737005000000-add-domain-toggle-fields.js
+++ b/database/migrations/1737005000000-add-domain-toggle-fields.js
@@ -1,0 +1,67 @@
+// Migration: Adds scrape_enabled and notify_enabled flags to the domain table so
+// scraping and notification behaviour can be toggled per domain.
+
+module.exports = {
+   up: async function up(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib = params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
+
+      return queryInterface.sequelize.transaction(async (t) => {
+         try {
+            const domainTableDefinition = await queryInterface.describeTable('domain');
+
+            if (domainTableDefinition && !domainTableDefinition.scrape_enabled) {
+               await queryInterface.addColumn(
+                  'domain',
+                  'scrape_enabled',
+                  { type: SequelizeLib.DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+                  { transaction: t }
+               );
+            }
+
+            if (domainTableDefinition && !domainTableDefinition.notify_enabled) {
+               await queryInterface.addColumn(
+                  'domain',
+                  'notify_enabled',
+                  { type: SequelizeLib.DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+                  { transaction: t }
+               );
+
+               if (domainTableDefinition.notification) {
+                  await queryInterface.sequelize.query(
+                     'UPDATE domain SET notify_enabled = notification',
+                     { transaction: t }
+                  );
+               }
+            }
+         } catch (error) {
+            console.log('error :', error);
+            throw error;
+         }
+      });
+   },
+
+   down: async function down(params = {}) {
+      const queryInterface = params?.context ?? params;
+
+      return queryInterface.sequelize.transaction(async (t) => {
+         try {
+            const domainTableDefinition = await queryInterface.describeTable('domain');
+
+            if (domainTableDefinition && domainTableDefinition.notify_enabled) {
+               await queryInterface.removeColumn('domain', 'notify_enabled', { transaction: t });
+            }
+
+            if (domainTableDefinition && domainTableDefinition.scrape_enabled) {
+               await queryInterface.removeColumn('domain', 'scrape_enabled', { transaction: t });
+            }
+         } catch (error) {
+            console.log('error :', error);
+            throw error;
+         }
+      });
+   },
+};

--- a/database/models/domain.ts
+++ b/database/models/domain.ts
@@ -30,6 +30,12 @@ class Domain extends Model {
    @Column({ type: DataType.STRING, allowNull: true, defaultValue: JSON.stringify([]) })
    tags!: string;
 
+   @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: true })
+   scrape_enabled!: boolean;
+
+   @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: true })
+   notify_enabled!: boolean;
+
    @Column({ type: DataType.BOOLEAN, allowNull: true, defaultValue: true })
    notification!: boolean;
 

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -39,14 +39,17 @@ const notify = async (req: NextApiRequest, res: NextApiResponse<NotifyResponse>)
       if (reqDomain) {
          const theDomain = await Domain.findOne({ where: { domain: reqDomain } });
          if (theDomain) {
-            await sendNotificationEmail(theDomain, settings);
+            const domainPlain = theDomain.get({ plain: true }) as DomainType;
+            if (domainPlain.notify_enabled !== false && domainPlain.notification !== false) {
+               await sendNotificationEmail(domainPlain, settings);
+            }
          }
       } else {
          const allDomains: Domain[] = await Domain.findAll();
          if (allDomains && allDomains.length > 0) {
             const domains = allDomains.map((el) => el.get({ plain: true }));
             for (const domain of domains) {
-               if (domain.notification !== false) {
+               if (domain.notify_enabled !== false && domain.notification !== false) {
                   await sendNotificationEmail(domain, settings);
                }
             }

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -8,7 +8,7 @@ import TopBar from '../../components/common/TopBar';
 import AddDomain from '../../components/domains/AddDomain';
 import Settings from '../../components/settings/Settings';
 import { useCheckMigrationStatus, useFetchSettings, useMigrateDatabase } from '../../services/settings';
-import { fetchDomainScreenshot, useFetchDomains } from '../../services/domains';
+import { fetchDomainScreenshot, useFetchDomains, SCREENSHOTS_ENABLED } from '../../services/domains';
 import DomainItem from '../../components/domains/DomainItem';
 import Icon from '../../components/common/Icon';
 import Footer from '../../components/common/Footer';
@@ -76,6 +76,7 @@ const Domains: NextPage = () => {
    }, [domainsData]);
 
    useEffect(() => {
+      if (!SCREENSHOTS_ENABLED) { return; }
       if (domainsData?.domains && domainsData.domains.length > 0) {
          const fetchAllScreenshots = async () => {
             const screenshotPromises = domainsData.domains.map(async (domain: DomainType) => {
@@ -109,6 +110,7 @@ const Domains: NextPage = () => {
    }, [domainsData]);
 
    const manuallyUpdateThumb = async (domain: string) => {
+      if (!SCREENSHOTS_ENABLED) { return; }
       if (domain) {
          const domainThumb = await fetchDomainScreenshot(domain, true);
          if (domainThumb) {
@@ -163,6 +165,7 @@ const Domains: NextPage = () => {
                            isConsoleIntegrated={!!(appSettings && appSettings.search_console_integrated) || !!domainSCAPiObj[domain.ID] }
                            thumb={domainThumbs[domain.domain]}
                            updateThumb={manuallyUpdateThumb}
+                           screenshotsEnabled={SCREENSHOTS_ENABLED}
                            // isConsoleIntegrated={false}
                            />;
                })}

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,6 +3,8 @@ type DomainType = {
    domain: string,
    slug: string,
    tags?: string,
+   scrape_enabled?: boolean,
+   notify_enabled?: boolean,
    notification: boolean,
    notification_interval: string,
    notification_emails: string,
@@ -75,7 +77,9 @@ type DomainSearchConsole = {
 type DomainSettings = {
    notification_interval: string,
    notification_emails: string,
-   search_console?: DomainSearchConsole
+   search_console?: DomainSearchConsole,
+   scrape_enabled?: boolean,
+   notify_enabled?: boolean,
 }
 
 type SettingsType = {

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -242,7 +242,7 @@ export const getAdwordsKeywordIdeas = async (credentials: AdwordsCredentials, ad
 
    let fetchedKeywords: IdeaKeyword[] = [];
    if (accessToken) {
-      const seedKeywords = [...keywords];
+      let seedKeywords = [...keywords];
 
       // Load Keywords from Google Search Console File.
       if ((seedType === 'searchconsole' || seedSCKeywords) && domainUrl) {

--- a/utils/client/chartBounds.ts
+++ b/utils/client/chartBounds.ts
@@ -1,0 +1,53 @@
+type ChartBoundsOptions = {
+   reverse?: boolean;
+   noMaxLimit?: boolean;
+};
+
+const isValidPoint = (value: unknown): value is number => {
+   return typeof value === 'number'
+      && Number.isFinite(value)
+      && value !== 0
+      && value !== 111;
+};
+
+const clamp = (value: number, min: number, max: number) => {
+   return Math.min(Math.max(value, min), max);
+};
+
+export const calculateChartBounds = (series: number[], options: ChartBoundsOptions = {}) => {
+   const { reverse = true, noMaxLimit = false } = options;
+   const validValues = series.filter(isValidPoint);
+
+   if (validValues.length === 0) {
+      return {
+         min: reverse ? 1 : 0,
+         max: !noMaxLimit && reverse ? 100 : undefined,
+      };
+   }
+
+   const minValue = Math.min(...validValues);
+   const maxValue = Math.max(...validValues);
+   const range = Math.max(maxValue - minValue, 1);
+   const padding = Math.max(1, Math.round(range * 0.1));
+
+   const minFloor = reverse ? 1 : 0;
+   const maxCeil = reverse && !noMaxLimit ? 100 : Number.POSITIVE_INFINITY;
+
+   let min = clamp(minValue - padding, minFloor, maxCeil);
+   let max = clamp(maxValue + padding, minFloor, maxCeil);
+
+   if (min >= max) {
+      min = clamp(minValue - 1, minFloor, maxCeil);
+      max = clamp(maxValue + 1, minFloor, maxCeil);
+      if (min >= max) {
+         max = clamp(min + 1, minFloor, maxCeil);
+      }
+   }
+
+   return {
+      min,
+      max: noMaxLimit ? max : (reverse ? clamp(max, minFloor, 100) : max),
+   };
+};
+
+export default calculateChartBounds;

--- a/utils/client/generateChartData.ts
+++ b/utils/client/generateChartData.ts
@@ -18,9 +18,10 @@ export const generateChartData = (history: KeywordHistory): ChartData => {
       // If have a missing serp in between dates, use the previous date's serp to fill the gap.
       const pastDateKey = `${pastDate.getFullYear()}-${pastDate.getMonth() + 1}-${pastDate.getDate()}`;
       const serpOftheDate = history[pastDateKey];
-      const lastLargestSerp = lastFoundSerp > 0 ? lastFoundSerp : 0;
-      seriesDates[pastDateKey] = history[pastDateKey] ? history[pastDateKey] : lastLargestSerp;
-      if (lastFoundSerp < serpOftheDate) { lastFoundSerp = serpOftheDate; }
+      const serpValue = typeof serpOftheDate === 'number' && serpOftheDate > 0 ? serpOftheDate : undefined;
+      const fallbackSerp = lastFoundSerp > 0 ? lastFoundSerp : 111;
+      seriesDates[pastDateKey] = serpValue ?? fallbackSerp;
+      if (typeof serpValue === 'number') { lastFoundSerp = serpValue; }
    }
 
    return { labels: priorDates, series: Object.values(seriesDates) };
@@ -44,8 +45,10 @@ export const generateTheChartData = (history: KeywordHistory, time:string = '30'
          // If have a missing serp in between dates, use the previous date's serp to fill the gap.
          const pastDateKey = `${pastDate.getFullYear()}-${pastDate.getMonth() + 1}-${pastDate.getDate()}`;
          const prevSerp = history[pastDateKey];
-         const serpVal = prevSerp || (lastFoundSerp > 0 ? lastFoundSerp : 111);
-         if (serpVal !== 0) { lastFoundSerp = prevSerp; }
+         const serpVal = (typeof prevSerp === 'number' && prevSerp > 0)
+            ? prevSerp
+            : (lastFoundSerp > 0 ? lastFoundSerp : 111);
+         if (typeof prevSerp === 'number' && prevSerp > 0) { lastFoundSerp = prevSerp; }
          chartData.labels.push(pastDateKey);
          chartData.series.push(serpVal);
       }

--- a/utils/searchConsole.ts
+++ b/utils/searchConsole.ts
@@ -44,7 +44,9 @@ export const isSearchConsoleDataFreshForToday = (
  */
 const fetchSearchConsoleData = async (domain:DomainType, days:number, type?:string, api?:SCAPISettings): Promise<fetchConsoleDataResponse> => {
    if (!domain) return { error: true, errorMsg: 'Domain Not Provided!' };
-   if (!api?.private_key || !api?.client_email) return { error: true, errorMsg: 'Search Console API Data Not Available.' };
+   if (!api?.private_key || !api?.client_email) {
+      return { error: true, errorMsg: 'Search Console API data is not available.' };
+   }
    const domainName = domain.domain;
    const defaultSCSettings = { property_type: 'domain', url: '', client_email: '', private_key: '' };
    const domainSettings = domain.search_console ? JSON.parse(domain.search_console) : defaultSCSettings;


### PR DESCRIPTION
## Summary
- add scrape/notify domain toggles with persistence, API enforcement, UI wiring, and migration
- enhance Google Ads integration with HTML callback, resilient parsing, and refreshed settings listener
- compute chart bounds dynamically, add screenshot env flag handling, and refresh API error propagation

## Testing
- npm run lint
- npm run lint:css
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d135c066e8832a923f045ddd426156