### PR TITLE
feat: add shared loaders for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Added a reusable page loader overlay and spinner placeholders so the domains dashboard, single-domain view, and research workspace stay blocked until router state and React Query data settle, while keeping loading labels accessible.
 * Removed redundant domain guards so dashboard headers, screenshots, and Search Console refreshes operate directly on the stored host names.
 * Removed the client-side guard that rejected blank domain slugs so `/api/domain` requests always hit the API and rely on server-side validation.
 * Replaced the fixed 105 rem layout cap with a reusable `desktop-container` utility so the dashboard and research views expand to 90 % of the viewport on large screens.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 - Connect a Google Ads test account to unlock keyword suggestions and historical volume data right inside SerpBear.
 - The app exposes the same functionality through its REST API, making it easy to integrate with reporting pipelines.
 
+### Loading states & accessibility
+
+- The domains dashboard, single-domain workspace, and research area now share a full-viewport loader that blocks interaction until router state and React Query data have settled.
+- Keyword, idea, and insight tables use a spinner-only placeholder with visually hidden labels so loading affordances stay consistent without repeating "Loading…" copy on screen.
+
 ### Notifications & reporting
 
 - Email digests summarise rank gains/losses, highlight top movers, and include Search Console traffic data when available.

--- a/__tests__/components/PageLoader.test.tsx
+++ b/__tests__/components/PageLoader.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import PageLoader from '../../components/common/PageLoader';
+
+describe('PageLoader', () => {
+   it('renders an overlay while loading', () => {
+      render(
+         <PageLoader isLoading label='Loading test'>
+            <div>Child content</div>
+         </PageLoader>,
+      );
+
+      const overlay = screen.getByTestId('page-loader-overlay');
+      expect(overlay).toBeInTheDocument();
+      expect(overlay).toHaveClass('fixed');
+      expect(screen.getByText('Child content')).toBeInTheDocument();
+      expect(screen.getByRole('status', { name: 'Loading test' })).toBeInTheDocument();
+   });
+
+   it('hides the overlay when loading finishes', () => {
+      const { container } = render(
+         <PageLoader isLoading={false}>
+            <div>Loaded content</div>
+         </PageLoader>,
+      );
+
+      expect(screen.queryByTestId('page-loader-overlay')).not.toBeInTheDocument();
+      expect(container.firstChild).toHaveAttribute('aria-busy', 'false');
+   });
+});

--- a/__tests__/components/SpinnerMessage.test.tsx
+++ b/__tests__/components/SpinnerMessage.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import SpinnerMessage from '../../components/common/SpinnerMessage';
+
+describe('SpinnerMessage', () => {
+   it('renders a spinner with an accessible label', () => {
+      render(<SpinnerMessage label='Loading keywords' />);
+
+      const status = screen.getByRole('status', { name: 'Loading keywords' });
+      expect(status).toBeInTheDocument();
+      expect(status.querySelector('svg')).not.toBeNull();
+   });
+});

--- a/__tests__/pages/domain.test.tsx
+++ b/__tests__/pages/domain.test.tsx
@@ -14,6 +14,7 @@ jest.mock('../../services/settings');
 jest.mock('next/router', () => ({
    useRouter: () => ({
      query: { slug: dummyDomain.slug },
+     isReady: true,
    }),
 }));
 
