### PR TITLE
Simplify domain guard checks for Search Console and screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Removed redundant domain guards so dashboard headers, screenshots, and Search Console refreshes operate directly on the stored host names.
 * Removed the client-side guard that rejected blank domain slugs so `/api/domain` requests always hit the API and rely on server-side validation.
 * Replaced the fixed 105 rem layout cap with a reusable `desktop-container` utility so the dashboard and research views expand to 90 % of the viewport on large screens.
 * Reworked the TopBar layout so mobile views drop the base `mx-auto`, extend the edge-to-edge helper through the 767px breakpoint, and include Jest coverage to prevent the right-side gutter from returning.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 - Authenticate with a service account and SerpBear will enrich each keyword with impression, click, and CTR metrics.
 - Cached data refreshes automatically once per `CRON_MAIN_SCHEDULE` cycle (respecting `CRON_TIMEZONE`) and can be refreshed manually from the settings view.
 - Search Console data is optional; when credentials are missing the UI gracefully hides related panels.
+- When credentials are present, manual refreshes and scheduled digests now always run the Search Console pipeline instead of skipping requests when the domain payload is unexpectedly falsy.
 
 ### Google Ads keyword research
 
@@ -238,6 +239,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
 ## Troubleshooting & tips
 
 - **Missing screenshots:** If dashboard thumbnails show the fallback favicon, confirm `SCREENSHOT_API` is set and `NEXT_PUBLIC_SCREENSHOTS=true`.
+- **Screenshot refresh skips:** Manual thumbnail updates now always hit the screenshot service with the stored host, so investigate provider logs if a toast reports a failure instead of assuming the button silently ignored the request.
 - **Empty domain slugs:** The dashboard now always requests `/api/domain`, even for blank slugs, so the API returns descriptive validation errors instead of the client throwing immediately.
 - **Domain scraping toggle not persisting:** The custom SQLite dialect now coerces boolean bindings to integers so `/api/domains` updates keep `scrape_enabled` and the legacy `notification` flag aligned.
 - **Scraper misconfiguration:** 500-series API responses often include descriptive JSON (with a `details` field) – surface these logs when opening support tickets.

--- a/components/domains/DomainHeader.tsx
+++ b/components/domains/DomainHeader.tsx
@@ -36,7 +36,7 @@ const DomainHeader = (
       <div className='domain_kewywords_head w-full '>
          <div>
             <h1 className="hidden lg:block text-xl font-bold my-3" data-testid="domain-header">
-               {domain && domain.domain && <><i className=' capitalize font-bold not-italic'>{domain.domain.charAt(0)}</i>{domain.domain.slice(1)}</>}
+               <><i className=' capitalize font-bold not-italic'>{domain.domain.charAt(0)}</i>{domain.domain.slice(1)}</>
             </h1>
             <div className='domain_selector bg-white mt-2 lg:hidden relative z-10'>
                <SelectField

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -54,11 +54,9 @@ const Domains: NextPage = () => {
       if (domainsData?.domains && domainsData.domains.length > 0) {
          const fetchAllScreenshots = async () => {
             const screenshotPromises = domainsData.domains.map(async (domain: DomainType) => {
-               if (domain.domain) {
-                  const domainThumb = await fetchDomainScreenshot(domain.domain);
-                  if (domainThumb) {
-                     return { domain: domain.domain, thumb: domainThumb };
-                  }
+               const domainThumb = await fetchDomainScreenshot(domain.domain);
+               if (domainThumb) {
+                  return { domain: domain.domain, thumb: domainThumb };
                }
                return null;
             });
@@ -70,7 +68,7 @@ const Domains: NextPage = () => {
                setDomainThumbs((currentThumbs) => {
                   const newThumbs = { ...currentThumbs };
                   validScreenshots.forEach(({ domain, thumb }) => {
-                     if (domain && thumb) {
+                     if (thumb) {
                         newThumbs[domain] = thumb;
                      }
                   });
@@ -85,14 +83,12 @@ const Domains: NextPage = () => {
 
    const manuallyUpdateThumb = async (domain: string) => {
       if (!SCREENSHOTS_ENABLED) { return; }
-      if (domain) {
-         const domainThumb = await fetchDomainScreenshot(domain, true);
-         if (domainThumb) {
-            toast(`${domain} Screenshot Updated Successfully!`, { icon: '✔️' });
-            setDomainThumbs((currentThumbs) => ({ ...currentThumbs, [domain]: domainThumb }));
-         } else {
-            toast(`Failed to Fetch ${domain} Screenshot!`, { icon: '⚠️' });
-         }
+      const domainThumb = await fetchDomainScreenshot(domain, true);
+      if (domainThumb) {
+         toast(`${domain} Screenshot Updated Successfully!`, { icon: '✔️' });
+         setDomainThumbs((currentThumbs) => ({ ...currentThumbs, [domain]: domainThumb }));
+      } else {
+         toast(`Failed to Fetch ${domain} Screenshot!`, { icon: '⚠️' });
       }
    };
 

--- a/utils/generateEmail.ts
+++ b/utils/generateEmail.ts
@@ -147,8 +147,6 @@ const generateEmail = async (domain:DomainType, keywords:KeywordType[], settings
  * @returns {Promise<string>}
  */
 export const generateGoogleConsoleStats = async (domain:DomainType): Promise<string> => {
-      if (!domain?.domain) return '';
-
       const initialSCData = await readLocalSCData(domain.domain);
       let localSCData:SCDomainDataType | null = initialSCData === false ? null : initialSCData;
       const cronTimezone = process.env.CRON_TIMEZONE || 'America/New_York';

--- a/utils/searchConsole.ts
+++ b/utils/searchConsole.ts
@@ -143,7 +143,7 @@ export const fetchDomainSCData = async (
    const apiCreds = (scDomainAPI?.client_email && scDomainAPI?.private_key)
       ? scDomainAPI
       : scGlobalAPI;
-   if (domain.domain && apiCreds?.client_email && apiCreds?.private_key) {
+   if (apiCreds?.client_email && apiCreds?.private_key) {
       const theDomain = domain;
       for (const day of days) {
          const items = await fetchSearchConsoleData(theDomain, day, undefined, apiCreds);


### PR DESCRIPTION
## Summary
- render the domain header and screenshot fetchers without redundant domain guards so they always use the stored host name
- ensure email and Search Console utilities rely on credential checks rather than short-circuiting on falsy domain payloads
- document the more aggressive refresh behaviour in the README and changelog

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d32775fdc8832ab42d8323f47f0e6a