### PR TITLE
Potential fix for code scanning alert no. 1110: Disallow unused variables

### DIFF
--- a/utils/security.ts
+++ b/utils/security.ts
@@ -136,7 +136,7 @@ export const sanitizeJsonInput = (input: any): { isValid: boolean; sanitized: an
       }
       
       return { isValid: false, sanitized: null };
-   } catch (error) {
+   } catch (_error) {
       return { isValid: false, sanitized: null };
    }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/djav1985/v-serpbear/security/code-scanning/1110](https://github.com/djav1985/v-serpbear/security/code-scanning/1110)

To fix the problem, the catch block parameter on line 139 should be renamed from `error` to `_error` to comply with ESLint's rule that unused caught error variables should match the regex `/^_/u`. This indicates to ESLint and other developers that the error variable is intentionally unused, and resolves the linting issue without changing any runtime behavior. The change should be limited to the catch block in the `sanitizeJsonInput` function. No additional imports or external changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
