### PR TITLE
feat: adopt shared desktop container layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Replaced the fixed 105 rem layout cap with a reusable `desktop-container` utility so the dashboard and research views expand to 90 % of the viewport on large screens.
 * Reworked the TopBar layout so mobile views drop the base `mx-auto`, extend the edge-to-edge helper through the 767px breakpoint, and include Jest coverage to prevent the right-side gutter from returning.
 * Added an optional SMTP TLS certificate hostname override, trimming saved settings and sanitising Nodemailer transports so whitespace and trailing dots no longer break certificate validation.
 * Normalised Google SERP extraction so redirect wrappers such as `/url` and `/interstitial` resolve to their destination URLs, hardened `getSerp` against hostless paths, and added Jest coverage for the regression.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ SerpBear is a full-stack Next.js application that tracks where your pages rank o
 - **Google Search Console enrichment:** Overlay verified impression and click data on keyword trends to see which rankings actually drive traffic.
 - **Scheduled notifications:** Deliver branded summaries of ranking changes, winners/losers, and visit counts to your inbox.
 - **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The layout keeps consistent gutters while the top navigation now stretches truly edge-to-edge on phones for a native feel—no more stray right-side padding.
+- **Adaptive desktop canvas:** Domain dashboards, Search Console insights, and the research workspace reuse a shared `desktop-container` utility that expands to 90 % of the viewport on large screens so wide monitors surface more data at once.
 - **Robust API:** Manage domains, keywords, settings, and refresh jobs programmatically for automated reporting pipelines.
 
 ### Platform architecture at a glance

--- a/__tests__/components/Topbar.test.tsx
+++ b/__tests__/components/Topbar.test.tsx
@@ -52,12 +52,12 @@ describe('TopBar Component', () => {
       expect(css).not.toMatch(mobileBodyOverride);
    });
 
-   it('keeps the mobile layout edge-to-edge without centering offsets', () => {
+   it('applies the shared desktop container utility', () => {
       const { container } = render(<TopBar showSettings={jest.fn} showAddModal={jest.fn} />);
       const topbarElement = container.querySelector('.topbar');
 
       expect(topbarElement).toBeInTheDocument();
-      expect(topbarElement?.classList.contains('md:mx-auto')).toBe(true);
-      expect(topbarElement?.classList.contains('mx-auto')).toBe(false);
+      expect(topbarElement?.classList.contains('desktop-container')).toBe(true);
+      expect(topbarElement?.className).not.toMatch(/max-w-\dxl?/);
    });
 });

--- a/__tests__/pages/domain.test.tsx
+++ b/__tests__/pages/domain.test.tsx
@@ -63,7 +63,7 @@ describe('SingleDomain Page', () => {
 
    it('applies gutter spacing between the sidebar and content area', () => {
       const { container } = render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
-      const layoutWrapper = container.querySelector('.max-w-8xl');
+      const layoutWrapper = container.querySelector('.desktop-container.gap-6');
       expect(layoutWrapper).toBeInTheDocument();
       expect(layoutWrapper).toHaveClass('gap-6');
    });

--- a/__tests__/pages/domains.test.tsx
+++ b/__tests__/pages/domains.test.tsx
@@ -89,7 +89,7 @@ describe('Domains Page', () => {
               <Domains />
           </QueryClientProvider>,
       );
-      const layoutWrapper = container.querySelector('.max-w-8xl');
+      const layoutWrapper = container.querySelector('.desktop-container.py-6');
       expect(layoutWrapper).toBeInTheDocument();
       expect(layoutWrapper).toHaveClass('py-6');
    });

--- a/components/common/TopBar.tsx
+++ b/components/common/TopBar.tsx
@@ -30,10 +30,10 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
    };
 
    return (
-       <div
-          className={`topbar flex items-center w-full justify-between
-       ${isDomainsPage ? 'max-w-5xl lg:justify-between' : 'max-w-7xl lg:justify-end'} bg-white lg:bg-transparent md:mx-auto`}
-       >
+      <div
+         className={`topbar desktop-container flex items-center justify-between
+       ${isDomainsPage ? 'lg:justify-between' : 'lg:justify-end'} bg-white lg:bg-transparent`}
+      >
 
          <h3 className={`p-4 text-base font-bold text-blue-700 ${isDomainsPage ? 'lg:pl-0' : 'lg:hidden'}`}>
             <span className=' relative top-[3px] mr-1'><Icon type="logo" size={24} color="#364AFF" /></span> SerpBear

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -60,7 +60,7 @@ const SingleDomain: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
+         <div className="flex desktop-container gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -95,7 +95,7 @@ const DiscoverPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
+         <div className="flex desktop-container gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain

--- a/pages/domain/ideas/[slug]/index.tsx
+++ b/pages/domain/ideas/[slug]/index.tsx
@@ -53,7 +53,7 @@ const DiscoverPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
+         <div className="flex desktop-container gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain ? (

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -53,7 +53,7 @@ const InsightPage: NextPage = () => {
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
-         <div className="flex w-full max-w-8xl mx-auto gap-6 lg:gap-10">
+         <div className="flex desktop-container gap-6 lg:gap-10">
             <Sidebar domains={theDomains} showAddModal={() => setShowAddDomain(true)} />
             <div className="domain_kewywords w-full pt-10 lg:pt-8">
                {activDomain && activDomain.domain

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -108,7 +108,7 @@ const Domains: NextPage = () => {
          </Head>
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
 
-         <div className="flex flex-col w-full max-w-8xl mx-auto py-6 lg:mt-24">
+         <div className="flex flex-col desktop-container py-6 lg:mt-24">
             <div className='flex justify-between mb-2 items-center'>
                <div className=' text-sm text-gray-600'>
                   {domainsData?.domains?.length || 0} Domains <span className=' text-gray-300 ml-1 mr-1'>|</span> {totalKeywords} keywords

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -62,7 +62,7 @@ const Research: NextPage = () => {
             <title>Research Keywords - SerpBear</title>
          </Head>
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => null } />
-         <div className=" w-full max-w-7xl mx-auto lg:flex lg:flex-row">
+         <div className="desktop-container lg:flex lg:flex-row">
             <div className="sidebar w-full p-6 lg:pt-44 lg:w-1/5 lg:block lg:pr-0" data-testid="sidebar">
                <h3 className="hidden py-7 text-base font-bold text-blue-700 lg:block">
                   <span className=' relative top-[3px] mr-1'><Icon type="logo" size={24} color="#364AFF" /></span> SerpBear

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,6 +4,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+   .desktop-container {
+      @apply w-full mx-auto lg:max-w-desktop;
+   }
+}
+
 :root {
    --layout-inline: clamp(1.5rem, 5vw, 10rem);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,10 +15,8 @@ module.exports = {
    theme: {
      extend: {
        maxWidth: {
-         '5xl': '105rem',
-         '7xl': '105rem',
-         '8xl': '105rem',
-       }
+         desktop: '90vw',
+       },
      },
    },
    plugins: [],


### PR DESCRIPTION
## Summary
- add a shared `desktop-container` utility and Tailwind max width that scale pages to 90% of the viewport on large screens
- replace the old fixed `max-w-*` wrappers on the top bar, domains dashboards, and research workspace with the new container
- refresh layout-focused tests plus the changelog and README to document the adaptive desktop canvas

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d322105fe8832aaed1a30afcde0215