### PR TITLE
Update footer to reference SerpBear v3.0.0 by Vontainment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Changed
 
+* Updated the global footer to display SerpBear v3.0.0 and link to Vontainment's homepage for publisher attribution.
 * Treated empty Google Ads keyword idea responses as 404s and updated the client mutation to bubble the server error, warn the user, and redirect to login on 401s with expanded service coverage.
 * Reserved HTTP 401 for authentication failures on `/api/notify`, returning 400 for SMTP misconfiguration and 500 for delivery errors alongside new regression tests.
 * Shortened the email map-pack badge label from "MAP" to "MP" so the stacked flag fits within narrow mail client layouts.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - 📘 **Documentation:** <https://docs.serpbear.com/>
 - 📜 **Changelog:** [`CHANGELOG.md`](./CHANGELOG.md)
 - 🐳 **Docker Hub image:** <https://hub.docker.com/r/vontainment/v-serpbear>
+- 🆕 **Current version:** v3.0.0 by [Vontainment](https://vontainment.com)
 - 🛟 **Community support:** [GitHub Discussions](https://github.com/djav1985/v-serpbear/discussions)
 
 ---

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import Footer from '../../components/common/Footer';
+
+const footerMatcher = (version: string) => (_: string, element?: Element | null) =>
+   element?.tagName === 'SPAN' &&
+   element.textContent?.replace(/\s+/g, ' ').trim() === `SerpBear v${version} by Vontainment`;
+
+describe('Footer component', () => {
+   it('renders the default version with a Vontainment link', () => {
+      render(<Footer currentVersion='' />);
+      expect(screen.getByText(footerMatcher('3.0.0'))).toBeVisible();
+      const link = screen.getByRole('link', { name: 'Vontainment' });
+      expect(link).toHaveAttribute('href', 'https://vontainment.com');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+   });
+
+   it('renders a provided version number', () => {
+      render(<Footer currentVersion='9.9.9' />);
+      expect(screen.getByText(footerMatcher('9.9.9'))).toBeVisible();
+   });
+});

--- a/__tests__/pages/domains.test.tsx
+++ b/__tests__/pages/domains.test.tsx
@@ -30,6 +30,10 @@ const asUrlString = (input: RequestInfo | URL): string => {
    return String(input);
 };
 
+const footerTextMatcher = (version: string) => (_: string, element?: Element | null) =>
+   element?.tagName === 'SPAN' &&
+   element.textContent?.replace(/\s+/g, ' ').includes(`SerpBear v${version} by Vontainment`);
+
 function createJsonResponse<T>(payload: T, status = 200): Response {
    return {
       ok: status >= 200 && status < 300,
@@ -49,7 +53,7 @@ const useQuerySpy = jest.spyOn(ReactQuery, 'useQuery');
 
 const buildUseQueryImplementation = (overrides?: QueryOverrides) => {
    const defaultSettings = {
-      data: { settings: { version: '0.0.0', scraper_type: 'proxy', search_console_integrated: false } },
+      data: { settings: { version: '3.0.0', scraper_type: 'proxy', search_console_integrated: false } },
       isLoading: false,
       isSuccess: true,
    };
@@ -161,7 +165,7 @@ describe('Domains Page', () => {
    });
    it('Should Display the version number in Footer.', async () => {
       render(<QueryClientProvider client={queryClient}><Domains /></QueryClientProvider>);
-      expect(screen.getByText('SerpBear v0.0.0')).toBeVisible();
+      expect(screen.getByText(footerTextMatcher('3.0.0'))).toBeVisible();
       expect(screen.queryByText(/Update to Version/i)).not.toBeInTheDocument();
    });
 });

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -4,7 +4,17 @@ interface FooterProps {
 
 const Footer = ({ currentVersion = '' }: FooterProps) => (
       <footer className='text-center flex flex-1 justify-center pb-5 items-end'>
-         <span className='text-gray-500 text-xs'>SerpBear v{currentVersion || '0.0.0'}</span>
+         <span className='text-gray-500 text-xs'>
+            SerpBear v{currentVersion || '3.0.0'} by{' '}
+            <a
+               className='text-gray-500 underline underline-offset-2 hover:text-gray-400 focus:text-gray-400 focus:outline-none'
+               href='https://vontainment.com'
+               rel='noopener noreferrer'
+               target='_blank'
+            >
+               Vontainment
+            </a>
+         </span>
       </footer>
    );
 


### PR DESCRIPTION
## Summary
- update the shared footer to display SerpBear v3.0.0 and link to Vontainment
- cover the new footer rendering with dedicated unit tests and refresh the domains page fixture
- document the version bump in the README quick links and changelog

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3fce12f68832abc367013de3f422f