### PR TITLE
Normalise keyword history persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. Releases no
 * Documented the new screenshot and console logging environment flags in `.env.example`, the README, and integration tests.
 * Encoded the nested Google Search request passed to ScrapingRobot so locale parameters stay bundled within the delegated `url` query parameter.
 * Retained server-side logging in the production bundle by gating Next.js `compiler.removeConsole` behind the `NEXT_REMOVE_CONSOLE` environment flag.
+* Normalised keyword history updates so refresh jobs coerce legacy `'[]'` payloads into objects, serialise SQLite-safe fields, and ship a migration that defaults `keyword.history` to `'{}'` (still auto-run via `entrypoint.sh`).
 * Centralised the Google Ads REST API version behind a `GOOGLE_ADS_API_VERSION` constant, updated documentation, and refreshed tests to ensure both keyword ideas and historical metrics use `v21`.
 * Settings now reload the window only when enabling a scraper from the previous `'none'` state, and the scraper modal has Jest coverage to verify the behaviour.
 * Search Console hooks key their queries by the active domain slug, skip fetches without a slug, and include tests that confirm refetching when switching domains.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The default compose stack maps `./data` to the container so your SQLite database
 - SQLite files live under `./data` by default; mount that directory when running inside containers to keep your historical data.
 - Apply new migrations with `npm run db:migrate` and roll back the most recent migration via `npm run db:revert`.
 - The bundled Sequelize/Umzug tooling works in both local and Docker environments without additional global installs.
+- Keyword history rows now default to `{}`. The included migrations (automatically executed by `entrypoint.sh` on container start)
+  also backfill any legacy `'[]'` payloads so refresh jobs always receive plain objects.
 
 ---
 

--- a/database/migrations/1737100000000-normalise-keyword-history.js
+++ b/database/migrations/1737100000000-normalise-keyword-history.js
@@ -1,0 +1,79 @@
+module.exports = {
+   up: async function up(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib = params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
+
+      return queryInterface.sequelize.transaction(async (transaction) => {
+         const keywordTableDefinition = await queryInterface.describeTable('keyword');
+
+         if (keywordTableDefinition?.history) {
+            await queryInterface.changeColumn(
+               'keyword',
+               'history',
+               {
+                  type: SequelizeLib.DataTypes.STRING,
+                  allowNull: true,
+                  defaultValue: JSON.stringify({}),
+               },
+               { transaction }
+            );
+         }
+
+         await queryInterface.sequelize.query(
+            [
+               "UPDATE keyword SET history = '{}'",
+               "WHERE history IS NULL",
+               "OR TRIM(history) = ''",
+               "OR history = '[]'",
+               "OR LOWER(history) = 'null'",
+               "OR LOWER(history) = 'false'",
+            ].join(' '),
+            { transaction }
+         );
+
+         console.log('Normalised keyword history defaults to empty objects.');
+      });
+   },
+
+   down: async function down(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib = params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
+
+      return queryInterface.sequelize.transaction(async (transaction) => {
+         const keywordTableDefinition = await queryInterface.describeTable('keyword');
+
+         if (keywordTableDefinition?.history) {
+            await queryInterface.changeColumn(
+               'keyword',
+               'history',
+               {
+                  type: SequelizeLib.DataTypes.STRING,
+                  allowNull: true,
+                  defaultValue: JSON.stringify([]),
+               },
+               { transaction }
+            );
+         }
+
+         await queryInterface.sequelize.query(
+            [
+               "UPDATE keyword SET history = '[]'",
+               "WHERE history IS NULL",
+               "OR TRIM(history) = ''",
+               "OR history = '{}'",
+               "OR LOWER(history) = 'null'",
+               "OR LOWER(history) = 'false'",
+            ].join(' '),
+            { transaction }
+         );
+
+         console.log('Reverted keyword history defaults to legacy empty arrays.');
+      });
+   },
+};

--- a/database/models/keyword.ts
+++ b/database/models/keyword.ts
@@ -47,7 +47,7 @@ class Keyword extends Model {
    @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 0 })
    position!: number;
 
-   @Column({ type: DataType.STRING, allowNull: true, defaultValue: JSON.stringify([]) })
+   @Column({ type: DataType.STRING, allowNull: true, defaultValue: JSON.stringify({}) })
    history!: string;
 
    @Column({ type: DataType.INTEGER, allowNull: false, defaultValue: 0 })

--- a/utils/parseKeywords.ts
+++ b/utils/parseKeywords.ts
@@ -1,5 +1,21 @@
 import Keyword from '../database/models/keyword';
 
+export const normaliseHistory = (rawHistory: unknown): KeywordHistory => {
+   if (!rawHistory || typeof rawHistory !== 'object' || Array.isArray(rawHistory)) {
+      return {};
+   }
+
+   return Object.entries(rawHistory as Record<string, unknown>).reduce<KeywordHistory>((acc, [key, value]) => {
+      if (!key) { return acc; }
+
+      const numericValue = typeof value === 'number' ? value : Number(value);
+      if (!Number.isNaN(numericValue)) {
+         acc[key] = numericValue;
+      }
+      return acc;
+   }, {});
+};
+
 /**
  * Parses the SQL Keyword Model object to frontend cosumable object.
  * @param {Keyword[]} allKeywords - Keywords to scrape
@@ -7,8 +23,9 @@ import Keyword from '../database/models/keyword';
  */
 const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
    const parsedItems = allKeywords.map((keywrd:Keyword) => {
-      let history: KeywordHistory = {};
-      try { history = JSON.parse(keywrd.history); } catch { history = {}; }
+      let historyRaw: unknown;
+      try { historyRaw = JSON.parse(keywrd.history); } catch { historyRaw = {}; }
+      const history = normaliseHistory(historyRaw);
 
       let tags: string[] = [];
       try { tags = JSON.parse(keywrd.tags); } catch { tags = []; }


### PR DESCRIPTION
## Summary
- sanitize refresh updates by normalising keyword history, serialising results, and sharing the helper across refresh parsing logic
- backfill legacy keyword history defaults through a new migration and align the Sequelize model plus docs with the '{}' default
- extend refresh unit coverage for URL-less scrapes and legacy history payloads while documenting the behaviour change in the changelog

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d195f6f618832ab6e1ff210fdc2187