### PR TITLE
feat(settings): guide manual notification trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Added inline guidance and ARIA status messaging to the Notification settings "Send Notifications Now" control so manual email runs advertise readiness and progress to assistive tech.
 * Removed trailing commas from configuration and migration files to align with the project's linting rules.
 
 * Replaced the Icon component's 50-branch conditional with a renderer map, exported reusable keyword filter predicates for both tracked and idea keywords, and added targeted Jest coverage to keep the new helpers and fallbacks correct.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 
 - Email digests summarise rank gains/losses, highlight top movers, and include Search Console traffic data when available.
 - Notification cadence is fully configurable through `CRON_EMAIL_SCHEDULE`. Disable SMTP variables to skip sending emails entirely.
-- Trigger a manual run from the **Send Notifications Now** button in the Notification settings modal to confirm SMTP credentials and email recipients immediately.
+- Trigger a manual run from the **Send Notifications Now** button in the Notification settings modal. Inline guidance and assistive-technology announcements walk through the prerequisites so teams can confirm SMTP credentials and email recipients immediately.
 
 ---
 

--- a/__tests__/components/settings/NotificationSettings.test.tsx
+++ b/__tests__/components/settings/NotificationSettings.test.tsx
@@ -44,6 +44,9 @@ describe('NotificationSettings manual trigger', () => {
 
       const triggerButton = screen.getByRole('button', { name: /send notifications now/i });
       expect(triggerButton).toBeEnabled();
+      expect(triggerButton).toHaveAttribute('aria-busy', 'false');
+      expect(screen.getByText(/Send a notification email immediately/i)).toBeInTheDocument();
+      expect(screen.getByText(/Ready to send notifications immediately\./i)).toBeInTheDocument();
 
       fireEvent.click(triggerButton);
 
@@ -65,6 +68,24 @@ describe('NotificationSettings manual trigger', () => {
       const triggerButton = screen.getByRole('button', { name: /send notifications now/i });
 
       expect(triggerButton).toBeDisabled();
+   });
+
+   it('announces progress updates for assistive technology when sending notifications', () => {
+      const mutate = jest.fn();
+      useSendNotificationsMock.mockReturnValue({ mutate, isLoading: true });
+
+      render(
+         <NotificationSettings
+            settings={buildSettings()}
+            settingsError={null}
+            updateSettings={jest.fn()}
+         />,
+      );
+
+      const triggerButton = screen.getByRole('button', { name: /send notifications now/i });
+
+      expect(triggerButton).toHaveAttribute('aria-busy', 'true');
+      expect(screen.getByText(/Sending notifications/i)).toBeInTheDocument();
    });
 
    it('handles numeric SMTP values without throwing TypeError', () => {
@@ -104,9 +125,8 @@ describe('NotificationSettings manual trigger', () => {
          smtp_password: 'password123',
       });
 
-      let component: any;
       expect(() => {
-         component = render(
+         render(
             <NotificationSettings
                settings={mixedSettings}
                settingsError={null}

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -30,6 +30,17 @@ const NotificationSettings = ({ settings, settingsError, updateSettings }:Notifi
       && hasSmtpPort
       && hasNotificationEmails;
 
+   const manualTriggerHelpId = 'manual-notification-help';
+   const manualTriggerStatusId = 'manual-notification-status';
+   const manualTriggerDescription = 'Send a notification email immediately to confirm your SMTP credentials '
+      + 'and recipient list.';
+   const manualTriggerStatus = sendingNotifications
+      ? 'Sending notifications…'
+      : canSendNotifications
+         ? 'Ready to send notifications immediately.'
+         : 'Update your SMTP and notification settings to enable manual sends.';
+   const manualTriggerAriaDescription = `${manualTriggerHelpId} ${manualTriggerStatusId}`;
+
    const handleSendNotifications = () => {
       triggerNotifications();
    };
@@ -132,8 +143,16 @@ const NotificationSettings = ({ settings, settingsError, updateSettings }:Notifi
                         />
                   </div>
                   <div className="settings__section__input mb-5">
+                     <p id={manualTriggerHelpId} className='text-xs text-slate-600 mb-2'>
+                        {manualTriggerDescription}
+                     </p>
+                     <p id={manualTriggerStatusId} className='sr-only' aria-live='polite'>
+                        {manualTriggerStatus}
+                     </p>
                      <button
                         type='button'
+                        aria-describedby={manualTriggerAriaDescription}
+                        aria-busy={sendingNotifications}
                         onClick={handleSendNotifications}
                         disabled={!canSendNotifications || sendingNotifications}
                         className={sendNotificationsButtonClasses}
@@ -147,7 +166,12 @@ const NotificationSettings = ({ settings, settingsError, updateSettings }:Notifi
 
             </div>
             {settingsError?.msg && (
-               <div className='absolute w-full bottom-16  text-center p-3 bg-red-100 text-red-600 text-sm font-semibold'>
+               <div
+                  className={[
+                     'absolute w-full bottom-16 text-center',
+                     'p-3 bg-red-100 text-red-600 text-sm font-semibold',
+                  ].join(' ')}
+               >
                   {settingsError.msg}
                </div>
             )}


### PR DESCRIPTION
## Summary
- add inline guidance and ARIA status messaging to the Notification settings manual send button
- surface manual send readiness in the README and changelog documentation
- extend NotificationSettings tests to cover the new accessibility affordances

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d361ffe870832aa20a3f4a10db187f