### PR TITLE
Ensure mobile topbar width spans viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Replaced the mobile TopBar gutter helper with explicit side paddings and a width expansion so its background spans the viewport while the body gutter stays intact.
 * Added a shared `LOG_SUCCESS_EVENTS` toggle so successful authentication and middleware INFO logs can be muted without touching warnings/errors, updated API callers to surface the option, and introduced Jest coverage for the quiet mode.
 * Added a manual "Send Notifications Now" action to the Notification settings modal, surfacing success or error toasts when `/api/notify` completes so teams can validate SMTP credentials instantly.
 * Added a reusable page loader overlay and spinner placeholders so the domains dashboard, single-domain view, and research workspace stay blocked until router state and React Query data settle, while keeping loading labels accessible.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ SerpBear is a full-stack Next.js application that tracks where your pages rank o
 - **Keyword research & ideas:** Pull search volumes and suggested keywords straight from your Google Ads test account.
 - **Google Search Console enrichment:** Overlay verified impression and click data on keyword trends to see which rankings actually drive traffic.
 - **Scheduled notifications:** Deliver branded summaries of ranking changes, winners/losers, and visit counts to your inbox.
-- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The layout keeps consistent gutters while the top navigation now stretches truly edge-to-edge on phones for a native feel—no more stray right-side padding.
+- **Mobile-ready progressive web app:** Install the dashboard on iOS or Android for quick monitoring on the go. The layout keeps consistent gutters while the top navigation now stretches truly edge-to-edge on phones—the helper offsets the body gutter and widens the bar so no stray right-side padding returns.
 - **Adaptive desktop canvas:** Domain dashboards, Search Console insights, and the research workspace reuse a shared `desktop-container` utility that expands to 90 % of the viewport on large screens so wide monitors surface more data at once.
 - **Focused loading states:** Keyword tables drive their own loading indicators, so the single-domain and research workspaces stay visible while data refreshes, and only the domains index keeps the full-page bootstrap overlay when first loading.
 - **Robust API:** Manage domains, keywords, settings, and refresh jobs programmatically for automated reporting pipelines.

--- a/__tests__/components/Topbar.test.tsx
+++ b/__tests__/components/Topbar.test.tsx
@@ -43,8 +43,11 @@ describe('TopBar Component', () => {
          expect(mobileSection).toMatch(/\.topbar\s*\{/);
          
          // Validate specific CSS properties with flexible whitespace handling
-         expect(mobileSection).toMatch(/margin-inline:\s*calc\(\s*-1\s*\*\s*var\(\s*--layout-inline\s*\)\s*\)\s*;/);
-         expect(mobileSection).toMatch(/padding-inline:\s*var\(\s*--layout-inline\s*\)\s*;/);
+         expect(mobileSection).toMatch(/margin-left:\s*calc\(\s*-1\s*\*\s*var\(\s*--layout-inline\s*\)\s*\)\s*;/);
+         expect(mobileSection).toMatch(/margin-right:\s*calc\(\s*-1\s*\*\s*var\(\s*--layout-inline\s*\)\s*\)\s*;/);
+         expect(mobileSection).toMatch(/padding-left:\s*var\(\s*--layout-inline\s*\)\s*;/);
+         expect(mobileSection).toMatch(/padding-right:\s*var\(\s*--layout-inline\s*\)\s*;/);
+         expect(mobileSection).toMatch(/width:\s*calc\(\s*100%\s*\+\s*\(\s*var\(\s*--layout-inline\s*\)\s*\*\s*2\s*\)\s*\)\s*;/);
       }
       
       // Ensure no body overrides in mobile media queries (maintains body gutters)

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -29,8 +29,11 @@ body {
 
 @media (max-width: 767px) {
    .topbar {
-      margin-inline: calc(-1 * var(--layout-inline));
-      padding-inline: var(--layout-inline);
+      margin-left: calc(-1 * var(--layout-inline));
+      margin-right: calc(-1 * var(--layout-inline));
+      padding-left: var(--layout-inline);
+      padding-right: var(--layout-inline);
+      width: calc(100% + (var(--layout-inline) * 2));
    }
 }
 


### PR DESCRIPTION
## Summary
- replace the mobile TopBar helper with explicit left/right margins and padding so the element offsets the body gutter
- expand the TopBar width to cover the viewport gutter and update the README/CHANGELOG documentation
- refresh the TopBar Jest assertion to match the new CSS declarations

## Testing
- npm run lint
- npm run lint:css
- npm run test -- __tests__/components/Topbar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d34411ab68832a87db43f20501b11e