### PR TITLE
Add white-label branding support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ SESSION_DURATION=24
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_SCREENSHOTS=true
 
+# White-label Branding
+NEXT_PUBLIC_WHITE_LABEL=false
+# File name (stored in /app/data) for the custom logo. Recommended dimensions: 96x96 pixels.
+WHITE_LABEL_LOGO_FILE=branding-logo.png
+NEXT_PUBLIC_PLATFORM_NAME=SerpBear
+
 # Cron Job Configuration
 CRON_TIMEZONE=America/New_York
 CRON_MAIN_SCHEDULE=0 0 0 * * *

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Features
 - Daily notification email now surfaces a tracker mini-summary ahead of the Search Console tables, styled to match the dashboard tracker card and only showing the Map Pack column when the active scraper supports it.
+- White-label deployments can override the platform name and supply a `/app/data` logo that propagates through the UI, emails, and Docker environment defaults.
 
 ### Bug Fixes
 - Cleared ESLint warnings by wiring width/min-width props into UI components, surfacing settings errors inline, sanitising SMTP TLS hostnames, and logging caught exceptions throughout Ads/Search Console utilities and API handlers.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ All runtime behaviour is controlled through environment variables. The tables be
 | --- | --- | --- | --- |
 | `NEXT_PUBLIC_APP_URL` | `http://localhost:3000` | ✅ | Public URL of your deployment. Determines callback URLs for integrations and absolute links in email digests. |
 | `NEXT_PUBLIC_SCREENSHOTS` | `true` | ✅ | Toggle keyword thumbnail capture in the UI. Set to `false` to fall back to favicons. |
+| `NEXT_PUBLIC_WHITE_LABEL` | `false` | Optional | Enables white-label branding. When `true`, the platform name and logo come from the variables below. |
+| `WHITE_LABEL_LOGO_FILE` | `branding-logo.png` | Optional | File name under `/app/data` for the custom logo. Use a 96×96px PNG, SVG, or WEBP asset for best results. |
+| `NEXT_PUBLIC_PLATFORM_NAME` | `SerpBear` | Optional | Display name for the application and notification emails in white-label mode. |
 | `SCREENSHOT_API` | — | ✅ | API key from your screenshot provider (e.g., ScreenshotOne). Without it the app refuses to queue screenshot jobs and surfaces configuration errors. |
 
 ### Scraping providers & keyword gathering
@@ -131,7 +134,7 @@ All runtime behaviour is controlled through environment variables. The tables be
 | `SMTP_USERNAME` | — | Optional | Authentication username (if required by your provider). |
 | `SMTP_PASSWORD` | — | Optional | Authentication password or app-specific token. |
 | `NOTIFICATION_EMAIL_FROM` | — | Optional | Sender email address that appears in notification emails. |
-| `NOTIFICATION_EMAIL_FROM_NAME` | `SerpBear` | Optional | Friendly sender name shown to recipients. |
+| `NOTIFICATION_EMAIL_FROM_NAME` | `SerpBear` | Optional | Friendly sender name shown to recipients. Automatically switches to `NEXT_PUBLIC_PLATFORM_NAME` when white-label branding is enabled. |
 
 SerpBear also accepts an optional **SMTP TLS certificate hostname** override from the Notification settings modal (or via the `smtp_tls_servername` field in the settings API). Whitespace and trailing dots are trimmed automatically before the value is passed to Nodemailer as the TLS `servername`, making it easier to work with proxies or shared SMTP endpoints whose certificates do not match the connection host.
 

