### PR TITLE
Normalize keyword map pack flag shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. Releases no
 - Fixed the Google Ads keyword ideas mutation so successful requests no longer throw a runtime reference error and now properly invalidate the cached query for the active domain.
 - Tracker email summary now falls back to live keyword data to compute average position and map-pack totals, preventing those counters from showing 0 when domain aggregates are unavailable.
 - Domain stats retrieval now omits average position and map-pack counts unless persisted values exist, avoiding stale recalculations from keyword snapshots.
+- Keywords API responses now drop the legacy `map_pack_top3` field so consumers rely exclusively on the normalised `mapPackTop3` flag.
 
 # [3.0.0](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v3.0.0) (2025-09-24)
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ Every feature available in the UI is backed by authenticated API routes. Authent
 - `POST /api/refresh` – queue immediate re-scrapes for selected keywords.
 - `GET /api/settings` – fetch the current scraper, cron, and notification settings.
 
+Keyword responses now expose only the camelCase `mapPackTop3` flag alongside the other normalised booleans so integrations no longer need to strip the legacy `map_pack_top3` column returned by some databases.
+
 Refer to the [official documentation](https://docs.serpbear.com/) for the complete endpoint catalogue and payload schemas.
 
 ---

--- a/__tests__/services/keywords.fetchKeywords.test.ts
+++ b/__tests__/services/keywords.fetchKeywords.test.ts
@@ -67,6 +67,7 @@ describe('fetchKeywords normalisation', () => {
       expect(typeof keyword.updating).toBe('boolean');
       expect(keyword.sticky).toBe(false);
       expect(keyword.mapPackTop3).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(keyword, 'map_pack_top3')).toBe(false);
    });
 
    it('returns consistent object structure when domain is falsy', async () => {

--- a/__tests__/utils/parseKeywords.test.ts
+++ b/__tests__/utils/parseKeywords.test.ts
@@ -19,6 +19,7 @@ describe('parseKeywords', () => {
       updating: false,
       lastUpdateError: 'false',
       mapPackTop3: false,
+      map_pack_top3: true,
       ...overrides,
    });
 
@@ -30,6 +31,7 @@ describe('parseKeywords', () => {
       expect(keyword.updating).toBe(false);
       expect(keyword.sticky).toBe(false);
       expect(keyword.mapPackTop3).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(keyword, 'map_pack_top3')).toBe(false);
    });
 
    it('normalises truthy boolean variants to true', () => {
@@ -40,6 +42,7 @@ describe('parseKeywords', () => {
       expect(keyword.updating).toBe(true);
       expect(keyword.sticky).toBe(true);
       expect(keyword.mapPackTop3).toBe(true);
+      expect(Object.prototype.hasOwnProperty.call(keyword, 'map_pack_top3')).toBe(false);
    });
 
    it('keeps existing keyword structure intact', () => {
@@ -49,5 +52,14 @@ describe('parseKeywords', () => {
       expect(keyword.tags).toEqual(['tag']);
       expect(keyword.lastResult).toEqual([]);
       expect(keyword.location).toBe('');
+   });
+
+   it('hydrates camelCase flag when only the snake_case column is present', () => {
+      const [{ mapPackTop3, map_pack_top3 }] = parseKeywords([
+         buildKeyword({ mapPackTop3: undefined, map_pack_top3: 1 }) as any,
+      ]);
+
+      expect(mapPackTop3).toBe(true);
+      expect(map_pack_top3).toBeUndefined();
    });
 });

--- a/utils/parseKeywords.ts
+++ b/utils/parseKeywords.ts
@@ -47,29 +47,32 @@ const normaliseBoolean = (value: unknown): boolean => {
 
 const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
    const parsedItems = allKeywords.map((keywrd:Keyword) => {
+      const keywordData = keywrd as unknown as Record<string, any>;
+      const { map_pack_top3, ...keywordWithoutSnakeCase } = keywordData;
+
       let historyRaw: unknown;
-      try { historyRaw = JSON.parse(keywrd.history); } catch { historyRaw = {}; }
+      try { historyRaw = JSON.parse(keywordData.history); } catch { historyRaw = {}; }
       const history = normaliseHistory(historyRaw);
 
       let tags: string[] = [];
-      try { tags = JSON.parse(keywrd.tags); } catch { tags = []; }
+      try { tags = JSON.parse(keywordData.tags); } catch { tags = []; }
 
       let lastResult: any[] = [];
-      try { lastResult = JSON.parse(keywrd.lastResult); } catch { lastResult = []; }
+      try { lastResult = JSON.parse(keywordData.lastResult); } catch { lastResult = []; }
 
       let lastUpdateError: any = false;
-      if (keywrd.lastUpdateError !== 'false' && keywrd.lastUpdateError.includes('{')) {
-         try { lastUpdateError = JSON.parse(keywrd.lastUpdateError); } catch { lastUpdateError = {}; }
+      if (typeof keywordData.lastUpdateError === 'string' && keywordData.lastUpdateError !== 'false' && keywordData.lastUpdateError.includes('{')) {
+         try { lastUpdateError = JSON.parse(keywordData.lastUpdateError); } catch { lastUpdateError = {}; }
       }
 
-      const mapPackTop3 = normaliseBoolean((keywrd as any).mapPackTop3);
+      const mapPackTop3 = normaliseBoolean(keywordData.mapPackTop3 ?? map_pack_top3);
 
-      const updating = normaliseBoolean((keywrd as any).updating);
-      const sticky = normaliseBoolean((keywrd as any).sticky);
+      const updating = normaliseBoolean(keywordData.updating);
+      const sticky = normaliseBoolean(keywordData.sticky);
 
       return {
-         ...keywrd,
-         location: typeof (keywrd as any).location === 'string' ? (keywrd as any).location : '',
+         ...keywordWithoutSnakeCase,
+         location: typeof keywordData.location === 'string' ? keywordData.location : '',
          history,
          tags,
          lastResult,


### PR DESCRIPTION
## Summary
- remove the legacy `map_pack_top3` property while building keyword payloads and keep the camelCase flag normalised
- assert the parser and client keyword fetcher exclude the snake_case map-pack flag and hydrate the camelCase fallback
- document the API change in the README and changelog

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d944609840832aa0c9f28eceb1a16b