### PR TITLE
Add manual notification trigger button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Added a manual "Send Notifications Now" action to the Notification settings modal, surfacing success or error toasts when `/api/notify` completes so teams can validate SMTP credentials instantly.
 * Added a reusable page loader overlay and spinner placeholders so the domains dashboard, single-domain view, and research workspace stay blocked until router state and React Query data settle, while keeping loading labels accessible.
 * Removed redundant domain guards so dashboard headers, screenshots, and Search Console refreshes operate directly on the stored host names.
 * Removed the client-side guard that rejected blank domain slugs so `/api/domain` requests always hit the API and rely on server-side validation.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 
 - Email digests summarise rank gains/losses, highlight top movers, and include Search Console traffic data when available.
 - Notification cadence is fully configurable through `CRON_EMAIL_SCHEDULE`. Disable SMTP variables to skip sending emails entirely.
+- Trigger a manual run from the **Send Notifications Now** button in the Notification settings modal to confirm SMTP credentials and email recipients immediately.
 
 ---
 

--- a/__tests__/components/settings/NotificationSettings.test.tsx
+++ b/__tests__/components/settings/NotificationSettings.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import NotificationSettings from '../../../components/settings/NotificationSettings';
+import { useSendNotifications } from '../../../services/settings';
+
+jest.mock('../../../services/settings');
+
+const useSendNotificationsMock = useSendNotifications as jest.Mock;
+
+const buildSettings = (overrides: Partial<SettingsType> = {}): SettingsType => ({
+   scraper_type: 'none',
+   notification_interval: 'daily',
+   notification_email: 'notify@example.com',
+   notification_email_from: 'no-reply@example.com',
+   notification_email_from_name: 'SerpBear',
+   smtp_server: 'smtp.example.com',
+   smtp_port: '587',
+   smtp_tls_servername: '',
+   smtp_username: 'smtp-user',
+   smtp_password: 'smtp-pass',
+   search_console: true,
+   search_console_client_email: '',
+   search_console_private_key: '',
+   keywordsColumns: ['Best', 'History', 'Volume', 'Search Console'],
+   ...overrides,
+});
+
+describe('NotificationSettings manual trigger', () => {
+   afterEach(() => {
+      jest.clearAllMocks();
+   });
+
+   it('calls the send notifications mutation when the button is clicked', () => {
+      const mutate = jest.fn();
+      useSendNotificationsMock.mockReturnValue({ mutate, isLoading: false });
+
+      render(
+         <NotificationSettings
+            settings={buildSettings()}
+            settingsError={null}
+            updateSettings={jest.fn()}
+         />,
+      );
+
+      const triggerButton = screen.getByRole('button', { name: /send notifications now/i });
+      expect(triggerButton).toBeEnabled();
+
+      fireEvent.click(triggerButton);
+
+      expect(mutate).toHaveBeenCalledTimes(1);
+   });
+
+   it('disables the button while notifications are being sent', () => {
+      const mutate = jest.fn();
+      useSendNotificationsMock.mockReturnValue({ mutate, isLoading: true });
+
+      render(
+         <NotificationSettings
+            settings={buildSettings()}
+            settingsError={null}
+            updateSettings={jest.fn()}
+         />,
+      );
+
+      const triggerButton = screen.getByRole('button', { name: /send notifications now/i });
+
+      expect(triggerButton).toBeDisabled();
+   });
+});

--- a/services/settings.ts
+++ b/services/settings.ts
@@ -61,5 +61,41 @@ export function useClearFailedQueue(onSuccess:Function) {
    });
 }
 
+export const useSendNotifications = () => {
+   return useMutation(async () => {
+      const headers = new Headers({ 'Content-Type': 'application/json', Accept: 'application/json' });
+      const fetchOpts = { method: 'POST', headers };
+      const res = await fetch(`${window.location.origin}/api/notify`, fetchOpts);
+      let data: unknown = null;
+
+      try {
+         data = await res.json();
+      } catch (error) {
+         data = null;
+      }
+
+      if (!res.ok) {
+         const errorMessage = typeof data === 'object' && data !== null
+            ? (data as { message?: string; error?: string }).message
+               || (data as { message?: string; error?: string }).error
+               || 'Error Sending Notifications.'
+            : 'Error Sending Notifications.';
+         throw new Error(errorMessage);
+      }
+
+      return data;
+   }, {
+      onSuccess: (response) => {
+         const successMessage = typeof response === 'object' && response !== null
+            ? (response as { message?: string }).message || 'Notifications Sent!'
+            : 'Notifications Sent!';
+         toast(successMessage, { icon: '✔️' });
+      },
+      onError: (error: Error) => {
+         toast(error.message || 'Error Sending Notifications.', { icon: '⚠️' });
+      },
+   });
+};
+
 // Migration helpers were removed when the database API endpoint was retired. The
 // Docker entrypoint now owns running migrations during container startup.


### PR DESCRIPTION
## Summary
- add a `useSendNotifications` mutation that posts to `/api/notify` and surfaces toast feedback
- expose a **Send Notifications Now** button in notification settings that honors SMTP validity and loading state
- cover the new button with a focused NotificationSettings test suite

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d33bc7fab8832a88a51cdc575593f5