### PR TITLE
Fix Serply API URL parameters and add Jest coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### Changed
 
 * Added per-domain `scrape_enabled`/`notify_enabled` toggles with database migration, cached UI updates, and API/cron guards so paused domains skip scraping and email runs.
+* Updated the Serply scraper to build `/v1/search` URLs with query-string parameters so the keyword travels via `?q=` alongside locale and pagination options.
 * Introduced dynamic chart bounds and a shared client helper so SERP line charts and sparklines zoom to the observed rank range instead of hard-coding 1–100.
 * Honoured the `NEXT_PUBLIC_SCREENSHOTS` environment flag in services and the dashboard so deployments can opt out of screenshot fetches and rely on favicons without UI clutter.
 * Returned an HTML OAuth callback from `/api/adwords` that posts an `adwordsIntegrated` message, accepted empty keyword-idea validation responses, and surfaced upstream errors in the settings toast listener.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ If you don't want to use proxies, you can use third party Scraping services to s
 | hasdata.com       | From $29/mo   | From 10,000/mo | Yes |
 
 The Scraping Robot integration now explicitly sends both Google locale parameters—`hl` for language and `gl` for geographic targeting—and percent-encodes the nested Google Search URL so the returned SERP data matches the country configured for each keyword.
+Serply API requests now encode the keyword, pagination count, and language as query-string parameters (`?q=...&num=100&hl=...`) so the upstream service receives the correct filters.
 
 **Tech Stack**
 

--- a/__tests__/scrapers/serply.test.ts
+++ b/__tests__/scrapers/serply.test.ts
@@ -1,0 +1,44 @@
+import serply from '../../scrapers/services/serply';
+
+describe('serply scraper', () => {
+  const settings = { scraping_api: 'token-123' } as any;
+
+  it('generates a query-string based API URL with search parameters', () => {
+    const keyword = {
+      keyword: 'best coffee beans',
+      country: 'US',
+      device: 'desktop',
+    } as any;
+
+    const url = serply.scrapeURL(keyword, settings, undefined as any);
+    const parsed = new URL(url);
+
+    expect(parsed.origin).toBe('https://api.serply.io');
+    expect(parsed.pathname).toBe('/v1/search');
+    expect(parsed.searchParams.get('q')).toBe(keyword.keyword);
+    expect(parsed.searchParams.get('num')).toBe('100');
+    expect(parsed.searchParams.get('hl')).toBe(keyword.country);
+  });
+
+  it('preserves header configuration for device and country handling', () => {
+    const mobileKeyword = {
+      keyword: 'espresso machines',
+      country: 'CA',
+      device: 'mobile',
+    } as any;
+
+    const desktopKeyword = {
+      keyword: 'espresso machines',
+      country: 'ZZ',
+      device: 'desktop',
+    } as any;
+
+    const mobileHeaders = serply.headers(mobileKeyword, settings, undefined as any);
+    const desktopHeaders = serply.headers(desktopKeyword, settings, undefined as any);
+
+    expect(mobileHeaders['X-User-Agent']).toBe('mobile');
+    expect(mobileHeaders['X-Proxy-Location']).toBe('CA');
+    expect(desktopHeaders['X-User-Agent']).toBe('desktop');
+    expect(desktopHeaders['X-Proxy-Location']).toBe('US');
+  });
+});

--- a/scrapers/services/serply.ts
+++ b/scrapers/services/serply.ts
@@ -20,7 +20,12 @@ const serply:ScraperSettings = {
    },
    scrapeURL: (keyword) => {
       const country = scraperCountries.includes(keyword.country.toUpperCase()) ? keyword.country : 'US';
-      return `https://api.serply.io/v1/search/q=${encodeURIComponent(keyword.keyword)}&num=100&hl=${country}`;
+      const searchParams = new URLSearchParams({
+         q: keyword.keyword,
+         num: '100',
+         hl: country,
+      });
+      return `https://api.serply.io/v1/search?${searchParams.toString()}`;
    },
    resultObjectKey: 'result',
    serpExtractor: (content) => {


### PR DESCRIPTION
## Summary
- update the Serply scraper URL builder to encode keyword, language, and pagination as query-string parameters
- add Jest coverage that validates the new URL shape and ensures the headers logic stays intact
- document the Serply change in the changelog and README

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14bbd808c832a8589836eae92e849