### PR TITLE
Refine page loading UX and mobile top bar spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file. Releases no
 * Normalised SQLite boolean bindings so `/api/domains` updates persist matching `scrape_enabled` and `notification` flags, and added API regression coverage for the domain toggle.
 * Removed the `/api/dbmigrate` endpoint, dashboard auto-migration banner, and related hooks so database upgrades run exclusively from the Docker `entrypoint.sh`.
 * Restored the global body gutter on mobile while offsetting the TopBar so its background still spans edge-to-edge on phones.
+* Let the single-domain and research pages rely on their table-level `isLoading` states instead of the global `<PageLoader>`, keeping modal transitions intact while limiting spinners to the content that is still fetching.
+* Limited the `.desktop-container` helper's centring to large screens so the TopBar and other mobile layouts reach the viewport edges without extra gutters.
 * Completely restructured `README.md` with a product-focused overview, expanded environment variable reference, and refreshed provider comparison to reflect the current codebase.
 * Replaced Jest's `jest-environment-jsdom` dependency with `@happy-dom/jest-environment` to eliminate deprecated transitive packages and speed up DOM-focused tests.
 * Added `npm run setup:git` to configure `init.defaultBranch` for the repository and avoid Git initialization warnings.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ SerpBear is a full-stack Next.js application that tracks where your pages rank o
 - **Scheduled notifications:** Deliver branded summaries of ranking changes, winners/losers, and visit counts to your inbox.
 - **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The layout keeps consistent gutters while the top navigation now stretches truly edge-to-edge on phones for a native feel—no more stray right-side padding.
 - **Adaptive desktop canvas:** Domain dashboards, Search Console insights, and the research workspace reuse a shared `desktop-container` utility that expands to 90 % of the viewport on large screens so wide monitors surface more data at once.
+- **Focused loading states:** Keyword tables drive their own loading indicators, so the single-domain and research workspaces stay visible while data refreshes, and only the domains index keeps the full-page bootstrap overlay when first loading.
 - **Robust API:** Manage domains, keywords, settings, and refresh jobs programmatically for automated reporting pipelines.
 
 ### Platform architecture at a glance

--- a/__tests__/pages/domain.test.tsx
+++ b/__tests__/pages/domain.test.tsx
@@ -62,16 +62,16 @@ describe('SingleDomain Page', () => {
       expect(screen.getByTestId('domain-header')).toBeInTheDocument();
    });
 
-   it('renders the page loader while queries resolve', () => {
+   it('shows the keyword table spinner while queries resolve', () => {
       useFetchSettingsFunc.mockImplementation(() => ({ data: undefined, isLoading: true }));
       useFetchDomainsFunc.mockImplementation(() => ({ data: undefined, isLoading: true }));
       useFetchKeywordsFunc.mockImplementation(() => ({ keywordsData: undefined, keywordsLoading: true }));
 
       render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
 
-      const overlay = screen.getByTestId('page-loader-overlay');
-      expect(overlay).toBeInTheDocument();
-      expect(overlay).toHaveClass('fixed');
+      expect(screen.queryByTestId('page-loader-overlay')).not.toBeInTheDocument();
+      const spinner = screen.getByRole('status', { name: /loading keywords/i });
+      expect(spinner).toBeInTheDocument();
    });
 
    it('applies gutter spacing between the sidebar and content area', () => {

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -16,7 +16,6 @@ import { useFetchKeywords } from '../../../services/keywords';
 import { useFetchSettings } from '../../../services/settings';
 import AddKeywords from '../../../components/keywords/AddKeywords';
 import Footer from '../../../components/common/Footer';
-import PageLoader from '../../../components/common/PageLoader';
 
 const SingleDomain: NextPage = () => {
    const router = useRouter();
@@ -26,7 +25,7 @@ const SingleDomain: NextPage = () => {
    const [showSettings, setShowSettings] = useState(false);
    const [keywordSPollInterval, setKeywordSPollInterval] = useState<undefined|number>(undefined);
    const { data: appSettingsData, isLoading: isAppSettingsLoading } = useFetchSettings();
-   const { data: domainsData, isLoading: isDomainsLoading } = useFetchDomains(router, false);
+   const { data: domainsData } = useFetchDomains(router, false);
    const appSettings: SettingsType = appSettingsData?.settings || {};
    const { scraper_type = '', available_scapers = [] } = appSettings;
    const activeScraper = useMemo(() => available_scapers.find((scraper) => scraper.value === scraper_type), [scraper_type, available_scapers]);
@@ -48,10 +47,8 @@ const SingleDomain: NextPage = () => {
    const theDomains: DomainType[] = (domainsData && domainsData.domains) || [];
    const theKeywords: KeywordType[] = keywordsData && keywordsData.keywords;
 
-   const isPageLoading = isAppSettingsLoading || isDomainsLoading || keywordsLoading || !router.isReady;
-
    return (
-      <PageLoader isLoading={isPageLoading} className="Domain">
+      <div className="Domain">
          {(!isAppSettingsLoading && scraper_type === 'none') && (
                <div className=' p-3 bg-red-600 text-white text-sm text-center'>
                   A Scrapper/Proxy has not been set up Yet. Open Settings to set it up and start using the app.
@@ -111,7 +108,7 @@ const SingleDomain: NextPage = () => {
                />
          </CSSTransition>
          <Footer currentVersion={appSettings?.version ? appSettings.version : ''} />
-      </PageLoader>
+      </div>
    );
 };
 

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -13,7 +13,6 @@ import Settings from '../../components/settings/Settings';
 import SelectField from '../../components/common/SelectField';
 import allCountries, { adwordsLanguages } from '../../utils/countries';
 import Footer from '../../components/common/Footer';
-import PageLoader from '../../components/common/PageLoader';
 
 const Research: NextPage = () => {
    const router = useRouter();
@@ -57,10 +56,8 @@ const Research: NextPage = () => {
    const buttonLabelStyle = 'ml-2 text-sm not-italic lg:invisible lg:opacity-0';
    const labelStyle = 'mb-2 font-semibold inline-block text-sm text-gray-700 capitalize w-full';
 
-   const isPageLoading = !router.isReady || isSettingsLoading || isLoadingIdeas;
-
    return (
-      <PageLoader isLoading={isPageLoading} className='Login'>
+      <div className='Login'>
          <Head>
             <title>Research Keywords - SerpBear</title>
          </Head>
@@ -146,7 +143,7 @@ const Research: NextPage = () => {
              <Settings closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
          <Footer currentVersion={appSettings?.settings?.version ? appSettings.settings.version : ''} />
-      </PageLoader>
+      </div>
    );
 };
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,7 +6,7 @@
 
 @layer components {
    .desktop-container {
-      @apply w-full mx-auto lg:max-w-desktop;
+      @apply w-full lg:mx-auto lg:max-w-desktop;
    }
 }
 


### PR DESCRIPTION
## Summary
- remove the PageLoader wrapper from the single-domain and research pages so their tables drive scoped spinners while keeping layout and transitions intact
- adjust the shared desktop-container helper to only center content on large screens, letting the TopBar reach edge-to-edge on phones, and update documentation accordingly
- refresh the domain page tests to assert the new in-table loading indicator and document the UX tweaks in the changelog and README

## Testing
- npm run lint
- npm run lint:css
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d338f4f438832abd096d4d1e11a047