### PR TITLE
Normalize keyword updating flags returned from parseKeywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Normalised keyword `updating` flags parsed from the database so `'0'`/`'false'` records no longer leave the dashboard stuck on loading spinners after a refresh.
 * Propagated map-pack membership from supported scrapers through persistence, emails, and keyword UIs, adding a stacked CSS badge that references `map-pack.png` whenever a tracked domain appears in the local pack top three.
 * Raised ESLint's `max-len` threshold to 200 characters, relaxed the complexity limit to a warning at 60, and delegated unused-variable checks to `@typescript-eslint` so linting no longer fails on long SVG paths or intentionally ignored caught errors.
 * Added inline guidance and ARIA status messaging to the Notification settings "Send Notifications Now" control so manual email runs advertise readiness and progress to assistive tech.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
 
 ## Troubleshooting & tips
 
+- **Keyword rows stuck on the loading spinner:** Upgrading to this release normalises legacy `'0'`/`'false'` boolean flags returned by SQLite/MySQL so refreshed keywords flip their `updating` state back to `false`. Trigger another keyword refresh after deploying to clear any previously stuck rows.
 - **Missing screenshots:** If dashboard thumbnails show the fallback favicon, confirm `SCREENSHOT_API` is set and `NEXT_PUBLIC_SCREENSHOTS=true`.
 - **Screenshot refresh skips:** Manual thumbnail updates now always hit the screenshot service with the stored host, so investigate provider logs if a toast reports a failure instead of assuming the button silently ignored the request.
 - **Empty domain slugs:** The dashboard now always requests `/api/domain`, even for blank slugs, so the API returns descriptive validation errors instead of the client throwing immediately.

--- a/__tests__/utils/parseKeywords.test.ts
+++ b/__tests__/utils/parseKeywords.test.ts
@@ -1,0 +1,53 @@
+import parseKeywords from '../../utils/parseKeywords';
+
+describe('parseKeywords', () => {
+   const buildKeyword = (overrides: Partial<Record<string, any>> = {}) => ({
+      ID: 1,
+      keyword: 'example keyword',
+      device: 'desktop',
+      country: 'US',
+      domain: 'example.com',
+      lastUpdated: '2025-01-01T00:00:00.000Z',
+      added: '2025-01-01T00:00:00.000Z',
+      position: 5,
+      volume: 100,
+      sticky: true,
+      history: JSON.stringify({ '2025-01-01': 5 }),
+      lastResult: JSON.stringify([]),
+      url: 'https://example.com/page',
+      tags: JSON.stringify(['tag']),
+      updating: false,
+      lastUpdateError: 'false',
+      map_pack_top3: 0,
+      ...overrides,
+   });
+
+   it('normalises falsy boolean variants to false', () => {
+      const [keyword] = parseKeywords([
+         buildKeyword({ updating: '0', sticky: 'no', map_pack_top3: 'false' }) as any,
+      ]);
+
+      expect(keyword.updating).toBe(false);
+      expect(keyword.sticky).toBe(false);
+      expect(keyword.mapPackTop3).toBe(false);
+   });
+
+   it('normalises truthy boolean variants to true', () => {
+      const [keyword] = parseKeywords([
+         buildKeyword({ updating: '1', sticky: 'YES', map_pack_top3: 1 }) as any,
+      ]);
+
+      expect(keyword.updating).toBe(true);
+      expect(keyword.sticky).toBe(true);
+      expect(keyword.mapPackTop3).toBe(true);
+   });
+
+   it('keeps existing keyword structure intact', () => {
+      const [keyword] = parseKeywords([buildKeyword({ updating: 0 }) as any]);
+
+      expect(keyword.history).toEqual({ '2025-01-01': 5 });
+      expect(keyword.tags).toEqual(['tag']);
+      expect(keyword.lastResult).toEqual([]);
+      expect(keyword.location).toBe('');
+   });
+});

--- a/utils/parseKeywords.ts
+++ b/utils/parseKeywords.ts
@@ -21,6 +21,30 @@ export const normaliseHistory = (rawHistory: unknown): KeywordHistory => {
  * @param {Keyword[]} allKeywords - Keywords to scrape
  * @returns {KeywordType[]}
  */
+const normaliseBoolean = (value: unknown): boolean => {
+   if (typeof value === 'boolean') {
+      return value;
+   }
+
+   if (typeof value === 'number') {
+      return value !== 0;
+   }
+
+   if (typeof value === 'string') {
+      const trimmed = value.trim().toLowerCase();
+      if (trimmed === '' || trimmed === '0' || trimmed === 'false' || trimmed === 'no' || trimmed === 'off') {
+         return false;
+      }
+      if (trimmed === '1' || trimmed === 'true' || trimmed === 'yes' || trimmed === 'on') {
+         return true;
+      }
+
+      return Boolean(trimmed);
+   }
+
+   return Boolean(value);
+};
+
 const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
    const parsedItems = allKeywords.map((keywrd:Keyword) => {
       let historyRaw: unknown;
@@ -38,10 +62,11 @@ const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
          try { lastUpdateError = JSON.parse(keywrd.lastUpdateError); } catch { lastUpdateError = {}; }
       }
 
-      const rawMapPack = (keywrd as any).map_pack_top3;
-      const mapPackTop3 = typeof rawMapPack === 'boolean'
-         ? rawMapPack
-         : ((keywrd as any).mapPackTop3 === true);
+      const rawMapPack = (keywrd as any).map_pack_top3 ?? (keywrd as any).mapPackTop3;
+      const mapPackTop3 = normaliseBoolean(rawMapPack);
+
+      const updating = normaliseBoolean((keywrd as any).updating);
+      const sticky = normaliseBoolean((keywrd as any).sticky);
 
       return {
          ...keywrd,
@@ -50,6 +75,8 @@ const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
          tags,
          lastResult,
          lastUpdateError,
+         sticky,
+         updating,
          mapPackTop3,
       };
    });


### PR DESCRIPTION
## Summary
- coerce boolean-like fields in `parseKeywords` so the dashboard stops treating `'0'`/`'false'` values as "updating"
- expand `parseKeywords` coverage to verify keyword structure and flag normalisation
- document the stuck-spinner fix in the changelog and README troubleshooting section

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d390a53d58832aa84adf2110e60956