### PR TITLE
Remove ValueSerp pagination parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 * Replaced the separate per-domain `scrape_enabled`/`notify_enabled` toggles with a unified Active/Deactive control that keeps both flags in sync across cached UI state, API payloads, and cron guards so paused domains skip scraping and email runs together.
 * Updated the Serply scraper to build `/v1/search` URLs with query-string parameters so the keyword travels via `?q=` alongside locale and pagination options.
+* Updated the ValueSerp scraper to drop the hard-coded `num=100` query parameter while continuing to pass device, language, and optional location filters for each keyword.
 * Introduced dynamic chart bounds and a shared client helper so SERP line charts and sparklines zoom to the observed rank range instead of hard-coding 1–100.
 * Honoured the `NEXT_PUBLIC_SCREENSHOTS` environment flag in services and the dashboard so deployments can opt out of screenshot fetches and rely on favicons without UI clutter.
 * Returned an HTML OAuth callback from `/api/adwords` that posts an `adwordsIntegrated` message, accepted empty keyword-idea validation responses, and surfaced upstream errors in the settings toast listener.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ If you don't want to use proxies, you can use third party Scraping services to s
 
 The Scraping Robot integration now explicitly sends both Google locale parameters—`hl` for language and `gl` for geographic targeting—and percent-encodes the nested Google Search URL so the returned SERP data matches the country configured for each keyword.
 Serply API requests now encode the keyword, pagination count, and language as query-string parameters (`?q=...&num=100&hl=...`) so the upstream service receives the correct filters.
+ValueSerp API calls now omit the `num` pagination parameter while still forwarding device, language, and optional location filters configured for each keyword.
 
 **Tech Stack**
 

--- a/__tests__/scrapers/valueserp.test.ts
+++ b/__tests__/scrapers/valueserp.test.ts
@@ -1,0 +1,37 @@
+import valueSerp from '../../scrapers/services/valueserp';
+
+describe('valueSerp scraper', () => {
+  const settings: Partial<SettingsType> = { scraping_api: 'token-123' };
+  const countryData = {
+    US: ['United States', 'Washington, D.C.', 'en', 2840],
+  } as any;
+
+  it('omits pagination parameter while preserving locale and device options', () => {
+    const keyword: Partial<KeywordType> = {
+      keyword: 'best coffee beans',
+      country: 'US',
+      device: 'mobile',
+      city: 'Miami',
+      state: 'FL',
+    };
+
+    const url = valueSerp.scrapeURL!(
+      keyword as KeywordType,
+      settings as SettingsType,
+      countryData
+    );
+    const parsed = new URL(url);
+
+    expect(parsed.origin).toBe('https://api.valueserp.com');
+    expect(parsed.pathname).toBe('/search');
+    expect(parsed.searchParams.get('q')).toBe(keyword.keyword);
+    expect(parsed.searchParams.get('gl')).toBe('US');
+    expect(parsed.searchParams.get('hl')).toBe('en');
+    expect(parsed.searchParams.get('device')).toBe('mobile');
+    expect(parsed.searchParams.get('location')).toBe('Miami,FL,United States');
+    expect(parsed.searchParams.get('output')).toBe('json');
+    expect(parsed.searchParams.get('include_answer_box')).toBe('false');
+    expect(parsed.searchParams.get('include_advertiser_info')).toBe('false');
+    expect(parsed.searchParams.has('num')).toBe(false);
+  });
+});

--- a/scrapers/services/valueserp.ts
+++ b/scrapers/services/valueserp.ts
@@ -20,8 +20,8 @@ const valueSerp:ScraperSettings = {
       const location = keyword.city || keyword.state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
       const device = keyword.device === 'mobile' ? '&device=mobile' : '';
       const lang = countryData[country][2];
-      console.log(`https://api.valueserp.com/search?api_key=${settings.scraping_api}&q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}${device}${location}&num=100&output=json&include_answer_box=false&include_advertiser_info=false`);
-      return `https://api.valueserp.com/search?api_key=${settings.scraping_api}&q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}${device}${location}&num=100&output=json&include_answer_box=false&include_advertiser_info=false`;
+      console.log(`https://api.valueserp.com/search?api_key=${settings.scraping_api}&q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}${device}${location}&output=json&include_answer_box=false&include_advertiser_info=false`);
+      return `https://api.valueserp.com/search?api_key=${settings.scraping_api}&q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}${device}${location}&output=json&include_answer_box=false&include_advertiser_info=false`;
    },
    resultObjectKey: 'organic_results',
    serpExtractor: (content) => {

--- a/utils/refresh.ts
+++ b/utils/refresh.ts
@@ -2,7 +2,7 @@ import { performance } from 'perf_hooks';
 import { setTimeout as sleep } from 'timers/promises';
 import { Op } from 'sequelize';
 import { readFile, writeFile } from 'fs/promises';
-import { Ref=reshResult, removeFromRetryQueue, retryScrape, scrapeKeywordFromGoogle } from './scraper';
+import { RefreshResult, removeFromRetryQueue, retryScrape, scrapeKeywordFromGoogle } from './scraper';
 import parseKeywords from './parseKeywords';
 import Keyword from '../database/models/keyword';
 import Domain from '../database/models/domain';


### PR DESCRIPTION
## Summary
- stop appending the num=100 query parameter to ValueSerp API URLs so only locale and device filters remain
- add unit coverage to confirm ValueSerp URL construction omits the pagination parameter while keeping language, location, and device options intact
- document the ValueSerp change and fix the RefreshResult import typo flagged by linting

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1679e2f7c832a9e4a1b64e66075b1