### PR TITLE
Potential fix for code scanning alert no. 53: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   cleanup-caches:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Authenticate GH CLI
         run: gh auth setup-git


### PR DESCRIPTION
Potential fix for [https://github.com/djav1985/v-serpbear/security/code-scanning/53](https://github.com/djav1985/v-serpbear/security/code-scanning/53)

To fix the issue, we must add the `permissions` block to the workflow or relevant job, specifying the minimal required permissions. The job deletes GitHub Actions caches (`gh actions-cache delete`), which requires `actions: write` permission. There is no indication that other write-level permissions (e.g., `contents: write`) are needed. To satisfy the principle of least privilege, we should add a `permissions` block granting only `actions: write` ("write" is required to delete caches) and nothing else. We can add this either at the workflow root or directly under the job (immediately beneath `cleanup-caches:`).

The canonical way is adding under the job definition, right after `runs-on: ubuntu-latest`.  
No imports, definitions, or other changes besides inserting the `permissions` block are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
