### PR TITLE
Add domain toggles, Ads OAuth callback, and chart bounds improvements

### DIFF
--- a/utils/refresh.ts
+++ b/utils/refresh.ts
@@ -40,6 +40,7 @@ const refreshAndUpdateKeywords = async (rawkeyword:Keyword[], settings:SettingsT
    if (skippedKeywords.length > 0) {
       const skippedIds = skippedKeywords.map((keyword) => keyword.ID);
       await Keyword.update({ updating: false }, { where: { ID: skippedIds } });
+      await Promise.all(skippedIds.map((id) => removeFromRetryQueue(id)));
    }
 
    if (eligibleKeywordModels.length === 0) { return []; }


### PR DESCRIPTION
## Summary
- add scrape/notify domain toggles with persistence, API enforcement, UI wiring, and migration
- enhance Google Ads integration with HTML callback, resilient parsing, and refreshed settings listener
- compute chart bounds dynamically, add screenshot env flag handling, and refresh API error propagation
- ensure keywords skipped when scraping is disabled are removed from the retry queue to keep cron traffic low

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1536ef334832a817520e94fffad6b