### PR TITLE
Rename map pack and domain toggle columns to camelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file. Releases no
 - Fixed the Google Ads keyword ideas mutation so successful requests no longer throw a runtime reference error and now properly invalidate the cached query for the active domain.
 - Tracker email summary now falls back to live keyword data to compute average position and map-pack totals, preventing those counters from showing 0 when domain aggregates are unavailable.
 - Domain stats retrieval now omits average position and map-pack counts unless persisted values exist, avoiding stale recalculations from keyword snapshots.
-- Keywords API responses now drop the legacy `map_pack_top3` field so consumers rely exclusively on the normalised `mapPackTop3` flag.
+- Renamed keyword `map_pack_top3` → `mapPackTop3` and domain `scrape_enabled` → `scrapeEnabled`, updating API responses and models accordingly. Run `npm run db:migrate` to apply the `1737426000000-rename-legacy-boolean-columns` migration before restarting services.
 
 # [3.0.0](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v3.0.0) (2025-09-24)
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Every feature available in the UI is backed by authenticated API routes. Authent
 - `POST /api/refresh` – queue immediate re-scrapes for selected keywords.
 - `GET /api/settings` – fetch the current scraper, cron, and notification settings.
 
-Keyword responses now expose only the camelCase `mapPackTop3` flag alongside the other normalised booleans so integrations no longer need to strip the legacy `map_pack_top3` column returned by some databases.
+Keyword responses now expose only the camelCase `mapPackTop3` flag alongside the other normalised booleans. The legacy `map_pack_top3` column has been renamed by the `1737426000000-rename-legacy-boolean-columns` migration so API consumers and integrations no longer need to handle both cases.
 
 Refer to the [official documentation](https://docs.serpbear.com/) for the complete endpoint catalogue and payload schemas.
 
@@ -267,6 +267,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
   - `npm run test:ci` mirrors the CI environment.
   - `npm run test:cv -- --runInBand` generates serialised coverage when debugging.
 - **Database scripts:** `npm run db:migrate` / `npm run db:revert`.
+- **Schema rename:** Apply the `1737426000000-rename-legacy-boolean-columns` migration after pulling this update to rename `keyword.map_pack_top3` → `mapPackTop3` and `domain.scrape_enabled` → `scrapeEnabled` before running the app.
 - **Production build:** `npm run build` followed by `npm run start`.
 - **UI patterns:** Add new icons through the `ICON_RENDERERS` map in `components/common/Icon.tsx` and rely on the exported keyword filtering helpers when building new table views to keep predicates shared and complexity low.
 - **Side panels & dropdowns:** The `SidePanel` component now honours its `width` prop (`small`, `medium`, `large`) and `SelectField` respects `minWidth`, making it easier to tune layouts without hand-editing Tailwind classes.
@@ -282,7 +283,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
 - **Screenshot refresh skips:** Manual thumbnail updates now always hit the screenshot service with the stored host, so investigate provider logs if a toast reports a failure instead of assuming the button silently ignored the request.
 - **Corrupted screenshot cache:** If thumbnail reloads stop responding after local `domainThumbs` storage is edited or damaged, the app now clears the cache automatically and fetches a fresh image the next time you open the modal.
 - **Empty domain slugs:** The dashboard now always requests `/api/domain`, even for blank slugs, so the API returns descriptive validation errors instead of the client throwing immediately.
-- **Domain scraping toggle not persisting:** The custom SQLite dialect now coerces boolean bindings to integers so `/api/domains` updates keep `scrape_enabled` and the legacy `notification` flag aligned.
+- **Domain scraping toggle not persisting:** The custom SQLite dialect now coerces boolean bindings to integers so `/api/domains` updates keep `scrapeEnabled` and the legacy `notification` flag aligned.
 - **Scraper misconfiguration:** 500-series API responses often include descriptive JSON (with a `details` field) – surface these logs when opening support tickets.
 - **Redirected SERP links:** The scraper now normalises Google results that route through `/url`, `/interstitial`, or related wrappers, so stored ranks always point at the destination domain. If you capture new HTML fixtures, keep those redirect paths intact so tests continue exercising the normalisation logic.
 - **Cron timing:** Adjust cron expressions and `CRON_TIMEZONE` to align with your reporting cadence; expressions are normalised automatically, so quoting them in `.env` files is safe.

--- a/__mocks__/data.ts
+++ b/__mocks__/data.ts
@@ -12,7 +12,7 @@ export const dummyDomain = {
    lastUpdated: '2022-11-11T10:00:32.243',
    added: '2022-11-11T10:00:32.244',
    tags: '',
-   scrape_enabled: true,
+   scrapeEnabled: true,
    notification: true,
    notification_interval: 'daily',
    notification_emails: '',

--- a/__tests__/api/cron.test.ts
+++ b/__tests__/api/cron.test.ts
@@ -60,8 +60,8 @@ describe('/api/cron', () => {
 
   it('only refreshes keywords for domains with scraping enabled', async () => {
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'enabled.com', scrape_enabled: true }) },
-      { get: () => ({ domain: 'disabled.com', scrape_enabled: false }) },
+      { get: () => ({ domain: 'enabled.com', scrapeEnabled: true }) },
+      { get: () => ({ domain: 'disabled.com', scrapeEnabled: false }) },
     ]);
 
     const keywordRecord = { domain: 'enabled.com' };
@@ -81,7 +81,7 @@ describe('/api/cron', () => {
 
   it('returns early when no domains have scraping enabled', async () => {
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'disabled.com', scrape_enabled: false }) },
+      { get: () => ({ domain: 'disabled.com', scrapeEnabled: false }) },
     ]);
 
     await handler(req, res as NextApiResponse);

