### PR TITLE
Prevent adding duplicate keyword ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Marked Google Ads keyword ideas that already exist in the tracker as disabled for the active device, preventing duplicate selections and covering the behaviour with component tests.
 * Added a shared `LOG_SUCCESS_EVENTS` toggle so successful authentication and middleware INFO logs can be muted without touching warnings/errors, updated API callers to surface the option, and introduced Jest coverage for the quiet mode.
 * Added a manual "Send Notifications Now" action to the Notification settings modal, surfacing success or error toasts when `/api/notify` completes so teams can validate SMTP credentials instantly.
 * Added a reusable page loader overlay and spinner placeholders so the domains dashboard, single-domain view, and research workspace stay blocked until router state and React Query data settle, while keeping loading labels accessible.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 
 - Connect a Google Ads test account to unlock keyword suggestions and historical volume data right inside SerpBear.
 - The app exposes the same functionality through its REST API, making it easy to integrate with reporting pipelines.
+- Already-tracked keyword ideas now render as disabled for the active device so research flows stay deduplicated when you revisit Google Ads suggestions.
 
 ### Loading states & accessibility
 

--- a/__tests__/components/KeywordIdeasTable.test.tsx
+++ b/__tests__/components/KeywordIdeasTable.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import KeywordIdeasTable from '../../components/ideas/KeywordIdeasTable';
+import { useFetchKeywords } from '../../services/keywords';
+
+jest.mock('next/router', () => ({
+   useRouter: () => ({
+      pathname: '/domain/ideas/example-domain',
+      push: jest.fn(),
+      query: { slug: 'example-domain' },
+   }),
+}));
+
+jest.mock('../../hooks/useIsMobile', () => jest.fn(() => [true]));
+jest.mock('../../hooks/useWindowResize', () => jest.fn());
+
+jest.mock('../../services/keywords', () => ({
+   useAddKeywords: () => ({ mutate: jest.fn() }),
+   useFetchKeywords: jest.fn(),
+}));
+
+jest.mock('../../services/adwords', () => ({
+   useMutateFavKeywordIdeas: () => ({ mutate: jest.fn(), isLoading: false }),
+}));
+
+jest.mock('../../services/domains', () => ({
+   fetchDomains: jest.fn().mockResolvedValue({ domains: [] }),
+}));
+
+jest.mock('react-chartjs-2', () => ({
+   Line: () => null,
+}));
+
+const useFetchKeywordsMock = useFetchKeywords as jest.MockedFunction<typeof useFetchKeywords>;
+
+describe('KeywordIdeasTable tracked keyword behaviour', () => {
+   let queryClient: QueryClient;
+
+   const domain: DomainType = {
+      ID: 1,
+      domain: 'example.com',
+      slug: 'example-com',
+      notification: true,
+      notification_interval: 'daily',
+      notification_emails: '',
+      lastUpdated: '2024-01-01T00:00:00.000Z',
+      added: '2024-01-01T00:00:00.000Z',
+   };
+
+   const ideaKeywords: IdeaKeyword[] = [
+      {
+         uid: 'tracked-idea',
+         keyword: 'tracked term',
+         competition: 'MEDIUM',
+         country: 'US',
+         domain: 'example.com',
+         competitionIndex: 42,
+         monthlySearchVolumes: { '2024-01': '100' },
+         avgMonthlySearches: 100,
+         added: Date.now(),
+         updated: Date.now(),
+         position: 0,
+      },
+      {
+         uid: 'new-idea',
+         keyword: 'new term',
+         competition: 'LOW',
+         country: 'US',
+         domain: 'example.com',
+         competitionIndex: 21,
+         monthlySearchVolumes: { '2024-01': '50' },
+         avgMonthlySearches: 50,
+         added: Date.now(),
+         updated: Date.now(),
+         position: 0,
+      },
+   ];
+
+   const trackedKeywords: KeywordType[] = [
+      {
+         ID: 10,
+         keyword: 'tracked term',
+         device: 'desktop',
+         country: 'US',
+         domain: 'example.com',
+         lastUpdated: '2024-01-01T00:00:00.000Z',
+         added: '2024-01-01T00:00:00.000Z',
+         position: 5,
+         volume: 100,
+         sticky: false,
+         history: {},
+         lastResult: [],
+         url: 'https://example.com',
+         tags: [],
+         updating: false,
+         lastUpdateError: false,
+      },
+   ];
+
+   const renderTable = () => {
+      return render(
+         <QueryClientProvider client={queryClient}>
+            <KeywordIdeasTable
+               domain={domain}
+               keywords={ideaKeywords}
+               favorites={[]}
+               isLoading={false}
+               noIdeasDatabase={false}
+               isAdwordsIntegrated={true}
+               showFavorites={false}
+               setShowFavorites={jest.fn()}
+            />
+         </QueryClientProvider>,
+      );
+   };
+
+   beforeEach(() => {
+      queryClient = new QueryClient({
+         defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+         },
+      });
+
+      useFetchKeywordsMock.mockReturnValue({ keywordsData: { keywords: trackedKeywords }, keywordsLoading: false } as any);
+   });
+
+   afterEach(() => {
+      queryClient.clear();
+      jest.clearAllMocks();
+   });
+
+   it('marks tracked keyword ideas as disabled and prevents selection', async () => {
+      renderTable();
+
+      const trackedRow = screen.getByText('tracked term').closest('div.keyword');
+      expect(trackedRow).toBeInTheDocument();
+
+      const trackedButton = within(trackedRow as HTMLElement).getByRole('button', { name: /already tracked/i });
+      expect(trackedButton).toBeDisabled();
+      expect(trackedButton).toHaveAttribute('aria-disabled', 'true');
+
+      fireEvent.click(trackedButton);
+      await waitFor(() => {
+         expect(screen.queryByText('Add Keywords to Tracker')).not.toBeInTheDocument();
+      });
+      expect(trackedRow).not.toHaveClass('keyword--selected');
+
+      const untrackedRow = screen.getByText('new term').closest('div.keyword');
+      expect(untrackedRow).toBeInTheDocument();
+
+      const untrackedButton = within(untrackedRow as HTMLElement).getByRole('button', { name: /select keyword idea/i });
+      expect(untrackedButton).toBeEnabled();
+
+      fireEvent.click(untrackedButton);
+      await waitFor(() => {
+         expect(untrackedRow).toHaveClass('keyword--selected');
+      });
+      expect(await screen.findByText('Add Keywords to Tracker')).toBeInTheDocument();
+   });
+});

