### PR TITLE
Update docs to focus on mapPackTop3 references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file. Releases no
 - Tracker email summary now falls back to live keyword data to compute average position and map-pack totals, preventing those counters from showing 0 when domain aggregates are unavailable.
 - Tracker email summary now respects persisted Map Pack totals when available while still deriving a fallback from live keyword data for domains without the stored value.
 - Domain stats retrieval now omits average position and map-pack counts unless persisted values exist, avoiding stale recalculations from keyword snapshots.
-- Renamed keyword `map_pack_top3` → `mapPackTop3` and domain `scrape_enabled` → `scrapeEnabled`, updating API responses and models accordingly. Run `npm run db:migrate` to apply the `1737426000000-rename-legacy-boolean-columns` migration before restarting services.
+- Completed the camelCase boolean migration so keywords now deliver the `mapPackTop3` flag and domains expose `scrapeEnabled` across API responses and models. Run `npm run db:migrate` to apply the `1737426000000-rename-legacy-boolean-columns` migration before restarting services.
 
 # [3.0.0](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v3.0.0) (2025-09-24)
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Every feature available in the UI is backed by authenticated API routes. Authent
 - `POST /api/refresh` – queue immediate re-scrapes for selected keywords.
 - `GET /api/settings` – fetch the current scraper, cron, and notification settings.
 
-Keyword responses now expose only the camelCase `mapPackTop3` flag alongside the other normalised booleans. The legacy `map_pack_top3` column has been renamed by the `1737426000000-rename-legacy-boolean-columns` migration so API consumers and integrations no longer need to handle both cases.
+Keyword responses now expose only the camelCase `mapPackTop3` flag alongside the other normalised booleans. Ensure the `1737426000000-rename-legacy-boolean-columns` migration has been applied so API consumers and integrations receive the consolidated field.
 
 Refer to the [official documentation](https://docs.serpbear.com/) for the complete endpoint catalogue and payload schemas.
 
@@ -267,7 +267,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
   - `npm run test:ci` mirrors the CI environment.
   - `npm run test:cv -- --runInBand` generates serialised coverage when debugging.
 - **Database scripts:** `npm run db:migrate` / `npm run db:revert`.
-- **Schema rename:** Apply the `1737426000000-rename-legacy-boolean-columns` migration after pulling this update to rename `keyword.map_pack_top3` → `mapPackTop3` and `domain.scrape_enabled` → `scrapeEnabled` before running the app.
+- **Schema rename:** Apply the `1737426000000-rename-legacy-boolean-columns` migration after pulling this update so keywords expose the `mapPackTop3` flag and domains surface the `scrapeEnabled` setting before running the app.
 - **Production build:** `npm run build` followed by `npm run start`.
 - **UI patterns:** Add new icons through the `ICON_RENDERERS` map in `components/common/Icon.tsx` and rely on the exported keyword filtering helpers when building new table views to keep predicates shared and complexity low.
 - **Side panels & dropdowns:** The `SidePanel` component now honours its `width` prop (`small`, `medium`, `large`) and `SelectField` respects `minWidth`, making it easier to tune layouts without hand-editing Tailwind classes.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,7 +4,7 @@ import { TextEncoder, TextDecoder } from 'util';
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: ({ src, alt, width, height, unoptimized, ...rest }) => {
+  default: ({ src, alt, width, height, unoptimized: _unoptimized, ...rest }) => {
     const React = require('react');
     return React.createElement('img', { src, alt, width, height, ...rest });
   },

--- a/pages/api/settings.ts
+++ b/pages/api/settings.ts
@@ -11,7 +11,7 @@ import { logger } from '../../utils/logger';
 import { trimStringProperties } from '../../utils/security';
 import { getBranding } from '../../utils/branding';
 
-const { platformName, whiteLabelEnabled } = getBranding();
+const { platformName } = getBranding();
 
 const SETTINGS_DEFAULTS: SettingsType = {
    scraper_type: 'none',

--- a/services/keywords.tsx
+++ b/services/keywords.tsx
@@ -296,7 +296,7 @@ export function useFetchSingleKeyword(keywordID:number) {
          throw new Error('Error Loading Keyword Details');
       }
    }, {
-      onError: (error) => {
+      onError: (_error) => {
          console.log('Error Loading Keyword Data!!!');
          toast('Error Loading Keyword Details.', { icon: '⚠️' });
       },


### PR DESCRIPTION
## Summary
- update README migration guidance to reference only the camelCase mapPackTop3 field
- note the completed boolean column transition in the changelog without citing the legacy name
- silence existing lint warnings triggered by unused variables in test helpers

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d954fa9aa4832a81a43409cc1f5531