--- a/__tests__/api/domains.test.ts
+++ b/__tests__/api/domains.test.ts
@@ -37,7 +37,7 @@ describe('PUT /api/domains', () => {
   let domainState: {
     domain: string;
     slug: string;
-    scrape_enabled: boolean;
+    scrapeEnabled: boolean;
     notification: boolean;
   };
   let domainInstance: {
@@ -45,7 +45,7 @@ describe('PUT /api/domains', () => {
     set: jest.Mock;
     save: jest.Mock;
   };
-  let persistedSnapshots: Array<{ scrape_enabled: number; notification: number }>;
+  let persistedSnapshots: Array<{ scrapeEnabled: number; notification: number }>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,7 +56,7 @@ describe('PUT /api/domains', () => {
     domainState = {
       domain: 'toggle-test.example.com',
       slug: 'toggle-test-slug',
-      scrape_enabled: true,
+      scrapeEnabled: true,
       notification: true,
     };
 
@@ -67,7 +67,7 @@ describe('PUT /api/domains', () => {
       }),
       save: jest.fn().mockImplementation(async () => {
         persistedSnapshots.push({
-          scrape_enabled: Number(domainState.scrape_enabled),
+          scrapeEnabled: Number(domainState.scrapeEnabled),
           notification: Number(domainState.notification),
         });
         return domainInstance;
@@ -77,11 +77,11 @@ describe('PUT /api/domains', () => {
     DomainMock.findOne.mockResolvedValue(domainInstance);
   });
 
-  it('persists scrape_enabled toggles and keeps notification in sync', async () => {
+  it('persists scrapeEnabled toggles and keeps notification in sync', async () => {
     const disableReq = {
       method: 'PUT',
       query: { domain: domainState.domain },
-      body: { scrape_enabled: false },
+      body: { scrapeEnabled: false },
       headers: {},
     } as unknown as NextApiRequest;
     const disableRes = createMockResponse();
@@ -91,7 +91,7 @@ describe('PUT /api/domains', () => {
     expect(dbMock.sync).toHaveBeenCalledTimes(1);
     expect(DomainMock.findOne).toHaveBeenCalledWith({ where: { domain: domainState.domain } });
     expect(domainInstance.set).toHaveBeenCalledWith(expect.objectContaining({
-      scrape_enabled: false,
+      scrapeEnabled: false,
       notification: false,
     }));
     expect(domainInstance.save).toHaveBeenCalledTimes(1);
@@ -99,14 +99,14 @@ describe('PUT /api/domains', () => {
 
     const disablePayload = (disableRes.json as jest.Mock).mock.calls[0][0];
     expect(disablePayload.domain).toBe(domainInstance);
-    expect(domainState.scrape_enabled).toBe(false);
+    expect(domainState.scrapeEnabled).toBe(false);
     expect(domainState.notification).toBe(false);
-    expect(persistedSnapshots[0]).toEqual({ scrape_enabled: 0, notification: 0 });
+    expect(persistedSnapshots[0]).toEqual({ scrapeEnabled: 0, notification: 0 });
 
     const enableReq = {
       method: 'PUT',
       query: { domain: domainState.domain },
-      body: { scrape_enabled: true },
+      body: { scrapeEnabled: true },
       headers: {},
     } as unknown as NextApiRequest;
     const enableRes = createMockResponse();
@@ -115,7 +115,7 @@ describe('PUT /api/domains', () => {
 
     expect(DomainMock.findOne).toHaveBeenCalledTimes(2);
     expect(domainInstance.set).toHaveBeenLastCalledWith(expect.objectContaining({
-      scrape_enabled: true,
+      scrapeEnabled: true,
       notification: true,
     }));
     expect(domainInstance.save).toHaveBeenCalledTimes(2);
@@ -123,8 +123,8 @@ describe('PUT /api/domains', () => {
 
     const enablePayload = (enableRes.json as jest.Mock).mock.calls[0][0];
     expect(enablePayload.domain).toBe(domainInstance);
-    expect(domainState.scrape_enabled).toBe(true);
+    expect(domainState.scrapeEnabled).toBe(true);
     expect(domainState.notification).toBe(true);
-    expect(persistedSnapshots[1]).toEqual({ scrape_enabled: 1, notification: 1 });
+    expect(persistedSnapshots[1]).toEqual({ scrapeEnabled: 1, notification: 1 });
   });
 });

--- a/__tests__/api/notify.test.ts
+++ b/__tests__/api/notify.test.ts
@@ -245,7 +245,7 @@ describe('/api/notify - authentication', () => {
       get: () => ({
         domain: 'example.com',
         notification: false,
-        scrape_enabled: false,
+        scrapeEnabled: false,
         notification_emails: 'custom@example.com',
       }),
     };
@@ -285,7 +285,7 @@ describe('/api/notify - authentication', () => {
       get: () => ({
         domain: 'example.com',
         notification: true,
-        scrape_enabled: true,
+        scrapeEnabled: true,
         notification_emails: 'custom@example.com',
       }),
     };

--- a/__tests__/api/refresh.test.ts
+++ b/__tests__/api/refresh.test.ts
@@ -75,7 +75,7 @@ describe('/api/refresh', () => {
     const keywordRecord = { ID: 1, domain: 'example.com' };
     (Keyword.findAll as jest.Mock).mockResolvedValue([keywordRecord]);
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'example.com', scrape_enabled: true }) },
+      { get: () => ({ domain: 'example.com', scrapeEnabled: true }) },
     ]);
 
     (refreshAndUpdateKeywords as jest.Mock).mockRejectedValue(new Error('scraper failed'));

--- a/__tests__/components/DomainItem.test.tsx
+++ b/__tests__/components/DomainItem.test.tsx
@@ -85,14 +85,14 @@ describe('DomainItem Component', () => {
 
       expect(toggleMutationMock).toHaveBeenCalledWith({
          domain: dummyDomain,
-         domainSettings: { scrape_enabled: false },
+         domainSettings: { scrapeEnabled: false },
       });
    });
 
    it('displays the deactive label when domain toggles are disabled', () => {
       const inactiveDomain = {
          ...dummyDomain,
-         scrape_enabled: false,
+         scrapeEnabled: false,
          notify_enabled: false,
          notification: false,
       };

--- a/__tests__/components/DomainSettings.test.tsx
+++ b/__tests__/components/DomainSettings.test.tsx
@@ -31,7 +31,7 @@ const mockDomain: DomainType = {
    added: '2023-01-01',
    updated: '2023-01-01',
    tags: '',
-   scrape_enabled: true,
+   scrapeEnabled: true,
    notify_enabled: true,
    notification: true,
    notification_interval: 'daily',
@@ -133,7 +133,7 @@ describe('DomainSettings Component', () => {
       expect(mutateMock).toHaveBeenCalledWith({
          domain: mockDomain,
          domainSettings: expect.objectContaining({
-            scrape_enabled: false,
+            scrapeEnabled: false,
          }),
       });
    });

--- a/__tests__/utils/parseKeywords.test.ts
+++ b/__tests__/utils/parseKeywords.test.ts
@@ -19,7 +19,6 @@ describe('parseKeywords', () => {
       updating: false,
       lastUpdateError: 'false',
       mapPackTop3: false,
-      map_pack_top3: true,
       ...overrides,
    });
 
@@ -54,12 +53,11 @@ describe('parseKeywords', () => {
       expect(keyword.location).toBe('');
    });
 
-   it('hydrates camelCase flag when only the snake_case column is present', () => {
-      const [{ mapPackTop3, map_pack_top3 }] = parseKeywords([
-         buildKeyword({ mapPackTop3: undefined, map_pack_top3: 1 }) as any,
+   it('returns false for missing mapPackTop3 flag', () => {
+      const [{ mapPackTop3 }] = parseKeywords([
+         buildKeyword({ mapPackTop3: undefined }) as any,
       ]);
 
-      expect(mapPackTop3).toBe(true);
-      expect(map_pack_top3).toBeUndefined();
+      expect(mapPackTop3).toBe(false);
    });
 });

--- a/__tests__/utils/refresh.test.ts
+++ b/__tests__/utils/refresh.test.ts
@@ -47,7 +47,7 @@ describe('refreshAndUpdateKeywords', () => {
     };
 
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'example.com', scrape_enabled: true }) },
+      { get: () => ({ domain: 'example.com', scrapeEnabled: true }) },
     ]);
 
     (Keyword.update as jest.Mock).mockResolvedValue([1]);
@@ -91,11 +91,11 @@ describe('refreshAndUpdateKeywords', () => {
       },
     ];
 
-    // Mock domains with scrape_enabled: false to trigger the skipped keywords path
+    // Mock domains with scrapeEnabled: false to trigger the skipped keywords path
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'disabled1.com', scrape_enabled: false }) },
-      { get: () => ({ domain: 'disabled2.com', scrape_enabled: false }) },
-      { get: () => ({ domain: 'disabled3.com', scrape_enabled: false }) },
+      { get: () => ({ domain: 'disabled1.com', scrapeEnabled: false }) },
+      { get: () => ({ domain: 'disabled2.com', scrapeEnabled: false }) },
+      { get: () => ({ domain: 'disabled3.com', scrapeEnabled: false }) },
     ]);
 
     (Keyword.update as jest.Mock).mockResolvedValue([3]);
@@ -144,7 +144,7 @@ describe('refreshAndUpdateKeywords', () => {
     ];
 
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'enabled.com', scrape_enabled: true }) },
+      { get: () => ({ domain: 'enabled.com', scrapeEnabled: true }) },
     ]);
 
     await refreshAndUpdateKeywords(mockKeywords, mockSettings);
@@ -166,7 +166,7 @@ describe('refreshAndUpdateKeywords', () => {
     ];
 
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'disabled.com', scrape_enabled: false }) },
+      { get: () => ({ domain: 'disabled.com', scrapeEnabled: false }) },
     ]);
 
     (Keyword.update as jest.Mock).mockResolvedValue([1]);
@@ -197,7 +197,7 @@ describe('refreshAndUpdateKeywords', () => {
     ];
 
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'disabled.com', scrape_enabled: false }) },
+      { get: () => ({ domain: 'disabled.com', scrapeEnabled: false }) },
     ]);
 
     (Keyword.update as jest.Mock).mockResolvedValue([1]);
