### PR TITLE
Improve keyword idea and notify error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Treated empty Google Ads keyword idea responses as 404s and updated the client mutation to bubble the server error, warn the user, and redirect to login on 401s with expanded service coverage.
+* Reserved HTTP 401 for authentication failures on `/api/notify`, returning 400 for SMTP misconfiguration and 500 for delivery errors alongside new regression tests.
 * Shortened the email map-pack badge label from "MAP" to "MP" so the stacked flag fits within narrow mail client layouts.
 * Surfaced a domains-dashboard "Map Pack" tracker counter that aggregates keywords detected in the local pack when the active scraper exposes that signal.
 * Hardened domain screenshot caching by tolerating corrupted `domainThumbs` entries, clearing the bad data, and retrying the thumbnail fetch instead of throwing in the browser.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 - Connect a Google Ads test account to unlock keyword suggestions and historical volume data right inside SerpBear.
 - The app exposes the same functionality through its REST API, making it easy to integrate with reporting pipelines.
 - Already-tracked keyword ideas now render as disabled for the active device so research flows stay deduplicated when you revisit Google Ads suggestions.
+- When Google Ads cannot supply any ideas that match your filters, the API now responds with a 404 and the UI shows a warning toast instead of a success banner so you can adjust the request immediately.
 
 ### Loading states & accessibility
 
@@ -215,6 +216,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 - Email digests summarise rank gains/losses, highlight top movers, and include Search Console traffic data when available.
 - Notification cadence is fully configurable through `CRON_EMAIL_SCHEDULE`. Disable SMTP variables to skip sending emails entirely.
 - Trigger a manual run from the **Send Notifications Now** button in the Notification settings modal. Inline guidance and assistive-technology announcements walk through the prerequisites so teams can confirm SMTP credentials and email recipients immediately.
+- `/api/notify` now reserves HTTP 401 strictly for authentication issues—misconfigured SMTP hosts return 400 and runtime delivery errors surface as 500 responses with descriptive messages for easier debugging.
 
 ---
 

--- a/pages/api/ideas.ts
+++ b/pages/api/ideas.ts
@@ -96,8 +96,8 @@ const updateKeywordIdeas = async (req: NextApiRequest, res: NextApiResponse<keyw
          if (keywordIdeas && Array.isArray(keywordIdeas) && keywordIdeas.length > 0) {
             return res.status(200).json({ keywords: keywordIdeas });
          }
-         // No error, just no keywords over the search volume minimum
-         return res.status(200).json({ keywords: [], error: 'No keywords found over the search volume minimum.' });
+         // Surface empty result sets as a not-found condition so the client can warn the user appropriately
+         return res.status(404).json({ keywords: [], error: 'No keywords found over the search volume minimum.' });
       } catch (error: any) {
          console.log('[ERROR] Fetching Keyword Ideas: ', error);
          const message = error?.message || errMsg;

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
    if (req.method === 'POST') {
       return notify(req, res);
    }
-   return res.status(401).json({ success: false, error: 'Invalid Method' });
+   return res.status(405).json({ success: false, error: 'Invalid Method' });
 }
 
 const notify = async (req: NextApiRequest, res: NextApiResponse<NotifyResponse>) => {
@@ -52,7 +52,7 @@ const notify = async (req: NextApiRequest, res: NextApiResponse<NotifyResponse>)
       normalizedSettings.smtp_tls_servername = sanitizeHostname(normalizedSettings.smtp_tls_servername);
 
       if (!sanitizedHost || !sanitizedPort || !sanitizedDefaultEmail) {
-         return res.status(401).json({ success: false, error: 'SMTP has not been setup properly!' });
+         return res.status(400).json({ success: false, error: 'SMTP has not been setup properly!' });
       }
 
       if (reqDomain) {
@@ -78,7 +78,9 @@ const notify = async (req: NextApiRequest, res: NextApiResponse<NotifyResponse>)
       return res.status(200).json({ success: true, error: null });
    } catch (error) {
       console.log(error);
-      return res.status(401).json({ success: false, error: 'Error Sending Notification Email.' });
+      const message = error instanceof Error && error.message ? error.message : 'Error Sending Notification Email.';
+      const isConfigError = error instanceof Error && error.message === 'Invalid SMTP host configured.';
+      return res.status(isConfigError ? 400 : 500).json({ success: false, error: message });
    }
 };
 


### PR DESCRIPTION
## Summary
- surface empty Google Ads keyword idea responses as 404s and teach the React mutation to read API errors, redirect on 401s, and warn users instead of showing false successes
- reserve HTTP 401 for authentication on `/api/notify`, returning descriptive 400/500 codes for configuration and runtime failures
- document the new behaviour and extend the Jest suites covering the keyword idea hook and notification API edge cases

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3b2f18920832aafc5990c35394ba1