### PR TITLE
Align keyword map pack tests with camelCase flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. Releases no
 - Documented the fork's stability, security, and performance improvements at the top of the README for quick comparison with upstream SerpBear.
 
 ### Bug Fixes
+- Clarified regression coverage to assert the camelCase `mapPackTop3` keyword property rather than the legacy snake_case flag.
 - Ensured keyword refresh cleanup always persists `updating` resets even when Sequelize instances still hold stale values after bulk updates, so failed scrapes no longer leave rows stuck in a loading state.
 - Cleared ESLint warnings by wiring width/min-width props into UI components, surfacing settings errors inline, sanitising SMTP TLS hostnames, and logging caught exceptions throughout Ads/Search Console utilities and API handlers.
 - Fixed the Google Ads keyword ideas mutation so successful requests no longer throw a runtime reference error and now properly invalidate the cached query for the active domain.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
   - `npm test` executes the Jest test suite using the `@happy-dom/jest-environment` adapter.
   - `npm run test:ci` mirrors the CI environment.
   - `npm run test:cv -- --runInBand` generates serialised coverage when debugging.
+  - Regression specs assert the camelCase `mapPackTop3` keyword flag—update fixtures to keep that property present when adding new cases.
 - **Database scripts:** `npm run db:migrate` / `npm run db:revert`.
 - **Schema rename:** Apply the `1737426000000-rename-legacy-boolean-columns` migration after pulling this update to rename `keyword.map_pack_top3` → `mapPackTop3` and `domain.scrape_enabled` → `scrapeEnabled` before running the app.
 - **Production build:** `npm run build` followed by `npm run start`.

--- a/__tests__/services/keywords.fetchKeywords.test.ts
+++ b/__tests__/services/keywords.fetchKeywords.test.ts
@@ -67,7 +67,7 @@ describe('fetchKeywords normalisation', () => {
       expect(typeof keyword.updating).toBe('boolean');
       expect(keyword.sticky).toBe(false);
       expect(keyword.mapPackTop3).toBe(true);
-      expect(Object.prototype.hasOwnProperty.call(keyword, 'map_pack_top3')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(keyword, 'mapPackTop3')).toBe(true);
    });
 
    it('returns consistent object structure when domain is falsy', async () => {

--- a/__tests__/utils/parseKeywords.test.ts
+++ b/__tests__/utils/parseKeywords.test.ts
@@ -30,7 +30,7 @@ describe('parseKeywords', () => {
       expect(keyword.updating).toBe(false);
       expect(keyword.sticky).toBe(false);
       expect(keyword.mapPackTop3).toBe(false);
-      expect(Object.prototype.hasOwnProperty.call(keyword, 'map_pack_top3')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(keyword, 'mapPackTop3')).toBe(true);
    });
 
    it('normalises truthy boolean variants to true', () => {
@@ -41,7 +41,7 @@ describe('parseKeywords', () => {
       expect(keyword.updating).toBe(true);
       expect(keyword.sticky).toBe(true);
       expect(keyword.mapPackTop3).toBe(true);
-      expect(Object.prototype.hasOwnProperty.call(keyword, 'map_pack_top3')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(keyword, 'mapPackTop3')).toBe(true);
    });
 
    it('keeps existing keyword structure intact', () => {


### PR DESCRIPTION
## Summary
- update keyword normalisation tests to assert the camelCase `mapPackTop3` property
- document the regression coverage adjustment in the README and changelog

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d954f8eea4832a9d688a6bd7865e5b