@@ -229,7 +229,7 @@ describe('refreshAndUpdateKeywords', () => {
     ];
 
     (Domain.findAll as jest.Mock).mockResolvedValue([
-      { get: () => ({ domain: 'disabled.com', scrape_enabled: false }) },
+      { get: () => ({ domain: 'disabled.com', scrapeEnabled: false }) },
     ]);
 
     (Keyword.update as jest.Mock).mockResolvedValue([1]);

--- a/__tests__/utils/updateDomainStats.test.ts
+++ b/__tests__/utils/updateDomainStats.test.ts
@@ -27,19 +27,19 @@ describe('updateDomainStats', () => {
       {
         get: () => ({
           position: 5,
-          map_pack_top3: true,
+          mapPackTop3: true,
         }),
       },
       {
         get: () => ({
           position: 15,
-          map_pack_top3: false,
+          mapPackTop3: false,
         }),
       },
       {
         get: () => ({
           position: 0, // Should be excluded from average
-          map_pack_top3: true,
+          mapPackTop3: true,
         }),
       },
     ];
@@ -53,7 +53,7 @@ describe('updateDomainStats', () => {
     expect(mockDomainUpdate).toHaveBeenCalledWith(
       {
         avgPosition: 10, // Math.round((5+15)/2) = 10
-        mapPackKeywords: 2, // Two keywords have map_pack_top3: true
+        mapPackKeywords: 2, // Two keywords have mapPackTop3: true
       },
       { where: { domain: 'example.com' } }
     );
@@ -79,13 +79,13 @@ describe('updateDomainStats', () => {
       {
         get: () => ({
           position: 0,
-          map_pack_top3: false,
+          mapPackTop3: false,
         }),
       },
       {
         get: () => ({
           position: 0,
-          map_pack_top3: true,
+          mapPackTop3: true,
         }),
       },
     ];
@@ -98,7 +98,7 @@ describe('updateDomainStats', () => {
     expect(mockDomainUpdate).toHaveBeenCalledWith(
       {
         avgPosition: 0, // No valid positions to average
-        mapPackKeywords: 1, // One keyword has map_pack_top3: true
+        mapPackKeywords: 1, // One keyword has mapPackTop3: true
       },
       { where: { domain: 'unranked.com' } }
     );

--- a/components/domains/DomainItem.tsx
+++ b/components/domains/DomainItem.tsx
@@ -40,11 +40,11 @@ const DomainItem = ({
    } = domain;
    const { mutateAsync: updateDomainToggle, isLoading: isToggleUpdating } = useUpdateDomainToggles();
 
-   const isDomainActive = (domain.scrape_enabled !== false)
+   const isDomainActive = (domain.scrapeEnabled !== false)
       && (domain.notification !== false);
 
    const handleDomainStatusToggle = async (nextValue: boolean) => {
-      const payload: Partial<DomainSettings> = { scrape_enabled: nextValue };
+      const payload: Partial<DomainSettings> = { scrapeEnabled: nextValue };
       try {
          await updateDomainToggle({ domain, domainSettings: payload });
          const message = `${domain.domain} ${nextValue ? 'marked as Active' : 'marked as Deactive'}.`;

--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -19,8 +19,8 @@ type DomainSettingsError = {
 
 const deriveDomainActiveState = (domainData?: DomainType | null) => {
    if (!domainData) { return true; }
-   const { scrape_enabled, notification } = domainData;
-   return (scrape_enabled !== false) && (notification !== false);
+   const { scrapeEnabled, notification } = domainData;
+   return (scrapeEnabled !== false) && (notification !== false);
 };
 
 const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
@@ -35,7 +35,7 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
       search_console: domain?.search_console ? JSON.parse(domain.search_console) : {
          property_type: 'domain', url: '', client_email: '', private_key: '',
       },
-      scrape_enabled: initialActiveState,
+      scrapeEnabled: initialActiveState,
    }));
 
    const { mutate: updateMutate, error: domainUpdateError, isLoading: isUpdating } = useUpdateDomain(() => closeModal(false));
@@ -48,18 +48,18 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
       setDomainSettings(prevSettings => ({
          ...prevSettings,
          search_console: currentSearchConsoleSettings || prevSettings.search_console,
-         scrape_enabled: nextActive,
+         scrapeEnabled: nextActive,
       }));
    });
 
    const updateDomainActiveState = (next: boolean) => {
       setDomainSettings(prevSettings => ({
          ...prevSettings,
-         scrape_enabled: next,
+         scrapeEnabled: next,
       }));
    };
 
-   const isDomainActive = domainSettings.scrape_enabled !== false;
+   const isDomainActive = domainSettings.scrapeEnabled !== false;
 
    const updateDomain = () => {
       let error: DomainSettingsError | null = null;

--- a/database/migrations/1737426000000-rename-legacy-boolean-columns.js
+++ b/database/migrations/1737426000000-rename-legacy-boolean-columns.js
@@ -1,0 +1,111 @@
+// Migration: Renames legacy snake_case boolean columns to camelCase equivalents while preserving constraints
+
+module.exports = {
+   up: async function up(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib =
+         params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
+
+      return queryInterface.sequelize.transaction(async (transaction) => {
+         try {
+            const keywordTableDefinition = await queryInterface.describeTable('keyword');
+            const domainTableDefinition = await queryInterface.describeTable('domain');
+
+            const hasLegacyKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'map_pack_top3');
+            const hasCamelKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'mapPackTop3');
+
+            if (hasLegacyKeywordFlag) {
+               await queryInterface.renameColumn('keyword', 'map_pack_top3', 'mapPackTop3', { transaction });
+            }
+
+            if (hasLegacyKeywordFlag || hasCamelKeywordFlag) {
+               await queryInterface.changeColumn(
+                  'keyword',
+                  'mapPackTop3',
+                  {
+                     type: SequelizeLib.DataTypes.BOOLEAN,
+                     allowNull: false,
+                     defaultValue: false,
+                  },
+                  { transaction }
+               );
+            }
+
+            const hasLegacyDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrape_enabled');
+            const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
+
+            if (hasLegacyDomainFlag) {
+               await queryInterface.renameColumn('domain', 'scrape_enabled', 'scrapeEnabled', { transaction });
+            }
+
+            if (hasLegacyDomainFlag || hasCamelDomainFlag) {
+               await queryInterface.changeColumn(
+                  'domain',
+                  'scrapeEnabled',
+                  {
+                     type: SequelizeLib.DataTypes.BOOLEAN,
+                     allowNull: false,
+                     defaultValue: true,
+                  },
+                  { transaction }
+               );
+            }
+         } catch (error) {
+            console.log('Migration error:', error);
+            throw error;
+         }
+      });
+   },
+
+   down: async function down(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib =
+         params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
+
+      return queryInterface.sequelize.transaction(async (transaction) => {
+         try {
+            const keywordTableDefinition = await queryInterface.describeTable('keyword');
+            const domainTableDefinition = await queryInterface.describeTable('domain');
+
+            const hasCamelKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'mapPackTop3');
+            if (hasCamelKeywordFlag) {
+               await queryInterface.renameColumn('keyword', 'mapPackTop3', 'map_pack_top3', { transaction });
+               await queryInterface.changeColumn(
+                  'keyword',
+                  'map_pack_top3',
+                  {
+                     type: SequelizeLib.DataTypes.BOOLEAN,
+                     allowNull: false,
+                     defaultValue: false,
+                  },
+                  { transaction }
+               );
+            }
+
+            const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
+            if (hasCamelDomainFlag) {
+               await queryInterface.renameColumn('domain', 'scrapeEnabled', 'scrape_enabled', { transaction });
+               await queryInterface.changeColumn(
+                  'domain',
+                  'scrape_enabled',
+                  {
+                     type: SequelizeLib.DataTypes.BOOLEAN,
+                     allowNull: false,
+                     defaultValue: true,
+                  },
+                  { transaction }
+               );
+            }
+         } catch (error) {
+            console.log('Migration rollback error:', error);
+            throw error;
+         }
+      });
+   },
+};

--- a/database/models/domain.ts
+++ b/database/models/domain.ts
@@ -28,7 +28,7 @@ class Domain extends Model {
    tags!: string;
 
    @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: true })
-   scrape_enabled!: boolean;
+   scrapeEnabled!: boolean;
 
    @Column({ type: DataType.BOOLEAN, allowNull: true, defaultValue: true })
    notification!: boolean;

--- a/database/models/keyword.ts
+++ b/database/models/keyword.ts
@@ -66,17 +66,7 @@ class Keyword extends Model {
    lastUpdateError!: string;
 
    @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: false })
-   map_pack_top3!: boolean;
-
-   // Getter to provide camelCase property that maps to the DB field
-   get mapPackTop3(): boolean {
-      return this.map_pack_top3;
-   }
-
-   // Setter to allow camelCase assignment to DB field
-   set mapPackTop3(value: boolean) {
-      this.map_pack_top3 = value;
-   }
+   mapPackTop3!: boolean;
 }
 
 export default Keyword;

--- a/pages/api/cron.ts
+++ b/pages/api/cron.ts
@@ -32,10 +32,10 @@ const cronRefreshkeywords = async (req: NextApiRequest, res: NextApiResponse<CRO
       if (!settings || (settings && settings.scraper_type === 'none')) {
          return res.status(400).json({ started: false, error: 'Scraper has not been set up yet.' });
       }
-      const domainToggles = await Domain.findAll({ attributes: ['domain', 'scrape_enabled'] });
+      const domainToggles = await Domain.findAll({ attributes: ['domain', 'scrapeEnabled'] });
       const enabledDomains = domainToggles
          .map((dom) => dom.get({ plain: true }))
-         .filter((dom) => dom.scrape_enabled !== false)
+         .filter((dom) => dom.scrapeEnabled !== false)
          .map((dom) => dom.domain);
 
       if (enabledDomains.length === 0) {

--- a/pages/api/domains.ts
+++ b/pages/api/domains.ts
@@ -89,7 +89,7 @@ const addDomain = async (req: NextApiRequest, res: NextApiResponse<DomainsAddRes
             slug: domain.trim().replaceAll('-', '_').replaceAll('.', '-').replaceAll('/', '-'),
             lastUpdated: new Date().toJSON(),
             added: new Date().toJSON(),
-            scrape_enabled: true,
+            scrapeEnabled: true,
             notification: true,
          });
       });
