### PR TITLE
style: remove trailing commas from configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Removed trailing commas from configuration and migration files to align with the project's linting rules.
+
 * Replaced the Icon component's 50-branch conditional with a renderer map, exported reusable keyword filter predicates for both tracked and idea keywords, and added targeted Jest coverage to keep the new helpers and fallbacks correct.
 * Marked Google Ads keyword ideas that already exist in the tracker as disabled for the active device, preventing duplicate selections and covering the behaviour with component tests.
 * Added a shared `LOG_SUCCESS_EVENTS` toggle so successful authentication and middleware INFO logs can be muted without touching warnings/errors, updated API callers to surface the option, and introduced Jest coverage for the quiet mode.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
 - **Code quality:**
   - `npm run lint` for ESLint (JavaScript/TypeScript).
   - `npm run lint:css` for Stylelint (global styles).
+  - Follow the repository's no-trailing-commas rule for object and array literals so configuration changes pass linting.
 - **Testing:**
   - `npm test` executes the Jest test suite using the `@happy-dom/jest-environment` adapter.
   - `npm run test:ci` mirrors the CI environment.

--- a/cron.js
+++ b/cron.js
@@ -42,7 +42,7 @@ const getAppSettings = async () => {
       smtp_server: '',
       smtp_port: '',
       smtp_username: '',
-      smtp_password: '',
+      smtp_password: ''
    };
    // console.log('process.env.SECRET: ', process.env.SECRET);
    try {

--- a/database/config.js
+++ b/database/config.js
@@ -13,7 +13,7 @@ module.exports = {
     storage: './data/database.sqlite',
     dialectModulePath,
     dialectOptions: {
-      bigNumberStrings: true,
-    },
-  },
+      bigNumberStrings: true
+    }
+  }
 };

--- a/database/migrations/1737100000000-normalise-keyword-history.js
+++ b/database/migrations/1737100000000-normalise-keyword-history.js
@@ -16,7 +16,7 @@ module.exports = {
                {
                   type: SequelizeLib.DataTypes.STRING,
                   allowNull: true,
-                  defaultValue: JSON.stringify({}),
+                  defaultValue: JSON.stringify({})
                },
                { transaction }
             );
@@ -29,7 +29,7 @@ module.exports = {
                "OR TRIM(history) = ''",
                "OR history = '[]'",
                "OR LOWER(history) = 'null'",
-               "OR LOWER(history) = 'false'",
+               "OR LOWER(history) = 'false'"
             ].join(' '),
             { transaction }
          );
@@ -55,7 +55,7 @@ module.exports = {
                {
                   type: SequelizeLib.DataTypes.STRING,
                   allowNull: true,
-                  defaultValue: JSON.stringify([]),
+                  defaultValue: JSON.stringify([])
                },
                { transaction }
             );
@@ -68,12 +68,12 @@ module.exports = {
                "OR TRIM(history) = ''",
                "OR history = '{}'",
                "OR LOWER(history) = 'null'",
-               "OR LOWER(history) = 'false'",
+               "OR LOWER(history) = 'false'"
             ].join(' '),
             { transaction }
          );
 
          console.log('Reverted keyword history defaults to legacy empty arrays.');
       });
-   },
+   }
 };

--- a/database/migrations/1737205000000-collapse-keyword-location-fields.js
+++ b/database/migrations/1737205000000-collapse-keyword-location-fields.js
@@ -155,7 +155,7 @@ module.exports = {
                const updates = {
                   city: parsed.city || '',
                   state: parsed.state || '',
-                  country: parsed.country || country || '',
+                  country: parsed.country || country || ''
                };
 
                await queryInterface.sequelize.query(
@@ -166,8 +166,8 @@ module.exports = {
                         id: ID,
                         city: updates.city,
                         state: updates.state,
-                        country: updates.country,
-                     },
+                        country: updates.country
+                     }
                   }
                );
             }
@@ -175,5 +175,5 @@ module.exports = {
 
          console.log('Restored keyword city/state columns from location.');
       });
-   },
+   }
 };