--- a/components/ideas/KeywordIdea.tsx
+++ b/components/ideas/KeywordIdea.tsx
@@ -54,8 +54,13 @@ const KeywordIdea = (props: KeywordIdeaProps) => {
             <button
                type="button"
                className={`p-0 mr-2 leading-[0px] inline-block rounded-sm pt-0 px-[1px] pb-[3px] border
-               ${isTracked || selected ? ' bg-blue-700 border-blue-700 text-white' : 'text-transparent'}
-               ${isTracked ? 'bg-gray-400 border-gray-400 cursor-not-allowed opacity-80' : ''}`}
+               ${
+                 isTracked
+                   ? 'bg-gray-400 border-gray-400 text-white cursor-not-allowed opacity-80'
+                   : selected
+                     ? 'bg-blue-700 border-blue-700 text-white'
+                     : 'text-transparent'
+               }`}
                aria-label={selectionLabel}
                aria-disabled={isTracked}
                disabled={isTracked}

--- a/components/ideas/KeywordIdea.tsx
+++ b/components/ideas/KeywordIdea.tsx
@@ -12,11 +12,22 @@ type KeywordIdeaProps = {
    style: Object,
    selectKeyword: Function,
    favoriteKeyword:Function,
-   showKeywordDetails: Function
+   showKeywordDetails: Function,
+   isTracked: boolean,
 }
 
 const KeywordIdea = (props: KeywordIdeaProps) => {
-   const { keywordData, selected, lastItem, selectKeyword, style, isFavorite = false, favoriteKeyword, showKeywordDetails } = props;
+   const {
+      keywordData,
+      selected,
+      lastItem,
+      selectKeyword,
+      style,
+      isFavorite = false,
+      favoriteKeyword,
+      showKeywordDetails,
+      isTracked = false,
+   } = props;
    const { keyword, uid, position, country, monthlySearchVolumes, avgMonthlySearches, competition, competitionIndex } = keywordData;
 
    const chartData = useMemo(() => {
@@ -28,20 +39,29 @@ const KeywordIdea = (props: KeywordIdeaProps) => {
       return chartDataObj;
    }, [monthlySearchVolumes]);
 
+   const selectionLabel = isTracked
+      ? 'Keyword already tracked'
+      : selected ? 'Deselect keyword idea' : 'Select keyword idea';
+
    return (
       <div
       key={keyword}
       style={style}
-      className={`keyword relative py-5 px-4 text-gray-600 border-b-[1px] border-gray-200 lg:py-4 lg:px-6 lg:border-0 
+      className={`keyword relative py-5 px-4 text-gray-600 border-b-[1px] border-gray-200 lg:py-4 lg:px-6 lg:border-0
       lg:flex lg:justify-between lg:items-center ${selected ? ' bg-indigo-50 keyword--selected' : ''} ${lastItem ? 'border-b-0' : ''}`}>
 
          <div className=' w-3/4 lg:flex-1 lg:basis-20 lg:w-auto font-semibold cursor-pointer'>
             <button
-               className={`p-0 mr-2 leading-[0px] inline-block rounded-sm pt-0 px-[1px] pb-[3px] border 
-               ${selected ? ' bg-blue-700 border-blue-700 text-white' : 'text-transparent'}`}
-               onClick={() => selectKeyword(uid)}
+               type="button"
+               className={`p-0 mr-2 leading-[0px] inline-block rounded-sm pt-0 px-[1px] pb-[3px] border
+               ${isTracked || selected ? ' bg-blue-700 border-blue-700 text-white' : 'text-transparent'}
+               ${isTracked ? 'bg-gray-400 border-gray-400 cursor-not-allowed opacity-80' : ''}`}
+               aria-label={selectionLabel}
+               aria-disabled={isTracked}
+               disabled={isTracked}
+               onClick={() => { if (!isTracked) { selectKeyword(uid, isTracked); } }}
                >
-                  <Icon type="check" size={10} />
+                  <Icon type="check" size={10} title={isTracked ? 'Already in Tracker' : ''} />
             </button>
             <a className='py-2 hover:text-blue-600' onClick={() => showKeywordDetails()}>
                <span className={`fflag fflag-${country} w-[18px] h-[12px] mr-2`} title={countries[country] && countries[country][0]} />{keyword}

--- a/components/ideas/KeywordIdea.tsx
+++ b/components/ideas/KeywordIdea.tsx
@@ -59,7 +59,7 @@ const KeywordIdea = (props: KeywordIdeaProps) => {
                aria-label={selectionLabel}
                aria-disabled={isTracked}
                disabled={isTracked}
-               onClick={() => { if (!isTracked) { selectKeyword(uid, isTracked); } }}
+               onClick={() => selectKeyword(uid, isTracked)}
                >
                   <Icon type="check" size={10} title={isTracked ? 'Already in Tracker' : ''} />
             </button>

--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -47,10 +47,10 @@ const IdeasKeywordsTable = ({
    const { keywordsData: trackedKeywordsData } = useFetchKeywords(router, trackedDomain);
 
    const trackedKeywordsList: KeywordType[] = useMemo(() => {
-      if (!trackedKeywordsData) { return []; }
-      if (Array.isArray(trackedKeywordsData)) { return trackedKeywordsData as KeywordType[]; }
-      if (Array.isArray(trackedKeywordsData.keywords)) { return trackedKeywordsData.keywords as KeywordType[]; }
-      return [];
+      if (Array.isArray(trackedKeywordsData)) {
+         return trackedKeywordsData as KeywordType[];
+      }
+      return (trackedKeywordsData?.keywords as KeywordType[]) || [];
    }, [trackedKeywordsData]);
 
    const trackedKeywordLookup = useMemo(() => {

--- a/components/ideas/KeywordIdeasTable.tsx
+++ b/components/ideas/KeywordIdeasTable.tsx
@@ -1,8 +1,8 @@
 import { useRouter } from 'next/router';
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useQuery } from 'react-query';
 import { FixedSizeList as List, ListChildComponentProps } from 'react-window';
-import { useAddKeywords } from '../../services/keywords';
+import { useAddKeywords, useFetchKeywords } from '../../services/keywords';
 import { formatLocation } from '../../utils/location';
 import Icon from '../common/Icon';
 import SpinnerMessage from '../common/SpinnerMessage';
@@ -43,6 +43,38 @@ const IdeasKeywordsTable = ({
    const [isMobile] = useIsMobile();
    const isResearchPage = router.pathname === '/research';
 
+   const trackedDomain = isResearchPage ? addKeywordDomain : (domain?.domain || '');
+   const { keywordsData: trackedKeywordsData } = useFetchKeywords(router, trackedDomain);
+
+   const trackedKeywordsList: KeywordType[] = useMemo(() => {
+      if (!trackedKeywordsData) { return []; }
+      if (Array.isArray(trackedKeywordsData)) { return trackedKeywordsData as KeywordType[]; }
+      if (Array.isArray(trackedKeywordsData.keywords)) { return trackedKeywordsData.keywords as KeywordType[]; }
+      return [];
+   }, [trackedKeywordsData]);
+
+   const trackedKeywordLookup = useMemo(() => {
+      const lookup:Record<string, boolean> = {};
+      trackedKeywordsList.forEach((trackedKeyword) => {
+         const { keyword: trackedKeywordValue, country: trackedCountry, device: trackedDevice } = trackedKeyword;
+         if (trackedKeywordValue && trackedCountry && trackedDevice) {
+            lookup[`${trackedKeywordValue}:${trackedCountry}:${trackedDevice}`] = true;
+         }
+      });
+      return lookup;
+   }, [trackedKeywordsList]);
+
+   const trackedDevicesToCheck = useMemo(() => {
+      if (addKeywordDevice === 'desktop' || addKeywordDevice === 'mobile') {
+         return [addKeywordDevice];
+      }
+      return ['desktop', 'mobile'];
+   }, [addKeywordDevice]);
+
+   const isIdeaTracked = useCallback((idea: IdeaKeyword) => {
+      return trackedDevicesToCheck.some((device) => trackedKeywordLookup[`${idea.keyword}:${idea.country}:${device}`]);
+   }, [trackedDevicesToCheck, trackedKeywordLookup]);
+
    const { data: domainsData } = useQuery(
       ['domains', false],
       () => fetchDomains(router, false),
@@ -57,6 +89,10 @@ const IdeasKeywordsTable = ({
       const sortedKeywords = IdeasSortKeywords(filteredKeywords, sortBy);
       return sortedKeywords;
    }, [keywords, showFavorites, favorites, filterParams, sortBy]);
+
+   const selectableKeywordIds = useMemo(() => {
+      return finalKeywords.filter((keyword) => !isIdeaTracked(keyword)).map((keyword) => keyword.uid);
+   }, [finalKeywords, isIdeaTracked]);
 
    const favoriteIDs: string[] = useMemo(() => favorites.map((fav) => fav.uid), [favorites]);
 
@@ -82,7 +118,8 @@ const IdeasKeywordsTable = ({
       return finalWordTags;
    }, [keywords]);
 
-   const selectKeyword = (keywordID: string) => {
+   const selectKeyword = (keywordID: string, isTrackedKeyword = false) => {
+      if (isTrackedKeyword) { return; }
       let updatedSelected = [...selectedKeywords, keywordID];
       if (selectedKeywords.includes(keywordID)) {
          updatedSelected = selectedKeywords.filter((keyID) => keyID !== keywordID);
@@ -115,10 +152,11 @@ const IdeasKeywordsTable = ({
       setSelectedKeywords([]);
    };
 
-   const selectedAllItems = selectedKeywords.length === finalKeywords.length;
+   const selectedAllItems = selectableKeywordIds.length > 0 && selectedKeywords.length === selectableKeywordIds.length;
 
    const Row = ({ data, index, style }:ListChildComponentProps) => {
       const keyword: IdeaKeyword = data[index];
+      const tracked = isIdeaTracked(keyword);
       return (
          <KeywordIdea
          key={keyword.uid}
@@ -130,6 +168,7 @@ const IdeasKeywordsTable = ({
          isFavorite={favoriteIDs.includes(keyword.uid)}
          keywordData={keyword}
          lastItem={index === (finalKeywords.length - 1)}
+         isTracked={tracked}
          />
       );
    };
@@ -139,7 +178,9 @@ const IdeasKeywordsTable = ({
       if (isMobile) {
          keywordsContent = (
             <div className='block sm:hidden'>
-               {finalKeywords.map((keyword, index) => (
+               {finalKeywords.map((keyword, index) => {
+                  const tracked = isIdeaTracked(keyword);
+                  return (
                   <KeywordIdea
                      key={keyword.uid}
                      style={{}}
@@ -150,8 +191,10 @@ const IdeasKeywordsTable = ({
                      isFavorite={favoriteIDs.includes(keyword.uid)}
                      keywordData={keyword}
                      lastItem={index === (finalKeywords.length - 1)}
+                     isTracked={tracked}
                   />
-               ))}
+               );
+               })}
             </div>
          );
       } else {
@@ -255,10 +298,10 @@ const IdeasKeywordsTable = ({
                         <button
                            className={`p-0 mr-2 leading-[0px] inline-block rounded-sm pt-0 px-[1px] pb-[3px]  border border-slate-300 
                            ${selectedAllItems ? ' bg-blue-700 border-blue-700 text-white' : 'text-transparent'}`}
-                           onClick={() => setSelectedKeywords(selectedAllItems ? [] : finalKeywords.map((k: IdeaKeyword) => k.uid))}
+                           onClick={() => setSelectedKeywords(selectedAllItems ? [] : [...selectableKeywordIds])}
                            >
                               <Icon type="check" size={10} />
-                        </button>
+                       </button>
                      )}
                         Keyword
                      </span>


### PR DESCRIPTION
## Summary
- load tracked keyword data for the current domain in the keyword ideas table and skip already-tracked entries when toggling selections
- disable the keyword idea selection checkbox when a suggestion already exists for the chosen device and style the button as read-only
- add component coverage to confirm tracked keyword ideas render disabled and cannot be added twice, plus document the behaviour

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d341dbe038832a9aeddd116f2a77d1