### PR TITLE
Remove mobile body gutters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Collapsed the global body gutters on mobile so dashboard content can span the full viewport width on phones.
 * Completely restructured `README.md` with a product-focused overview, expanded environment variable reference, and refreshed provider comparison to reflect the current codebase.
 * Replaced Jest's `jest-environment-jsdom` dependency with `@happy-dom/jest-environment` to eliminate deprecated transitive packages and speed up DOM-focused tests.
 * Added `npm run setup:git` to configure `init.defaultBranch` for the repository and avoid Git initialization warnings.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SerpBear is a full-stack Next.js application that tracks where your pages rank o
 - **Keyword research & ideas:** Pull search volumes and suggested keywords straight from your Google Ads test account.
 - **Google Search Console enrichment:** Overlay verified impression and click data on keyword trends to see which rankings actually drive traffic.
 - **Scheduled notifications:** Deliver branded summaries of ranking changes, winners/losers, and visit counts to your inbox.
-- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go.
+- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The dashboard now stretches edge-to-edge on phones by removing the body gutters on small screens.
 - **Robust API:** Manage domains, keywords, settings, and refresh jobs programmatically for automated reporting pipelines.
 
 ### Platform architecture at a glance

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,6 +13,12 @@ body {
    padding-inline: var(--layout-inline);
 }
 
+@media (max-width: 640px) {
+   body {
+      padding-inline: 0;
+   }
+}
+
 .topbar {
    position: relative;
 }


### PR DESCRIPTION
## Summary
- collapse the global body padding on narrow viewports so mobile layouts reach the screen edge
- document the mobile gutter change in the README and changelog

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d18a81549c832a8a37dd445400797c