--- a/database/sqlite-dialect.js
+++ b/database/sqlite-dialect.js
@@ -130,7 +130,7 @@ class Database extends EventEmitter {
     try {
       const options = {
         readonly: hasFlag(flags, OPEN_READONLY) && !hasFlag(flags, OPEN_READWRITE),
-        fileMustExist: !hasFlag(flags, OPEN_CREATE),
+        fileMustExist: !hasFlag(flags, OPEN_CREATE)
       };
       this.driver = new BetterSqlite3(filename, options);
       this.open = true;
@@ -229,7 +229,7 @@ class Database extends EventEmitter {
       database: this,
       sql,
       lastID: undefined,
-      changes: 0,
+      changes: 0
     };
 
     try {
@@ -277,7 +277,7 @@ const cached = {
       }
     }
     return this.objects[resolved];
-  },
+  }
 };
 
 const sqlite = {
@@ -288,7 +288,7 @@ const sqlite = {
   cached,
   verbose() {
     return sqlite;
-  },
+  }
 };
 
 module.exports = sqlite;

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ require('dotenv').config({ path: './.env.local' });
 
 const createJestConfig = nextJest({
   // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-  dir: './',
+  dir: './'
 });
 
 const uuidPath = require.resolve('uuid');
@@ -17,14 +17,14 @@ const customJestConfig = {
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: '@happy-dom/jest-environment',
   transformIgnorePatterns: [
-    '/node_modules/(?!(sequelize|until-async|@bundled-es-modules|msw|uuid)/)',
+    '/node_modules/(?!(sequelize|until-async|@bundled-es-modules|msw|uuid)/)'
   ],
   moduleNameMapper: {
     '^uuid$': uuidPath,
     'better-sqlite3': '<rootDir>/__mocks__/better-sqlite3.js',
-    '^until-async$': '<rootDir>/__mocks__/until-async.js',
+    '^until-async$': '<rootDir>/__mocks__/until-async.js'
   },
-  modulePathIgnorePatterns: ['<rootDir>/.next/'],
+  modulePathIgnorePatterns: ['<rootDir>/.next/']
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,13 +8,13 @@ global.TextDecoder = TextDecoder;
 const { ReadableStream, WritableStream, TransformStream } = require('stream/web');
 
 if (!global.ReadableStream) {
-   global.ReadableStream = ReadableStream;
+  global.ReadableStream = ReadableStream;
 }
 if (!global.WritableStream) {
-   global.WritableStream = WritableStream;
+  global.WritableStream = WritableStream;
 }
 if (!global.TransformStream) {
-   global.TransformStream = TransformStream;
+  global.TransformStream = TransformStream;
 }
 
 const { fetch: undiciFetch, Headers, Request, Response } = require('undici');
@@ -25,43 +25,47 @@ const { fetch: undiciFetch, Headers, Request, Response } = require('undici');
 // Learn more: https://github.com/testing-library/jest-dom
 
 if (typeof window !== 'undefined') {
-   window.matchMedia = (query) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: jest.fn(), // deprecated
-      removeListener: jest.fn(), // deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-   });
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  });
 
-   const locationMock = {
-      hash: '',
-      host: 'localhost',
-      hostname: 'localhost',
-      href: 'http://localhost/',
-      origin: 'http://localhost',
-      pathname: '/',
-      port: '',
-      protocol: 'http:',
-      search: '',
-      assign: jest.fn((value) => { locationMock.href = value; }),
-      replace: jest.fn((value) => { locationMock.href = value; }),
-      reload: jest.fn(),
-      toString: () => locationMock.href,
-   };
+  const locationMock = {
+    hash: '',
+    host: 'localhost',
+    hostname: 'localhost',
+    href: 'http://localhost/',
+    origin: 'http://localhost',
+    pathname: '/',
+    port: '',
+    protocol: 'http:',
+    search: '',
+    assign: jest.fn((value) => {
+      locationMock.href = value;
+    }),
+    replace: jest.fn((value) => {
+      locationMock.href = value;
+    }),
+    reload: jest.fn(),
+    toString: () => locationMock.href
+  };
 
-   Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: locationMock,
-   });
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: locationMock
+  });
 }
 
 global.ResizeObserver = require('resize-observer-polyfill');
 
 if (!global.fetch) {
-   global.fetch = undiciFetch;
+  global.fetch = undiciFetch;
 }
 global.Headers = Headers;
 global.Request = Request;
