### PR TITLE
Adjust mobile topbar gutters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 * Normalised SQLite boolean bindings so `/api/domains` updates persist matching `scrape_enabled` and `notification` flags, and added API regression coverage for the domain toggle.
 * Removed the `/api/dbmigrate` endpoint, dashboard auto-migration banner, and related hooks so database upgrades run exclusively from the Docker `entrypoint.sh`.
-* Collapsed the global body gutters on mobile so dashboard content can span the full viewport width on phones.
+* Restored the global body gutter on mobile while offsetting the TopBar so its background still spans edge-to-edge on phones.
 * Completely restructured `README.md` with a product-focused overview, expanded environment variable reference, and refreshed provider comparison to reflect the current codebase.
 * Replaced Jest's `jest-environment-jsdom` dependency with `@happy-dom/jest-environment` to eliminate deprecated transitive packages and speed up DOM-focused tests.
 * Added `npm run setup:git` to configure `init.defaultBranch` for the repository and avoid Git initialization warnings.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SerpBear is a full-stack Next.js application that tracks where your pages rank o
 - **Keyword research & ideas:** Pull search volumes and suggested keywords straight from your Google Ads test account.
 - **Google Search Console enrichment:** Overlay verified impression and click data on keyword trends to see which rankings actually drive traffic.
 - **Scheduled notifications:** Deliver branded summaries of ranking changes, winners/losers, and visit counts to your inbox.
-- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The dashboard now stretches edge-to-edge on phones by removing the body gutters on small screens.
+- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The layout keeps consistent gutters while the top navigation stretches edge-to-edge on phones for a native feel.
 - **Robust API:** Manage domains, keywords, settings, and refresh jobs programmatically for automated reporting pipelines.
 
 ### Platform architecture at a glance

--- a/__tests__/components/Topbar.test.tsx
+++ b/__tests__/components/Topbar.test.tsx
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { render, screen } from '@testing-library/react';
 import TopBar from '../../components/common/TopBar';
 
@@ -21,5 +23,19 @@ describe('TopBar Component', () => {
       const backLink = container.querySelector('.topbar__back');
       expect(backLink).toBeInTheDocument();
       expect(backLink).toHaveClass('topbar__back');
+   });
+
+   it('applies the mobile edge-to-edge helper via global CSS', () => {
+      const globalsPath = path.join(process.cwd(), 'styles', 'globals.css');
+      const css = fs.readFileSync(globalsPath, 'utf8');
+
+      const mobileTopbarRule = new RegExp(
+         '@media \\(max-width: 760px\\)\\s*{\\s*\\.topbar {[^}]*margin-inline: '
+         + 'calc\\(-1 \\* var\\(--layout-inline\\)\\);[^}]*padding-inline: var\\(--layout-inline\\);',
+      );
+      const mobileBodyOverride = /@media \(max-width: 760px\)\s*{\s*body\s*{/;
+
+      expect(css).toMatch(mobileTopbarRule);
+      expect(css).not.toMatch(mobileBodyOverride);
    });
 });

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,18 +13,19 @@ body {
    padding-inline: var(--layout-inline);
 }
 
-@media (max-width: 760px) {
-   body {
-      padding-inline: 0;
-   }
-}
-
 .topbar {
    position: relative;
 }
 
 .topbar__back {
    position: absolute;
+}
+
+@media (max-width: 760px) {
+   .topbar {
+      margin-inline: calc(-1 * var(--layout-inline));
+      padding-inline: var(--layout-inline);
+   }
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- keep the global body gutter active on mobile and offset the TopBar so its background still reaches the viewport edges
- cover the new mobile CSS helper in the TopBar test suite so regressions are caught
- document the refreshed mobile layout behaviour in the README and changelog

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a9458a3c832a9c6c51771b9905c9