### PR TITLE
Fix mobile TopBar gutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Reworked the TopBar layout so mobile views drop the base `mx-auto`, extend the edge-to-edge helper through the 767px breakpoint, and include Jest coverage to prevent the right-side gutter from returning.
 * Normalised Google SERP extraction so redirect wrappers such as `/url` and `/interstitial` resolve to their destination URLs, hardened `getSerp` against hostless paths, and added Jest coverage for the regression.
 * Consolidated keyword location metadata into a single `location` column, migrated existing records, and introduced shared helpers so the API, UI, scrapers, and email exports consistently format and validate paired city/state input.
 * Removed the persisted `domain.keywordCount` column in favour of a computed `keywordsTracked` value returned by the domains API and rendered throughout the dashboard.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SerpBear is a full-stack Next.js application that tracks where your pages rank o
 - **Keyword research & ideas:** Pull search volumes and suggested keywords straight from your Google Ads test account.
 - **Google Search Console enrichment:** Overlay verified impression and click data on keyword trends to see which rankings actually drive traffic.
 - **Scheduled notifications:** Deliver branded summaries of ranking changes, winners/losers, and visit counts to your inbox.
-- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The layout keeps consistent gutters while the top navigation stretches edge-to-edge on phones for a native feel.
+- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The layout keeps consistent gutters while the top navigation now stretches truly edge-to-edge on phones for a native feel—no more stray right-side padding.
 - **Robust API:** Manage domains, keywords, settings, and refresh jobs programmatically for automated reporting pipelines.
 
 ### Platform architecture at a glance

--- a/__tests__/components/Topbar.test.tsx
+++ b/__tests__/components/Topbar.test.tsx
@@ -31,7 +31,7 @@ describe('TopBar Component', () => {
 
       // More robust CSS validation with better error reporting and maintainability
       // Extract the mobile media query section for targeted testing
-      const mobileMediaQueryRegex = /@media\s*\(\s*max-width:\s*760px\s*\)\s*\{([^{}]*\{[^{}]*\}[^{}]*)\}/;
+      const mobileMediaQueryRegex = /@media\s*\(\s*max-width:\s*767px\s*\)\s*\{([^{}]*\{[^{}]*\}[^{}]*)\}/;
       const mobileMediaMatch = css.match(mobileMediaQueryRegex);
       
       expect(mobileMediaMatch).toBeTruthy();
@@ -48,7 +48,16 @@ describe('TopBar Component', () => {
       }
       
       // Ensure no body overrides in mobile media queries (maintains body gutters)
-      const mobileBodyOverride = /@media\s*\(\s*max-width:\s*760px\s*\)\s*\{[^}]*body\s*\{/;
+      const mobileBodyOverride = /@media\s*\(\s*max-width:\s*767px\s*\)\s*\{[^}]*body\s*\{/;
       expect(css).not.toMatch(mobileBodyOverride);
+   });
+
+   it('keeps the mobile layout edge-to-edge without centering offsets', () => {
+      const { container } = render(<TopBar showSettings={jest.fn} showAddModal={jest.fn} />);
+      const topbarElement = container.querySelector('.topbar');
+
+      expect(topbarElement).toBeInTheDocument();
+      expect(topbarElement?.classList.contains('md:mx-auto')).toBe(true);
+      expect(topbarElement?.classList.contains('mx-auto')).toBe(false);
    });
 });

--- a/components/common/TopBar.tsx
+++ b/components/common/TopBar.tsx
@@ -30,8 +30,10 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
    };
 
    return (
-       <div className={`topbar flex items-center w-full mx-auto justify-between
-       ${isDomainsPage ? 'max-w-5xl lg:justify-between' : 'max-w-7xl lg:justify-end'}  bg-white lg:bg-transparent`}>
+       <div
+          className={`topbar flex items-center w-full justify-between
+       ${isDomainsPage ? 'max-w-5xl lg:justify-between' : 'max-w-7xl lg:justify-end'} bg-white lg:bg-transparent md:mx-auto`}
+       >
 
          <h3 className={`p-4 text-base font-bold text-blue-700 ${isDomainsPage ? 'lg:pl-0' : 'lg:hidden'}`}>
             <span className=' relative top-[3px] mr-1'><Icon type="logo" size={24} color="#364AFF" /></span> SerpBear

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -21,7 +21,7 @@ body {
    position: absolute;
 }
 
-@media (max-width: 760px) {
+@media (max-width: 767px) {
    .topbar {
       margin-inline: calc(-1 * var(--layout-inline));
       padding-inline: var(--layout-inline);


### PR DESCRIPTION
## Summary
- remove the base mx-auto offset from the TopBar so the mobile header spans the viewport and keep centring from the md breakpoint upward
- extend the mobile CSS helper through 767px and cover the behaviour with a new unit test
- document the fix in the README and changelog

## Testing
- npm run lint
- npm run lint:css
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1cccaf98c832aaaaca37bbcca4440