@@ -69,25 +73,25 @@ global.Response = Response;
 
 // polyfill BroadcastChannel for msw
 class BroadcastChannelMock {
-   constructor(name) {
-      this.name = name;
-      this.messages = [];
-   }
+  constructor(name) {
+    this.name = name;
+    this.messages = [];
+  }
 
-   postMessage(message) {
-      this.messages.push(message);
-   }
+  postMessage(message) {
+    this.messages.push(message);
+  }
 
-   close() {
-      this.messages = [];
-   }
+  close() {
+    this.messages = [];
+  }
 
-   addEventListener() {
-      return this;
-   }
+  addEventListener() {
+    return this;
+  }
 
-   removeEventListener() {
-      return this;
-   }
+  removeEventListener() {
+    return this;
+  }
 }
 global.BroadcastChannel = BroadcastChannelMock;

--- a/next.config.js
+++ b/next.config.js
@@ -5,25 +5,25 @@ const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
   publicRuntimeConfig: {
-    version,
+    version
   },
-  
+
   // Performance optimizations
   experimental: {
-    optimizePackageImports: ['react-icons', 'react-chartjs-2', 'react-query'],
+    optimizePackageImports: ['react-icons', 'react-chartjs-2', 'react-query']
   },
-  
+
   // Compiler optimizations
   compiler: {
     // Preserve server logging by default; opt-in via NEXT_REMOVE_CONSOLE
     removeConsole:
       process.env.NEXT_REMOVE_CONSOLE === 'true'
         ? {
-            exclude: ['error'],
+            exclude: ['error']
           }
-        : false,
+        : false
   },
-  
+
   // Bundle analyzer (enable with ANALYZE=true)
   ...(process.env.ANALYZE === 'true' && {
     webpack: (config, { dev, isServer, defaultLoaders, nextRuntime, webpack }) => {
@@ -33,21 +33,21 @@ const nextConfig = {
           new BundleAnalyzerPlugin({
             analyzerMode: 'static',
             reportFilename: 'bundle-analyzer-report.html',
-            openAnalyzer: false,
+            openAnalyzer: false
           })
         );
       }
       return config;
-    },
+    }
   }),
-  
+
   // Image optimization
   images: {
     formats: ['image/webp', 'image/avif'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384]
   },
-  
+
   // Webpack optimizations
   webpack: (config, { dev, isServer, defaultLoaders, nextRuntime, webpack }) => {
     // Bundle size optimizations
@@ -58,19 +58,19 @@ const nextConfig = {
           test: /[\\/]node_modules[\\/]/,
           name: 'vendors',
           chunks: 'all',
-          priority: 10,
+          priority: 10
         },
         common: {
           name: 'common',
           minChunks: 2,
           chunks: 'all',
-          priority: 5,
-        },
+          priority: 5
+        }
       };
     }
-    
+
     return config;
-  },
+  }
 };
 
 module.exports = nextConfig;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
-    autoprefixer: {},
-  },
+    autoprefixer: {}
+  }
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,23 +1,23 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-   content: [
-      './pages/**/*.{js,ts,jsx,tsx}',
-      './components/**/*.{js,ts,jsx,tsx}',
-   ],
-   safelist: [
-      'max-h-48',
-      'w-[150px]',
-      'w-[240px]',
-      'min-w-[270px]',
-      'min-w-[180px]',
-      'max-w-[180px]',
-    ],
-   theme: {
-     extend: {
-       maxWidth: {
-         desktop: '90vw',
-       },
-     },
-   },
-   plugins: [],
- };
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  safelist: [
+    'max-h-48',
+    'w-[150px]',
+    'w-[240px]',
+    'min-w-[270px]',
+    'min-w-[180px]',
+    'max-w-[180px]'
+  ],
+  theme: {
+    extend: {
+      maxWidth: {
+        desktop: '90vw'
+      }
+    }
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- remove trailing commas from Tailwind, PostCSS, Next.js, and Jest configs to satisfy the lint rule on object and array literals
- strip trailing commas from cron defaults, database migrations, and the SQLite dialect implementation so runtime helpers match the same formatting
- document the no-trailing-commas convention in the changelog and README contribution guidance

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d352735c44832a9bc0ab06a0d50782