### PR TITLE
feat: unify domain active toggles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Changed
 
-* Added per-domain `scrape_enabled`/`notify_enabled` toggles with database migration, cached UI updates, and API/cron guards so paused domains skip scraping and email runs.
+* Replaced the separate per-domain `scrape_enabled`/`notify_enabled` toggles with a unified Active/Deactive control that keeps both flags in sync across cached UI state, API payloads, and cron guards so paused domains skip scraping and email runs together.
 * Updated the Serply scraper to build `/v1/search` URLs with query-string parameters so the keyword travels via `?q=` alongside locale and pagination options.
 * Introduced dynamic chart bounds and a shared client helper so SERP line charts and sparklines zoom to the observed rank range instead of hard-coding 1–100.
 * Honoured the `NEXT_PUBLIC_SCREENSHOTS` environment flag in services and the dashboard so deployments can opt out of screenshot fetches and rely on favicons without UI clutter.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SerpBear is an Open Source Search Engine Position Tracking and Keyword Research 
 - **Email Notification:** Get notified of your keyword position changes daily/weekly/monthly through email.
 - **SERP API:** SerpBear comes with built-in API that you can use for your marketing & data reporting tools.
 - **Keyword Research:** Ability to research keywords and auto-generate keyword ideas from your tracked website's content by integrating your Google Ads test account.
-- **Domain-level toggles:** Pause scraping or notification email delivery per domain; UI switches update instantly and API/cron jobs skip disabled domains.
+- **Domain-level status toggle:** Flip domains between Active and Deactive states to pause both scraping and notification email delivery; UI switches update instantly and API/cron jobs skip disabled domains.
 - **Auto-zooming charts:** Rank trend charts now compute dynamic min/max bounds so sparkline and full charts focus on the captured data instead of the entire 1–100 range.
 - **Google Search Console Integration:** Get the actual visit count, impressions & more for each keyword. Cached data refreshes automatically once per cron day based on the configured timezone, can be manually refreshed from settings, and falls back to global credentials when domain-level credentials aren't configured. Dashboards now automatically refetch when switching between domains thanks to slug-keyed queries, ensuring the Search Console view and insight reports stay aligned with the active property.
 - **Mobile App:** Add the PWA app to your mobile for a better mobile experience.

--- a/__tests__/components/DomainItem.test.tsx
+++ b/__tests__/components/DomainItem.test.tsx
@@ -59,29 +59,38 @@ describe('DomainItem Component', () => {
       expect(container.querySelector('.domain_thumb button')).not.toBeInTheDocument();
    });
 
-   it('optimistically toggles tracking state', async () => {
+   it('renders the unified active toggle', () => {
+      render(<DomainItem {...defaultProps} />);
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+      expect(screen.getByLabelText('Toggle domain active status')).toBeInTheDocument();
+   });
+
+   it('submits a combined toggle payload', async () => {
       toggleMutationMock.mockResolvedValueOnce(undefined);
       render(<DomainItem {...defaultProps} />);
 
-      const toggle = screen.getByLabelText('Track keyword positions');
+      const toggle = screen.getByLabelText('Toggle domain active status');
       fireEvent.click(toggle);
 
       expect(toggleMutationMock).toHaveBeenCalledWith({
          domain: dummyDomain,
-         domainSettings: { scrape_enabled: false },
+         domainSettings: { scrape_enabled: false, notify_enabled: false },
       });
    });
 
-   it('optimistically toggles notifications state', async () => {
-      toggleMutationMock.mockResolvedValueOnce(undefined);
-      render(<DomainItem {...defaultProps} />);
+   it('displays the deactive label when domain toggles are disabled', () => {
+      const inactiveDomain = {
+         ...dummyDomain,
+         scrape_enabled: false,
+         notify_enabled: false,
+         notification: false,
+      };
 
-      const toggle = screen.getByLabelText('Send notification emails');
-      fireEvent.click(toggle);
+      render(<DomainItem {...defaultProps} domain={inactiveDomain} />);
 
-      expect(toggleMutationMock).toHaveBeenCalledWith({
-         domain: dummyDomain,
-         domainSettings: { notify_enabled: false },
-      });
+      expect(screen.getByText('Deactive')).toBeInTheDocument();
+      const toggle = screen.getByLabelText('Toggle domain active status') as HTMLInputElement;
+      expect(toggle.checked).toBe(false);
    });
 });

--- a/__tests__/components/DomainSettings.test.tsx
+++ b/__tests__/components/DomainSettings.test.tsx
@@ -29,6 +29,9 @@ const mockDomain: DomainType = {
    added: '2023-01-01',
    updated: '2023-01-01',
    tags: '',
+   scrape_enabled: true,
+   notify_enabled: true,
+   notification: true,
    notification_interval: 'daily',
    notification_emails: 'test@example.com',
    search_console: JSON.stringify({
@@ -97,6 +100,43 @@ describe('DomainSettings Component', () => {
       expect(screen.getByText('Domain Settings')).toBeInTheDocument();
       expect(screen.getByText('Notification')).toBeInTheDocument();
       expect(screen.getByText('Search Console')).toBeInTheDocument();
+   });
+
+   it('syncs scrape and notify flags when toggling the unified active control', async () => {
+      mockUseFetchDomain.mockImplementation(() => {});
+      const mutateMock = jest.fn();
+      mockUseUpdateDomain.mockReturnValue({
+         mutate: mutateMock,
+         error: null,
+         isLoading: false,
+      });
+
+      renderWithQueryClient(
+         <DomainSettings domain={mockDomain} closeModal={mockCloseModal} />,
+      );
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+      const toggle = screen.getByLabelText('Toggle domain active status');
+      fireEvent.click(toggle);
+
+      await waitFor(() => {
+         expect(screen.getByText('Deactive')).toBeInTheDocument();
+      });
+
+      const updateButton = screen.getByText('Update Settings');
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+         expect(mutateMock).toHaveBeenCalled();
+      });
+
+      expect(mutateMock).toHaveBeenCalledWith({
+         domain: mockDomain,
+         domainSettings: expect.objectContaining({
+            scrape_enabled: false,
+            notify_enabled: false,
+         }),
+      });
    });
 
    it('preserves user changes to other settings when async fetch completes (functional state update fix)', async () => {

--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -71,7 +71,7 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
       }));
    };
 
-   const isDomainActive = (domainSettings.scrape_enabled !== false) && (domainSettings.notify_enabled !== false);
+   const isDomainActive = domainSettings.scrape_enabled !== false;
 
    const updateDomain = () => {
       let error: DomainSettingsError | null = null;


### PR DESCRIPTION
## Summary
- replace the separate tracking and notification toggles with a unified Active/Deactive control in the domain list and settings modal while keeping both flags in sync
- update unit tests and documentation to cover the new status toggle workflow

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14ee62300832aade3fbbf13d6dc7d