@@ -59,6 +60,18 @@ describe('SingleDomain Page', () => {
    it('Render without crashing.', async () => {
       render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
       expect(screen.getByTestId('domain-header')).toBeInTheDocument();
+   });
+
+   it('renders the page loader while queries resolve', () => {
+      useFetchSettingsFunc.mockImplementation(() => ({ data: undefined, isLoading: true }));
+      useFetchDomainsFunc.mockImplementation(() => ({ data: undefined, isLoading: true }));
+      useFetchKeywordsFunc.mockImplementation(() => ({ keywordsData: undefined, keywordsLoading: true }));
+
+      render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
+
+      const overlay = screen.getByTestId('page-loader-overlay');
+      expect(overlay).toBeInTheDocument();
+      expect(overlay).toHaveClass('fixed');
    });
 
    it('applies gutter spacing between the sidebar and content area', () => {

--- a/components/common/PageLoader.tsx
+++ b/components/common/PageLoader.tsx
@@ -1,0 +1,30 @@
+import React, { type HTMLAttributes, type ReactNode } from 'react';
+import Icon from './Icon';
+
+type PageLoaderProps = {
+   isLoading: boolean;
+   label?: string;
+   children: ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
+
+const PageLoader = ({ isLoading, label = 'Loading content', children, className = '', ...rest }: PageLoaderProps) => {
+   return (
+      <div className={className} {...rest} aria-busy={isLoading}>
+         {children}
+         {isLoading && (
+            <div
+               className='fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-sm'
+               role='status'
+               aria-live='polite'
+               aria-label={label}
+               data-testid='page-loader-overlay'
+            >
+               <Icon type='loading' size={48} />
+               <span className='sr-only'>{label}</span>
+            </div>
+         )}
+      </div>
+   );
+};
+
+export default PageLoader;

--- a/components/common/SpinnerMessage.tsx
+++ b/components/common/SpinnerMessage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Icon from './Icon';
+
+type SpinnerMessageProps = {
+   label?: string;
+   className?: string;
+};
+
+const SpinnerMessage = ({ label = 'Loading data', className = '' }: SpinnerMessageProps) => {
+   return (
+      <div
+         className={`flex flex-col items-center justify-center text-gray-500 ${className}`.trim()}
+         role='status'
+         aria-live='polite'
+         aria-label={label}
+      >
+         <Icon type='loading' size={24} />
+         <span className='sr-only'>{label}</span>
+      </div>
+   );
+};
+
+export default SpinnerMessage;

--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -5,6 +5,7 @@ import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { useAddKeywords } from '../../services/keywords';
 import { formatLocation } from '../../utils/location';
 import Icon from '../common/Icon';
+import SpinnerMessage from '../common/SpinnerMessage';
 import KeywordIdea from './KeywordIdea';
 import useWindowResize from '../../hooks/useWindowResize';
 import useIsMobile from '../../hooks/useIsMobile';
@@ -174,7 +175,7 @@ const IdeasKeywordsTable = ({
       keywordsContent = (
          <>
             {isAdwordsIntegrated && isLoading && (
-               <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Keywords Ideas...</p>
+               <SpinnerMessage className='p-9 pt-[10%] text-center' label='Loading keyword ideas' />
             )}
             {isAdwordsIntegrated && noIdeasDatabase && !isLoading && (
                <p className=' p-9 pt-[10%] text-center text-gray-500'>

--- a/components/insight/Insight.tsx
+++ b/components/insight/Insight.tsx
@@ -3,6 +3,7 @@ import { sortInsightItems } from '../../utils/insight';
 import SelectField from '../common/SelectField';
 import InsightItem from './InsightItem';
 import InsightStats from './InsightStats';
+import SpinnerMessage from '../common/SpinnerMessage';
 
 type SCInsightProps = {
    domain: DomainType | null,
@@ -112,7 +113,7 @@ const SCInsight = ({ insight, isLoading = true, isConsoleIntegrated = true, doma
                         )
                      }
                      {isConsoleIntegrated && isLoading && (
-                        <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Insight...</p>
+                        <SpinnerMessage className='p-9 pt-[10%] text-center' label='Loading insights' />
                      )}
                      {!isConsoleIntegrated && (
                         <p className=' p-9 pt-[10%] text-center text-gray-500'>

--- a/components/keywords/KeywordsTable.tsx
+++ b/components/keywords/KeywordsTable.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { filterKeywords, keywordsByDevice, sortKeywords } from '../../utils/client/sortFilter';
 import Icon from '../common/Icon';
+import SpinnerMessage from '../common/SpinnerMessage';
 import Keyword from './Keyword';
 import KeywordDetails from './KeywordDetails';
 import KeywordFilters from './KeywordFilter';
@@ -175,7 +176,7 @@ const KeywordsTable = (props: KeywordsTableProps) => {
          !isLoading ? (
             <p className=' p-9 pt-[10%] text-center text-gray-500'>No Keywords Added for this Device Type.</p>
          ) : (
-            <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Keywords...</p>
+            <SpinnerMessage className='p-9 pt-[10%] text-center' label='Loading keywords' />
          )
       );
    }

--- a/components/keywords/SCKeywordsTable.tsx
+++ b/components/keywords/SCKeywordsTable.tsx
@@ -4,6 +4,7 @@ import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
 import { useAddKeywords, useFetchKeywords } from '../../services/keywords';
 import { SCfilterKeywords, SCkeywordsByDevice, SCsortKeywords } from '../../utils/client/SCsortFilter';
 import Icon from '../common/Icon';
+import SpinnerMessage from '../common/SpinnerMessage';
 import KeywordFilters from './KeywordFilter';
 import SCKeyword from './SCKeyword';
 import useWindowResize from '../../hooks/useWindowResize';
@@ -214,7 +215,7 @@ const SCKeywordsTable = ({ domain, keywords = [], isLoading = true, isConsoleInt
                         </p>
                      )}
                      {isConsoleIntegrated && isLoading && (
-                        <p className=' p-9 pt-[10%] text-center text-gray-500'>Loading Keywords...</p>
+                        <SpinnerMessage className='p-9 pt-[10%] text-center' label='Loading Search Console keywords' />
                      )}
                      {!isConsoleIntegrated && (
                         <p className=' p-9 pt-[10%] text-center text-gray-500'>

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -16,6 +16,7 @@ import { useFetchKeywords } from '../../../services/keywords';
 import { useFetchSettings } from '../../../services/settings';
 import AddKeywords from '../../../components/keywords/AddKeywords';
 import Footer from '../../../components/common/Footer';
+import PageLoader from '../../../components/common/PageLoader';
 
 const SingleDomain: NextPage = () => {
    const router = useRouter();
@@ -25,7 +26,7 @@ const SingleDomain: NextPage = () => {
    const [showSettings, setShowSettings] = useState(false);
    const [keywordSPollInterval, setKeywordSPollInterval] = useState<undefined|number>(undefined);
    const { data: appSettingsData, isLoading: isAppSettingsLoading } = useFetchSettings();
-   const { data: domainsData } = useFetchDomains(router, false);
+   const { data: domainsData, isLoading: isDomainsLoading } = useFetchDomains(router, false);
    const appSettings: SettingsType = appSettingsData?.settings || {};
    const { scraper_type = '', available_scapers = [] } = appSettings;
    const activeScraper = useMemo(() => available_scapers.find((scraper) => scraper.value === scraper_type), [scraper_type, available_scapers]);
@@ -47,8 +48,10 @@ const SingleDomain: NextPage = () => {
    const theDomains: DomainType[] = (domainsData && domainsData.domains) || [];
    const theKeywords: KeywordType[] = keywordsData && keywordsData.keywords;
 
+   const isPageLoading = isAppSettingsLoading || isDomainsLoading || keywordsLoading || !router.isReady;
+
    return (
-      <div className="Domain ">
+      <PageLoader isLoading={isPageLoading} className="Domain">
          {(!isAppSettingsLoading && scraper_type === 'none') && (
                <div className=' p-3 bg-red-600 text-white text-sm text-center'>
                   A Scrapper/Proxy has not been set up Yet. Open Settings to set it up and start using the app.
@@ -108,7 +111,7 @@ const SingleDomain: NextPage = () => {
                />
          </CSSTransition>
          <Footer currentVersion={appSettings?.version ? appSettings.version : ''} />
-      </div>
+      </PageLoader>
    );
 };
 

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -10,9 +10,9 @@ import Settings from '../../components/settings/Settings';
 import { useFetchSettings } from '../../services/settings';
 import { fetchDomainScreenshot, useFetchDomains, SCREENSHOTS_ENABLED } from '../../services/domains';
 import DomainItem from '../../components/domains/DomainItem';
-import Icon from '../../components/common/Icon';
 import Footer from '../../components/common/Footer';
 import { withAuth } from '../../hooks/useAuth';
+import PageLoader from '../../components/common/PageLoader';
 
 type thumbImages = { [domain:string] : string }
 
@@ -23,7 +23,7 @@ const Domains: NextPage = () => {
    const [showAddDomain, setShowAddDomain] = useState(false);
    const [domainThumbs, setDomainThumbs] = useState<thumbImages>({});
    const { data: appSettingsData, isLoading: isAppSettingsLoading } = useFetchSettings();
-   const { data: domainsData, isLoading } = useFetchDomains(router, true);
+   const { data: domainsData, isLoading: isDomainsLoading } = useFetchDomains(router, true);
 
    const appSettings:SettingsType = appSettingsData?.settings || {};
    const { scraper_type = '' } = appSettings;
@@ -92,8 +92,14 @@ const Domains: NextPage = () => {
       }
    };
 
+   const isPageLoading = isAppSettingsLoading || isDomainsLoading || !router.isReady;
+
    return (
-      <div data-testid="domains" className="Domain flex flex-col min-h-screen">
+      <PageLoader
+         isLoading={isPageLoading}
+         className="Domain flex flex-col min-h-screen"
+         data-testid="domains"
+      >
          {(!isAppSettingsLoading && scraper_type === 'none') && (
                <div className=' p-3 bg-red-600 text-white text-sm text-center'>
                   A Scrapper/Proxy has not been set up Yet. Open Settings to set it up and start using the app.
@@ -133,12 +139,7 @@ const Domains: NextPage = () => {
                            // isConsoleIntegrated={false}
                            />;
                })}
-               {isLoading && (
-                  <div className='noDomains mt-4 p-5 py-12 rounded border text-center bg-white text-sm'>
-                     <Icon type="loading" /> Loading Domains...
-                  </div>
-               )}
-               {!isLoading && domainsData && domainsData.domains && domainsData.domains.length === 0 && (
+               {!isDomainsLoading && domainsData && domainsData.domains && domainsData.domains.length === 0 && (
                   <div className='noDomains mt-4 p-5 py-12 rounded border text-center bg-white text-sm'>
                      No Domains Found. Add a Domain to get started!
                   </div>
@@ -153,7 +154,7 @@ const Domains: NextPage = () => {
              <Settings closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
          <Footer currentVersion={appSettings?.version ? appSettings.version : ''} />
-      </div>
+      </PageLoader>
    );
 };
 

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -13,6 +13,7 @@ import Settings from '../../components/settings/Settings';
 import SelectField from '../../components/common/SelectField';
 import allCountries, { adwordsLanguages } from '../../utils/countries';
 import Footer from '../../components/common/Footer';
+import PageLoader from '../../components/common/PageLoader';
 
 const Research: NextPage = () => {
    const router = useRouter();
@@ -22,7 +23,7 @@ const Research: NextPage = () => {
    const [country, setCountry] = useState('US');
    const [seedKeywords, setSeedKeywords] = useState('');
 
-   const { data: appSettings } = useFetchSettings();
+   const { data: appSettings, isLoading: isSettingsLoading } = useFetchSettings();
    const adwordsConnected = !!(appSettings && appSettings?.settings?.adwords_refresh_token
       && appSettings?.settings?.adwords_developer_token, appSettings?.settings?.adwords_account_id);
    const { data: keywordIdeasData, isLoading: isLoadingIdeas, isError: errorLoadingIdeas } = useFetchKeywordIdeas(router, adwordsConnected);
@@ -56,8 +57,10 @@ const Research: NextPage = () => {
    const buttonLabelStyle = 'ml-2 text-sm not-italic lg:invisible lg:opacity-0';
    const labelStyle = 'mb-2 font-semibold inline-block text-sm text-gray-700 capitalize w-full';
 
+   const isPageLoading = !router.isReady || isSettingsLoading || isLoadingIdeas;
+
    return (
-      <div className={'Login'}>
+      <PageLoader isLoading={isPageLoading} className='Login'>
          <Head>
             <title>Research Keywords - SerpBear</title>
          </Head>
@@ -143,7 +146,7 @@ const Research: NextPage = () => {
              <Settings closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
          <Footer currentVersion={appSettings?.settings?.version ? appSettings.settings.version : ''} />
-      </div>
+      </PageLoader>
    );
 };
 


### PR DESCRIPTION
## Summary
- add a reusable PageLoader overlay and SpinnerMessage helper to centralise loading UX
- wrap the domains, single-domain, and research pages in the new loader and replace inline loading copy with spinner placeholders across keyword tables and insights
- expand Jest coverage for the loader/spinner behaviours and document the UI change in the README and changelog

## Testing
- npm run lint
- npm run lint:css
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d328bbc848832ab9279f18fe56f5bd