--- a/__mocks__/data.ts
+++ b/__mocks__/data.ts
@@ -1,3 +1,7 @@
+import { getBranding } from '../utils/branding';
+
+const { platformName } = getBranding();
+
 export const dummyDomain = {
    ID: 1,
    domain: 'compressimage.io',
@@ -75,7 +79,7 @@ export const dummySettings = {
    notification_interval: 'never',
    notification_email: '',
    notification_email_from: '',
-   notification_email_from_name: 'SerpBear',
+   notification_email_from_name: platformName,
    smtp_server: '',
    smtp_port: '',
    smtp_username: '',

--- a/__tests__/api/notify.test.ts
+++ b/__tests__/api/notify.test.ts
@@ -8,6 +8,9 @@ import verifyUser from '../../utils/verifyUser';
 import parseKeywords from '../../utils/parseKeywords';
 import generateEmail from '../../utils/generateEmail';
 import { getAppSettings } from '../../pages/api/settings';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 jest.mock('../../database/database', () => ({
   __esModule: true,
@@ -77,7 +80,7 @@ describe('/api/notify - authentication', () => {
       smtp_password: '',
       notification_email: 'notify@example.com',
       notification_email_from: '',
-      notification_email_from_name: 'SerpBear',
+      notification_email_from_name: platformName,
     });
   });
 
@@ -177,7 +180,7 @@ describe('/api/notify - authentication', () => {
       smtp_tls_servername: ' override.test. ',
       notification_email: ' notify@example.com ',
       notification_email_from: ' ',
-      notification_email_from_name: ' SerpBear ',
+      notification_email_from_name: ` ${platformName} `,
     });
 
     const domainRecord = {
@@ -231,7 +234,7 @@ describe('/api/notify - authentication', () => {
     }));
     expect(sendMailMock).toHaveBeenCalledWith(expect.objectContaining({
       to: 'custom@example.com',
-      from: 'SerpBear <no-reply@serpbear.com>',
+      from: `${platformName} <no-reply@serpbear.com>`,
     }));
   });
 
@@ -265,7 +268,7 @@ describe('/api/notify - authentication', () => {
       smtp_password: '',
       notification_email: '',
       notification_email_from: '',
-      notification_email_from_name: 'SerpBear',
+      notification_email_from_name: platformName,
     });
 
     await handler(req as NextApiRequest, res as NextApiResponse);

--- a/__tests__/api/settings.test.ts
+++ b/__tests__/api/settings.test.ts
@@ -3,6 +3,9 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import getConfig from 'next/config';
 import handler from '../../pages/api/settings';
 import * as settingsApi from '../../pages/api/settings';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 import verifyUser from '../../utils/verifyUser';
 
 jest.mock('../../utils/verifyUser', () => ({
@@ -193,7 +196,7 @@ describe('GET /api/settings and configuration requirements', () => {
       notification_interval: 'never',
       notification_email: '',
       notification_email_from: '',
-      notification_email_from_name: 'SerpBear',
+      notification_email_from_name: platformName,
       smtp_server: '',
       smtp_port: '',
       smtp_username: '',

--- a/__tests__/components/Branding.test.tsx
+++ b/__tests__/components/Branding.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('Branding components', () => {
+   afterEach(() => {
+      process.env = { ...ORIGINAL_ENV };
+      jest.resetModules();
+   });
+
+   it('falls back to the default icon when white-label is disabled', async () => {
+      jest.resetModules();
+      process.env = { ...ORIGINAL_ENV, NEXT_PUBLIC_WHITE_LABEL: 'false', NEXT_PUBLIC_PLATFORM_NAME: '' };
+      const brandingModule = await import('../../components/common/Branding');
+      const { BrandTitle } = brandingModule;
+      const { container } = render(<BrandTitle />);
+      expect(container.querySelector('svg')).toBeInTheDocument();
+   });
+
+   it('renders the custom logo and platform name when white-label is enabled', async () => {
+      jest.resetModules();
+      process.env = {
+         ...ORIGINAL_ENV,
+         NEXT_PUBLIC_WHITE_LABEL: 'true',
+         NEXT_PUBLIC_PLATFORM_NAME: 'Acme Rankings',
+         WHITE_LABEL_LOGO_FILE: 'brand.svg',
+      };
+      const brandingModule = await import('../../components/common/Branding');
+      const { BrandTitle } = brandingModule;
+      const { getByAltText } = render(<BrandTitle />);
+      const logo = getByAltText('Acme Rankings logo') as HTMLImageElement;
+      expect(logo).toBeInTheDocument();
+      expect(logo.src).toContain('/api/branding/logo');
+   });
+});

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -1,9 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import Footer from '../../components/common/Footer';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 const footerMatcher = (version: string) => (_: string, element?: Element | null) =>
    element?.tagName === 'SPAN' &&
-   element.textContent?.replace(/\s+/g, ' ').trim() === `SerpBear v${version} by Vontainment`;
+   element.textContent?.replace(/\s+/g, ' ').trim() === `${platformName} v${version} by Vontainment`;
 
 describe('Footer component', () => {
    it('renders the default version with a Vontainment link', () => {

--- a/__tests__/components/Sidebar.test.tsx
+++ b/__tests__/components/Sidebar.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import Sidebar from '../../components/common/Sidebar';
 import { dummyDomain } from '../../__mocks__/data';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 const addDomainMock = jest.fn();
 jest.mock('next/router', () => jest.requireActual('next-router-mock'));
@@ -8,7 +11,7 @@ jest.mock('next/router', () => jest.requireActual('next-router-mock'));
 describe('Sidebar Component', () => {
    it('renders without crashing', async () => {
        render(<Sidebar domains={[dummyDomain]} showAddModal={addDomainMock} />);
-       expect(screen.getByText('SerpBear')).toBeInTheDocument();
+       expect(screen.getByText(platformName)).toBeInTheDocument();
    });
    it('renders domain list', async () => {
       render(<Sidebar domains={[dummyDomain]} showAddModal={addDomainMock} />);

--- a/__tests__/components/Topbar.test.tsx
+++ b/__tests__/components/Topbar.test.tsx
@@ -2,6 +2,9 @@ import fs from 'fs';
 import path from 'path';
 import { render, screen } from '@testing-library/react';
 import TopBar from '../../components/common/TopBar';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 jest.mock('next/router', () => ({
    useRouter: () => ({
@@ -14,7 +17,7 @@ describe('TopBar Component', () => {
    it('renders without crashing', async () => {
        render(<TopBar showSettings={jest.fn} showAddModal={jest.fn} />);
        expect(
-           await screen.findByText('SerpBear'),
+           await screen.findByText(platformName),
        ).toBeInTheDocument();
    });
 

--- a/__tests__/components/settings/NotificationSettings.test.tsx
+++ b/__tests__/components/settings/NotificationSettings.test.tsx
@@ -4,17 +4,20 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import NotificationSettings from '../../../components/settings/NotificationSettings';
 import { useSendNotifications } from '../../../services/settings';
+import { getBranding } from '../../../utils/branding';
 
 jest.mock('../../../services/settings');
 
 const useSendNotificationsMock = useSendNotifications as jest.Mock;
+
+const { platformName } = getBranding();
 
 const buildSettings = (overrides: Partial<SettingsType> = {}): SettingsType => ({
    scraper_type: 'none',
    notification_interval: 'daily',
    notification_email: 'notify@example.com',
    notification_email_from: 'no-reply@example.com',
-   notification_email_from_name: 'SerpBear',
+   notification_email_from_name: platformName,
    smtp_server: 'smtp.example.com',
    smtp_port: '587',
    smtp_tls_servername: '',

--- a/__tests__/pages/domains.test.tsx
+++ b/__tests__/pages/domains.test.tsx
@@ -4,6 +4,9 @@ import * as ReactQuery from 'react-query';
 import { dummyDomain } from '../../__mocks__/data';
 import Domains from '../../pages/domains';
 import router from 'next-router-mock';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 // Mock the useAuth hook to always return authenticated state
 jest.mock('../../hooks/useAuth', () => ({
@@ -32,7 +35,7 @@ const asUrlString = (input: RequestInfo | URL): string => {
 
 const footerTextMatcher = (version: string) => (_: string, element?: Element | null) =>
    element?.tagName === 'SPAN' &&
-   element.textContent?.replace(/\s+/g, ' ').includes(`SerpBear v${version} by Vontainment`);
+   element.textContent?.replace(/\s+/g, ' ').includes(`${platformName} v${version} by Vontainment`);
 
 function createJsonResponse<T>(payload: T, status = 200): Response {
    return {

--- a/components/common/Branding.tsx
+++ b/components/common/Branding.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import Image from 'next/image';
+import Icon from './Icon';
+import { getBranding, buildLogoUrl } from '../../utils/branding';
+
+type BrandMarkProps = {
+   size?: number;
+   className?: string;
+};
+
+type BrandTitleProps = {
+   className?: string;
+   showMark?: boolean;
+   markClassName?: string;
+   markSize?: number;
+};
+
+const DEFAULT_MARK_CLASS = 'relative top-[3px] mr-1';
+
+export const BrandMark: React.FC<BrandMarkProps> = ({ size = 24, className = '' }) => {
+   const { hasCustomLogo, platformName } = getBranding();
+   const logoUrl = buildLogoUrl();
+   const wrapperClassName = ['inline-flex items-center', className].filter(Boolean).join(' ');
+
+   if (hasCustomLogo && logoUrl) {
+      return (
+         <span className={wrapperClassName}>
+            <Image
+               src={logoUrl}
+               alt={`${platformName} logo`}
+               width={size}
+               height={size}
+               unoptimized
+               className="inline-block align-middle"
+            />
+         </span>
+      );
+   }
+
+   return (
+      <span className={wrapperClassName}>
+         <Icon type="logo" size={size} color="#364AFF" />
+      </span>
+   );
+};
+
+export const BrandTitle: React.FC<BrandTitleProps> = ({
+   className = '',
+   showMark = true,
+   markClassName = DEFAULT_MARK_CLASS,
+   markSize = 24,
+}) => {
+   const { platformName } = getBranding();
+   const titleClassName = ['inline-flex items-center', className].filter(Boolean).join(' ');
+
+   return (
+      <span className={titleClassName}>
+         {showMark && <BrandMark className={markClassName} size={markSize} />}
+         {platformName}
+      </span>
+   );
+};
+

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -1,11 +1,15 @@
+import { getBranding } from '../../utils/branding';
+
 interface FooterProps {
    currentVersion: string
 }
 
+const { platformName } = getBranding();
+
 const Footer = ({ currentVersion = '' }: FooterProps) => (
       <footer className='text-center flex flex-1 justify-center pb-5 items-end'>
          <span className='text-gray-500 text-xs'>
-            SerpBear v{currentVersion || '3.0.0'} by{' '}
+            {platformName} v{currentVersion || '3.0.0'} by{' '}
             <a
                className='text-gray-500 underline underline-offset-2 hover:text-gray-400 focus:text-gray-400 focus:outline-none'
                href='https://vontainment.com'

--- a/components/common/Sidebar.tsx
+++ b/components/common/Sidebar.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import Icon from './Icon';
+import { BrandTitle } from './Branding';
 
 type SidebarProps = {
    domains: DomainType[],
@@ -15,7 +15,7 @@ const Sidebar = ({ domains, showAddModal } : SidebarProps) => {
    return (
       <div className="sidebar pt-44 w-1/5 hidden lg:block" data-testid="sidebar">
          <h3 className="py-7 text-base font-bold text-blue-700">
-            <span className=' relative top-[3px] mr-1'><Icon type="logo" size={24} color="#364AFF" /></span> SerpBear
+            <BrandTitle />
          </h3>
          <div className="sidebar_menu max-h-96 overflow-auto styled-scrollbar">
             <ul className=' font-medium text-sm'>

--- a/components/common/TopBar.tsx
+++ b/components/common/TopBar.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 import toast from 'react-hot-toast';
 import Icon from './Icon';
+import { BrandTitle } from './Branding';
 
 type TopbarProps = {
    showSettings: Function,
@@ -37,7 +38,7 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
       >
 
          <h3 className={`p-4 text-base font-bold text-blue-700 ${isDomainsPage ? 'lg:pl-0' : 'lg:hidden'}`}>
-            <span className=' relative top-[3px] mr-1'><Icon type="logo" size={24} color="#364AFF" /></span> SerpBear
+            <BrandTitle />
             <button className='px-3 py-1 font-bold text-blue-700  lg:hidden ml-3 text-lg' onClick={() => showAddModal()}>+</button>
          </h3>
          {!isDomainsPage && router.asPath !== '/research' && (

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -7,6 +7,7 @@ import InputField from '../common/InputField';
 import Icon from '../common/Icon';
 import { useSendNotifications } from '../../services/settings';
 import { hasTrimmedLength } from '../../utils/security';
+import { getBranding } from '../../utils/branding';
 
 type NotificationSettingsProps = {
    settings: SettingsType,
@@ -19,6 +20,7 @@ type NotificationSettingsProps = {
 
 const NotificationSettings = ({ settings, settingsError, updateSettings }:NotificationSettingsProps) => {
    const { mutate: triggerNotifications, isLoading: sendingNotifications } = useSendNotifications();
+   const { platformName } = getBranding();
 
    const sanitizedNotificationEmails = (settings.notification_email || '')
       .split(',')
@@ -139,8 +141,8 @@ const NotificationSettings = ({ settings, settingsError, updateSettings }:Notifi
                         <InputField
                         label='Email From Name'
                         hasError={settingsError?.type === 'no_smtp_from'}
-                        value={settings?.notification_email_from_name || 'Serpbear'}
-                        placeholder="Serpbear"
+                        value={settings?.notification_email_from_name || platformName}
+                        placeholder={platformName}
                         onChange={(value:string) => updateSettings('notification_email_from_name', value)}
                         />
                   </div>

--- a/components/settings/Settings.tsx
+++ b/components/settings/Settings.tsx
@@ -7,6 +7,7 @@ import NotificationSettings from './NotificationSettings';
 import ScraperSettings from './ScraperSettings';
 import useOnKey from '../../hooks/useOnKey';
 import IntegrationSettings from './IntegrationSettings';
+import { getBranding } from '../../utils/branding';
 
 type SettingsProps = {
    closeSettings: Function,
@@ -17,6 +18,8 @@ type SettingsError = {
    type: string,
    msg: string
 }
+
+const { platformName } = getBranding();
 
 export const defaultSettings: SettingsType = {
    scraper_type: 'none',
@@ -30,7 +33,7 @@ export const defaultSettings: SettingsType = {
    smtp_username: '',
    smtp_password: '',
    notification_email_from: '',
-   notification_email_from_name: 'SerpBear',
+   notification_email_from_name: platformName,
    search_console: true,
    search_console_client_email: '',
    search_console_private_key: '',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       - APIKEY=5saedXklbbjbjbhp3pih4fdnakhjwq5
       - SESSION_DURATION=24
       - NEXT_PUBLIC_SCREENSHOTS=true
+      - NEXT_PUBLIC_WHITE_LABEL=false
+      # File name (stored in /app/data) for the white-label logo. Recommended dimensions: 96x96 pixels.
+      - WHITE_LABEL_LOGO_FILE=branding-logo.png
+      - NEXT_PUBLIC_PLATFORM_NAME=SerpBear
       - SEARCH_CONSOLE_CLIENT_EMAIL=
       - SEARCH_CONSOLE_PRIVATE_KEY=--
       - NEXT_PUBLIC_APP_URL=https://serp.hugev.xyz

--- a/email/email.html
+++ b/email/email.html
@@ -507,7 +507,7 @@
             <div class="topbar">
                <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                   <tr>
-                    <td class="logo">{{logo}} SerpBear</td>
+                    <td class="logo">{{logo}} {{platformName}}</td>
                     <td align="right" style="vertical-align: bottom ;" >{{currentDate}}</td>
                   </tr>
                </table>
@@ -564,7 +564,7 @@
               <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block powered-by">
-                    Powered by <a href="https://serpbear.com">SerpBear</a> |  <a href="{{appURL}}">Visit Dashboard</a>
+                    Powered by {{platformName}} |  <a href="{{appURL}}">Visit Dashboard</a>
                   </td>
                 </tr>
               </table>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,6 +2,14 @@ import './styles/globals.css';
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
 
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ src, alt, width, height, unoptimized, ...rest }) => {
+    const React = require('react');
+    return React.createElement('img', { src, alt, width, height, ...rest });
+  },
+}));
+
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 

--- a/pages/api/branding/logo.ts
+++ b/pages/api/branding/logo.ts
@@ -1,0 +1,71 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createReadStream, promises as fs } from 'fs';
+import path from 'path';
+import { getBranding } from '../../../utils/branding';
+
+const respondNotFound = (res: NextApiResponse) => {
+   res.status(404).end('Logo not found');
+};
+
+const isAllowedMethod = (method?: string): method is 'GET' | 'HEAD' => method === 'GET' || method === 'HEAD';
+
+const dataDirectory = path.join(process.cwd(), 'data');
+
+const resolveLogoPath = (fileName: string): string => {
+   const sanitizedFileName = path.basename(fileName);
+   return path.join(dataDirectory, sanitizedFileName);
+};
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+   if (!isAllowedMethod(req.method)) {
+      res.setHeader('Allow', 'GET, HEAD');
+      res.status(405).end('Method Not Allowed');
+      return;
+   }
+
+   const { whiteLabelEnabled, hasCustomLogo, logoFile, logoMimeType } = getBranding();
+
+   if (!whiteLabelEnabled || !hasCustomLogo || !logoMimeType) {
+      respondNotFound(res);
+      return;
+   }
+
+   const filePath = resolveLogoPath(logoFile);
+   const resolvedPath = path.resolve(filePath);
+
+   if (!resolvedPath.startsWith(dataDirectory)) {
+      respondNotFound(res);
+      return;
+   }
+
+   try {
+      // Path is constrained to `/app/data` via `resolveLogoPath` and checked above.
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      const stat = await fs.stat(resolvedPath);
+      if (!stat.isFile()) {
+         respondNotFound(res);
+         return;
+      }
+
+      res.setHeader('Content-Type', logoMimeType);
+      res.setHeader('Content-Length', stat.size.toString());
+      res.setHeader('Cache-Control', 'public, max-age=3600, immutable');
+
+      if (req.method === 'HEAD') {
+         res.status(200).end();
+         return;
+      }
+
+      // Path is constrained to `/app/data` via `resolveLogoPath` and checked above.
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      const stream = createReadStream(resolvedPath);
+      stream.on('error', () => {
+         respondNotFound(res);
+      });
+      stream.pipe(res);
+   } catch (_error) {
+      respondNotFound(res);
+   }
+};
+
+export default handler;

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -11,6 +11,9 @@ import verifyUser from '../../utils/verifyUser';
 import { canSendEmail, recordEmailSent } from '../../utils/emailThrottle';
 import { getAppSettings } from './settings';
 import { trimStringProperties } from '../../utils/security';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 type NotifyResponse = {
    success?: boolean
@@ -102,7 +105,7 @@ const sendNotificationEmail = async (domain: DomainType | Domain, settings: Sett
       smtp_password = '',
       notification_email = '',
       notification_email_from = '',
-      notification_email_from_name = 'SerpBear',
+      notification_email_from_name = platformName,
       smtp_tls_servername = '',
      } = settings;
 
@@ -112,7 +115,7 @@ const sendNotificationEmail = async (domain: DomainType | Domain, settings: Sett
 
    const tlsServername = sanitizeHostname(smtp_tls_servername);
    const fromAddress = notification_email_from || 'no-reply@serpbear.com';
-   const fromName = notification_email_from_name || 'SerpBear';
+   const fromName = notification_email_from_name || platformName;
    const fromEmail = `${fromName} <${fromAddress}>`;
    const portNum = parseInt(smtp_port, 10);
    const validPort = isNaN(portNum) ? 587 : Math.max(1, Math.min(65535, portNum)); // Default to 587, validate range

--- a/pages/api/settings.ts
+++ b/pages/api/settings.ts
@@ -9,6 +9,9 @@ import allScrapers from '../../scrapers/index';
 import { withApiLogging } from '../../utils/apiLogging';
 import { logger } from '../../utils/logger';
 import { trimStringProperties } from '../../utils/security';
+import { getBranding } from '../../utils/branding';
+
+const { platformName, whiteLabelEnabled } = getBranding();
 
 const SETTINGS_DEFAULTS: SettingsType = {
    scraper_type: 'none',
@@ -17,7 +20,7 @@ const SETTINGS_DEFAULTS: SettingsType = {
    notification_interval: 'never',
    notification_email: '',
    notification_email_from: '',
-   notification_email_from_name: 'SerpBear',
+   notification_email_from_name: platformName,
    smtp_server: '',
    smtp_port: '',
    smtp_tls_servername: '',
@@ -171,8 +174,15 @@ export const getAppSettings = async () : Promise<SettingsType> => {
          console.log('Error Decrypting Settings API Keys!', error);
       }
 
-      return {
+      const normalizedSettings: SettingsType = {
          ...decryptedSettings,
+         notification_email_from_name: whiteLabelEnabled
+            ? platformName
+            : (decryptedSettings.notification_email_from_name || platformName),
+      };
+
+      return {
+         ...normalizedSettings,
          search_console_integrated:
             !!(process.env.SEARCH_CONSOLE_PRIVATE_KEY && process.env.SEARCH_CONSOLE_CLIENT_EMAIL)
             || !!(decryptedSettings.search_console_client_email && decryptedSettings.search_console_private_key),

--- a/pages/api/settings.ts
+++ b/pages/api/settings.ts
@@ -176,9 +176,7 @@ export const getAppSettings = async () : Promise<SettingsType> => {
 
       const normalizedSettings: SettingsType = {
          ...decryptedSettings,
-         notification_email_from_name: whiteLabelEnabled
-            ? platformName
-            : (decryptedSettings.notification_email_from_name || platformName),
+         notification_email_from_name: decryptedSettings.notification_email_from_name || platformName,
       };
 
       return {

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -16,6 +16,9 @@ import { useFetchKeywords } from '../../../services/keywords';
 import { useFetchSettings } from '../../../services/settings';
 import AddKeywords from '../../../components/keywords/AddKeywords';
 import Footer from '../../../components/common/Footer';
+import { getBranding } from '../../../utils/branding';
+
+const { platformName } = getBranding();
 
 const SingleDomain: NextPage = () => {
    const router = useRouter();
@@ -56,7 +59,7 @@ const SingleDomain: NextPage = () => {
          )}
          {activDomain && activDomain.domain
          && <Head>
-               <title>{`${activDomain.domain} - SerpBear` } </title>
+               <title>{`${activDomain.domain} - ${platformName}` } </title>
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -17,6 +17,9 @@ import { useFetchSCKeywords } from '../../../../services/searchConsole';
 import SCKeywordsTable from '../../../../components/keywords/SCKeywordsTable';
 import { useFetchSettings } from '../../../../services/settings';
 import Footer from '../../../../components/common/Footer';
+import { getBranding } from '../../../../utils/branding';
+
+const { platformName } = getBranding();
 
 const DiscoverPage: NextPage = () => {
    const router = useRouter();
@@ -83,7 +86,7 @@ const DiscoverPage: NextPage = () => {
       <div className="Domain ">
          {activDomain && activDomain.domain
          && <Head>
-               <title>{`${activDomain.domain} - SerpBear` } </title>
+               <title>{`${activDomain.domain} - ${platformName}` } </title>
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -17,6 +17,9 @@ import { useFetchSCInsight } from '../../../../services/searchConsole';
 import SCInsight from '../../../../components/insight/Insight';
 import { useFetchSettings } from '../../../../services/settings';
 import Footer from '../../../../components/common/Footer';
+import { getBranding } from '../../../../utils/branding';
+
+const { platformName } = getBranding();
 
 const InsightPage: NextPage = () => {
    const router = useRouter();
@@ -49,7 +52,7 @@ const InsightPage: NextPage = () => {
       <div className="Domain ">
          {activDomain && activDomain.domain
          && <Head>
-               <title>{`${activDomain.domain} - SerpBear` } </title>
+               <title>{`${activDomain.domain} - ${platformName}` } </title>
             </Head>
          }
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -13,6 +13,9 @@ import DomainItem from '../../components/domains/DomainItem';
 import Footer from '../../components/common/Footer';
 import { withAuth } from '../../hooks/useAuth';
 import PageLoader from '../../components/common/PageLoader';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 type thumbImages = { [domain:string] : string }
 
@@ -112,7 +115,7 @@ const Domains: NextPage = () => {
                </div>
          )}
          <Head>
-            <title>Domains - SerpBear</title>
+            <title>Domains - {platformName}</title>
          </Head>
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => setShowAddDomain(true)} />
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,9 @@ import { useEffect } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Icon from '../components/common/Icon';
+import { getBranding } from '../utils/branding';
+
+const { platformName } = getBranding();
 
 const Home: NextPage = () => {
    const router = useRouter();
@@ -13,8 +16,8 @@ const Home: NextPage = () => {
   return (
     <div>
       <Head>
-        <title>SerpBear</title>
-        <meta name="description" content="SerpBear Google Keyword Position Tracking App" />
+        <title>{platformName}</title>
+        <meta name="description" content={`${platformName} Google Keyword Position Tracking App`} />
         <link rel="icon" href="/favicon.ico" />
       </Head>
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -2,12 +2,15 @@ import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
-import Icon from '../../components/common/Icon';
+import { BrandTitle } from '../../components/common/Branding';
+import { getBranding } from '../../utils/branding';
 
 type LoginError = {
    type: string,
    msg: string,
 }
+
+const { platformName } = getBranding();
 
 const Login: NextPage = () => {
    const [error, setError] = useState<LoginError|null>(null);
@@ -63,14 +66,12 @@ const Login: NextPage = () => {
    return (
       <div className={'Login'}>
          <Head>
-            <title>Login - SerpBear</title>
+            <title>Login - {platformName}</title>
          </Head>
          <div className='flex items-center justify-center w-full min-h-screen overflow-y-auto'>
             <div className='w-80'>
                <h3 className="py-7 text-2xl font-bold text-blue-700 text-center">
-                  <span className=' relative top-[3px] mr-1'>
-                     <Icon type="logo" size={30} color="#364AFF" />
-                  </span> SerpBear
+                  <BrandTitle markSize={30} />
                </h3>
                <div className='relative bg-[white] rounded-md text-sm border p-5'>
                   <div className="settings__section__input mb-5">

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -13,6 +13,10 @@ import Settings from '../../components/settings/Settings';
 import SelectField from '../../components/common/SelectField';
 import allCountries, { adwordsLanguages } from '../../utils/countries';
 import Footer from '../../components/common/Footer';
+import { BrandTitle } from '../../components/common/Branding';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
 
 const Research: NextPage = () => {
    const router = useRouter();
@@ -57,13 +61,13 @@ const Research: NextPage = () => {
    return (
       <div className='Research'>
          <Head>
-            <title>Research Keywords - SerpBear</title>
+            <title>Research Keywords - {platformName}</title>
          </Head>
          <TopBar showSettings={() => setShowSettings(true)} showAddModal={() => null } />
          <div className="desktop-container lg:flex lg:flex-row">
             <div className="sidebar w-full p-6 lg:pt-44 lg:w-1/5 lg:block lg:pr-0" data-testid="sidebar">
                <h3 className="hidden py-7 text-base font-bold text-blue-700 lg:block">
-                  <span className=' relative top-[3px] mr-1'><Icon type="logo" size={24} color="#364AFF" /></span> SerpBear
+                  <BrandTitle />
                </h3>
                <div className={`sidebar_menu domKeywords max-h-96 overflow-auto styled-scrollbar p-4
                 bg-white border border-gray-200 rounded lg:rounded-none lg:rounded-s lg:border-r-0`}>

--- a/types.d.ts
+++ b/types.d.ts
@@ -112,6 +112,9 @@ type SettingsType = {
    adwords_developer_token?: string,
    adwords_account_id?: string,
    keywordsColumns: string[]
+   white_label_enabled?: boolean,
+   white_label_logo_file?: string,
+   platform_name?: string,
 }
 
 type KeywordSCDataChild = {

--- a/utils/branding.ts
+++ b/utils/branding.ts
@@ -1,0 +1,62 @@
+const DEFAULT_PLATFORM_NAME = 'SerpBear';
+
+const LOGO_MIME_TYPES: Record<string, string> = {
+   '.png': 'image/png',
+   '.jpg': 'image/jpeg',
+   '.jpeg': 'image/jpeg',
+   '.gif': 'image/gif',
+   '.svg': 'image/svg+xml',
+   '.webp': 'image/webp',
+};
+
+const normalizeBoolean = (value?: string): boolean => (value || '').toLowerCase() === 'true';
+
+const trimString = (value?: string | null): string => (value || '').trim();
+
+const stripTrailingSlash = (value: string): string => (value.endsWith('/') ? value.slice(0, -1) : value);
+
+export const getLogoMimeType = (fileName: string): string => {
+   const lastDot = fileName.lastIndexOf('.');
+   if (lastDot === -1) {
+      return '';
+   }
+
+   const extension = fileName.slice(lastDot).toLowerCase();
+   return LOGO_MIME_TYPES[extension] || '';
+};
+
+export const getBranding = () => {
+   const whiteLabelEnabled = normalizeBoolean(process.env.NEXT_PUBLIC_WHITE_LABEL);
+   const platformNameSetting = trimString(process.env.NEXT_PUBLIC_PLATFORM_NAME);
+   const logoFileSetting = trimString(process.env.WHITE_LABEL_LOGO_FILE || 'branding-logo.png');
+   const logoMimeType = getLogoMimeType(logoFileSetting);
+   const hasCustomLogo = whiteLabelEnabled && !!logoMimeType && !!logoFileSetting;
+
+   const platformName = whiteLabelEnabled && platformNameSetting
+      ? platformNameSetting
+      : DEFAULT_PLATFORM_NAME;
+
+   return {
+      defaultPlatformName: DEFAULT_PLATFORM_NAME,
+      whiteLabelEnabled,
+      platformName,
+      logoFile: logoFileSetting,
+      hasCustomLogo,
+      logoMimeType,
+      logoApiPath: '/api/branding/logo',
+   } as const;
+};
+
+export const branding = getBranding();
+
+export const getPlatformName = (): string => getBranding().platformName;
+
+export const buildLogoUrl = (origin = ''): string => {
+   const { hasCustomLogo, logoApiPath } = getBranding();
+   if (!hasCustomLogo) {
+      return '';
+   }
+
+   const sanitizedOrigin = origin ? stripTrailingSlash(origin) : '';
+   return `${sanitizedOrigin}${logoApiPath}`;
+};

--- a/utils/generateEmail.ts
+++ b/utils/generateEmail.ts
@@ -4,11 +4,24 @@ import path from 'path';
 import { getKeywordsInsight, getPagesInsight } from './insight';
 import { fetchDomainSCData, getSearchConsoleApiInfo, isSearchConsoleDataFreshForToday, readLocalSCData } from './searchConsole';
 import { parseLocation } from './location';
+import { buildLogoUrl, getBranding } from './branding';
 
-const serpBearLogo = 'https://serpbear.b-cdn.net/ikAdjQq.png';
+const DEFAULT_BRAND_LOGO = 'https://serpbear.b-cdn.net/ikAdjQq.png';
 const mobileIcon = 'https://serpbear.b-cdn.net/SqXD9rd.png';
 const desktopIcon = 'https://serpbear.b-cdn.net/Dx3u0XD.png';
 const googleIcon = 'https://serpbear.b-cdn.net/Sx3u0X9.png';
+
+const resolveEmailBranding = () => {
+   const brandingDetails = getBranding();
+   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || '';
+   const useCustomLogo = brandingDetails.whiteLabelEnabled && Boolean(baseUrl);
+   const logoUrl = useCustomLogo ? buildLogoUrl(baseUrl) : '';
+
+   return {
+      ...brandingDetails,
+      emailLogo: logoUrl || DEFAULT_BRAND_LOGO,
+   } as const;
+};
 
 type SCStatsObject = {
    [key:string]: {
@@ -213,8 +226,11 @@ const generateEmail = async (domain:DomainType, keywords:KeywordType[], settings
                               </tbody>
                            </table>`;
 
+   const { emailLogo, platformName: brandName } = resolveEmailBranding();
+
    const updatedEmail = emailTemplate
-         .replace('{{logo}}', `<img class="logo_img" src="${serpBearLogo}" alt="SerpBear" width="24" height="24" />`)
+         .replace('{{logo}}', `<img class="logo_img" src="${emailLogo}" alt="${brandName}" width="24" height="24" />`)
+         .replace(/{{platformName}}/g, brandName)
          .replace('{{currentDate}}', currentDate)
          .replace('{{domainName}}', domainName)
          .replace('{{keywordsCount}}', keywordsCount.toString())


### PR DESCRIPTION
## Summary
- add a reusable branding helper and API endpoint so deployments can serve a custom logo and platform name when white-label mode is enabled
- update UI layouts, email templates, and notification defaults to honour the new branding fields while keeping existing behaviour when white-label is disabled
- document the new environment variables across `.env.example`, Docker Compose, README, and changelog entries, and add unit coverage for both branding modes

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5cf00bc78832aa86d5211aa421e99