@@ -132,7 +132,7 @@ export const updateDomain = async (req: NextApiRequest, res: NextApiResponse<Dom
       notification_interval,
       notification_emails,
       search_console,
-      scrape_enabled,
+      scrapeEnabled,
    } = payload;
 
    try {
@@ -152,10 +152,10 @@ export const updateDomain = async (req: NextApiRequest, res: NextApiResponse<Dom
          const updates: Partial<Domain> = {};
          if (typeof notification_interval === 'string') { updates.notification_interval = notification_interval; }
          if (typeof notification_emails === 'string') { updates.notification_emails = notification_emails; }
-         if (typeof scrape_enabled === 'boolean') { 
-            updates.scrape_enabled = scrape_enabled;
-            // Update the legacy notification field to match scrape_enabled
-            updates.notification = scrape_enabled;
+         if (typeof scrapeEnabled === 'boolean') {
+            updates.scrapeEnabled = scrapeEnabled;
+            // Update the legacy notification field to match scrapeEnabled
+            updates.notification = scrapeEnabled;
          }
          if (search_console) {
             updates.search_console = JSON.stringify(search_console);

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -63,7 +63,7 @@ const notify = async (req: NextApiRequest, res: NextApiResponse<NotifyResponse>)
          const theDomain = await Domain.findOne({ where: { domain: reqDomain } });
          if (theDomain) {
             const domainPlain = theDomain.get({ plain: true }) as DomainType;
-            if (domainPlain.scrape_enabled !== false && domainPlain.notification !== false) {
+            if (domainPlain.scrapeEnabled !== false && domainPlain.notification !== false) {
                await sendNotificationEmail(domainPlain, normalizedSettings);
             }
          }
@@ -72,7 +72,7 @@ const notify = async (req: NextApiRequest, res: NextApiResponse<NotifyResponse>)
          if (allDomains && allDomains.length > 0) {
             const domains = allDomains.map((el) => el.get({ plain: true }));
             for (const domain of domains) {
-               if (domain.scrape_enabled !== false && domain.notification !== false) {
+               if (domain.scrapeEnabled !== false && domain.notification !== false) {
                   await sendNotificationEmail(domain, normalizedSettings);
                }
             }

--- a/pages/api/refresh.ts
+++ b/pages/api/refresh.ts
@@ -76,10 +76,10 @@ const refreshTheKeywords = async (req: NextApiRequest, res: NextApiResponse<Keyw
       }
 
       const domainNames = Array.from(new Set(keywordQueries.map((keyword) => keyword.domain).filter(Boolean)));
-      const domainRecords = await Domain.findAll({ where: { domain: domainNames }, attributes: ['domain', 'scrape_enabled'] });
+      const domainRecords = await Domain.findAll({ where: { domain: domainNames }, attributes: ['domain', 'scrapeEnabled'] });
       const scrapeEnabledMap = new Map(domainRecords.map((record) => {
          const plain = record.get({ plain: true }) as DomainType;
-         return [plain.domain, plain.scrape_enabled !== false];
+         return [plain.domain, plain.scrapeEnabled !== false];
       }));
 
       const keywordsToRefresh = keywordQueries.filter((keyword) => scrapeEnabledMap.get(keyword.domain) !== false);

--- a/services/domains.tsx
+++ b/services/domains.tsx
@@ -16,10 +16,10 @@ export const SCREENSHOTS_ENABLED = normalizeEnvFlag(process.env.NEXT_PUBLIC_SCRE
 
 const normalizeDomainPatch = (patch: Partial<DomainSettings>): Partial<DomainType> => {
    const updates: Partial<DomainType> = {};
-   if (typeof patch.scrape_enabled === 'boolean') {
-      updates.scrape_enabled = patch.scrape_enabled;
-      // Update the legacy notification field to match scrape_enabled
-      updates.notification = patch.scrape_enabled;
+   if (typeof patch.scrapeEnabled === 'boolean') {
+      updates.scrapeEnabled = patch.scrapeEnabled;
+      // Update the legacy notification field to match scrapeEnabled
+      updates.notification = patch.scrapeEnabled;
    }
    if (typeof patch.notification_interval === 'string') {
       updates.notification_interval = patch.notification_interval;

--- a/types.d.ts
+++ b/types.d.ts
@@ -3,7 +3,7 @@ type DomainType = {
    domain: string,
    slug: string,
    tags?: string,
-   scrape_enabled?: boolean,
+   scrapeEnabled?: boolean,
    notification: boolean,
    notification_interval: string,
    notification_emails: string,
@@ -80,7 +80,7 @@ type DomainSettings = {
    notification_interval: string,
    notification_emails: string,
    search_console?: DomainSearchConsole,
-   scrape_enabled?: boolean,
+   scrapeEnabled?: boolean,
 }
 
 type SettingsType = {

--- a/utils/parseKeywords.ts
+++ b/utils/parseKeywords.ts
@@ -48,7 +48,7 @@ const normaliseBoolean = (value: unknown): boolean => {
 const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
    const parsedItems = allKeywords.map((keywrd:Keyword) => {
       const keywordData = keywrd as unknown as Record<string, any>;
-      const { map_pack_top3, ...keywordWithoutSnakeCase } = keywordData;
+      const { mapPackTop3, ...keywordWithoutMapPack } = keywordData;
 
       let historyRaw: unknown;
       try { historyRaw = JSON.parse(keywordData.history); } catch { historyRaw = {}; }
@@ -65,13 +65,13 @@ const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
          try { lastUpdateError = JSON.parse(keywordData.lastUpdateError); } catch { lastUpdateError = {}; }
       }
 
-      const mapPackTop3 = normaliseBoolean(keywordData.mapPackTop3 ?? map_pack_top3);
+      const normalisedMapPackTop3 = normaliseBoolean(mapPackTop3);
 
       const updating = normaliseBoolean(keywordData.updating);
       const sticky = normaliseBoolean(keywordData.sticky);
 
       return {
-         ...keywordWithoutSnakeCase,
+         ...keywordWithoutMapPack,
          location: typeof keywordData.location === 'string' ? keywordData.location : '',
          history,
          tags,
@@ -79,7 +79,7 @@ const parseKeywords = (allKeywords: Keyword[]) : KeywordType[] => {
          lastUpdateError,
          sticky,
          updating,
-         mapPackTop3,
+         mapPackTop3: normalisedMapPackTop3,
       };
    });
    return parsedItems;

--- a/utils/refresh.ts
+++ b/utils/refresh.ts
@@ -25,10 +25,10 @@ const refreshAndUpdateKeywords = async (rawkeyword:Keyword[], settings:SettingsT
    let scrapePermissions = new Map<string, boolean>();
 
    if (domainNames.length > 0) {
-      const domains = await Domain.findAll({ where: { domain: domainNames }, attributes: ['domain', 'scrape_enabled'] });
+      const domains = await Domain.findAll({ where: { domain: domainNames }, attributes: ['domain', 'scrapeEnabled'] });
       scrapePermissions = new Map(domains.map((domain) => {
          const domainPlain = domain.get({ plain: true }) as DomainType;
-         return [domainPlain.domain, domainPlain.scrape_enabled !== false];
+         return [domainPlain.domain, domainPlain.scrapeEnabled !== false];
       }));
    }
 

--- a/utils/updateDomainStats.ts
+++ b/utils/updateDomainStats.ts
@@ -19,7 +19,7 @@ export const updateDomainStats = async (domainName: string): Promise<void> => {
             const keywordData = keyword.get({ plain: true });
             
             // Count mapPack keywords
-            if (keywordData.map_pack_top3 === true) {
+            if (keywordData.mapPackTop3 === true) {
                acc.mapPackKeywords++;
             }
             


### PR DESCRIPTION
## Summary
- add a guarded migration that renames `keyword.map_pack_top3` to `mapPackTop3` and `domain.scrape_enabled` to `scrapeEnabled` while preserving the boolean constraints
- update Sequelize models, API handlers, utilities, React components, and shared types to use the camelCase properties directly and drop the legacy snake_case shims
- refresh fixtures, Jest suites, and documentation to cover the renamed flags and instruct operators to run the new migration

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d94c4f841c832ab8daea480ecaaef8