### PR TITLE
Align map pack migrations with camelCase column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file. Releases no
 - Tracker email summary now falls back to live keyword data to compute average position and map-pack totals, preventing those counters from showing 0 when domain aggregates are unavailable.
 - Tracker email summary now respects persisted Map Pack totals when available while still deriving a fallback from live keyword data for domains without the stored value.
 - Domain stats retrieval now omits average position and map-pack counts unless persisted values exist, avoiding stale recalculations from keyword snapshots.
-- Renamed keyword `map_pack_top3` → `mapPackTop3` and domain `scrape_enabled` → `scrapeEnabled`, updating API responses and models accordingly. Run `npm run db:migrate` to apply the `1737426000000-rename-legacy-boolean-columns` migration before restarting services.
+- Promoted keyword `mapPackTop3` and domain `scrapeEnabled` as the canonical booleans, removing their legacy snake_case columns via the `1737426000000-rename-legacy-boolean-columns` migration so downstream code only sees the camelCase identifiers. Run `npm run db:migrate` before restarting services.
 
 # [3.0.0](https://github.com/djav1985/v-serpbear/compare/v2.0.7...v3.0.0) (2025-09-24)
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Every feature available in the UI is backed by authenticated API routes. Authent
 - `POST /api/refresh` – queue immediate re-scrapes for selected keywords.
 - `GET /api/settings` – fetch the current scraper, cron, and notification settings.
 
-Keyword responses now expose only the camelCase `mapPackTop3` flag alongside the other normalised booleans. The legacy `map_pack_top3` column has been renamed by the `1737426000000-rename-legacy-boolean-columns` migration so API consumers and integrations no longer need to handle both cases.
+Keyword responses now expose only the camelCase `mapPackTop3` flag alongside the other normalised booleans. The `1737426000000-rename-legacy-boolean-columns` migration removes the legacy `map_pack_top3` column entirely so API consumers and integrations only interact with the canonical camelCase field.
 
 Refer to the [official documentation](https://docs.serpbear.com/) for the complete endpoint catalogue and payload schemas.
 
@@ -267,7 +267,7 @@ Refer to the [official documentation](https://docs.serpbear.com/) for the comple
   - `npm run test:ci` mirrors the CI environment.
   - `npm run test:cv -- --runInBand` generates serialised coverage when debugging.
 - **Database scripts:** `npm run db:migrate` / `npm run db:revert`.
-- **Schema rename:** Apply the `1737426000000-rename-legacy-boolean-columns` migration after pulling this update to rename `keyword.map_pack_top3` → `mapPackTop3` and `domain.scrape_enabled` → `scrapeEnabled` before running the app.
+- **Schema cleanup:** Apply the `1737426000000-rename-legacy-boolean-columns` migration after pulling this update to drop the deprecated `keyword.map_pack_top3`/`domain.scrape_enabled` columns and enforce the camelCase `mapPackTop3`/`scrapeEnabled` pair before running the app.
 - **Production build:** `npm run build` followed by `npm run start`.
 - **UI patterns:** Add new icons through the `ICON_RENDERERS` map in `components/common/Icon.tsx` and rely on the exported keyword filtering helpers when building new table views to keep predicates shared and complexity low.
 - **Side panels & dropdowns:** The `SidePanel` component now honours its `width` prop (`small`, `medium`, `large`) and `SelectField` respects `minWidth`, making it easier to tune layouts without hand-editing Tailwind classes.

--- a/__tests__/database/map-pack-migration.test.ts
+++ b/__tests__/database/map-pack-migration.test.ts
@@ -22,7 +22,7 @@ describe('Map Pack Top3 Migration', () => {
     }
   });
 
-  test('migration adds map_pack_top3 column with proper constraints', async () => {
+  test('migration adds mapPackTop3 column with proper constraints', async () => {
     const migration = require('../../database/migrations/1737307000000-add-keyword-map-pack-flag');
     const { DataTypes } = require('sequelize');
     
@@ -34,7 +34,7 @@ describe('Map Pack Top3 Migration', () => {
         query: jest.fn().mockResolvedValue(undefined),
       },
       describeTable: jest.fn().mockResolvedValue({
-        // Simulate table without the 'map_pack_top3' field initially
+        // Simulate table without the 'mapPackTop3' field initially
       }),
       addColumn: jest.fn().mockResolvedValue(undefined),
       changeColumn: jest.fn().mockResolvedValue(undefined),
@@ -46,7 +46,7 @@ describe('Map Pack Top3 Migration', () => {
     // Verify the column is added as nullable first
     expect(mockQueryInterface.addColumn).toHaveBeenCalledWith(
       'keyword',
-      'map_pack_top3',
+      'mapPackTop3',
       {
         type: DataTypes.BOOLEAN,
         allowNull: true,
@@ -54,17 +54,17 @@ describe('Map Pack Top3 Migration', () => {
       },
       { transaction: { transaction: 'mock' } }
     );
-    
+
     // Verify backfill UPDATE query is executed
     expect(mockQueryInterface.sequelize.query).toHaveBeenCalledWith(
-      'UPDATE keyword SET map_pack_top3 = 0 WHERE map_pack_top3 IS NULL',
+      'UPDATE keyword SET mapPackTop3 = 0 WHERE mapPackTop3 IS NULL',
       { transaction: { transaction: 'mock' } }
     );
-    
+
     // Verify column is changed to NOT NULL after backfill
     expect(mockQueryInterface.changeColumn).toHaveBeenCalledWith(
       'keyword',
-      'map_pack_top3',
+      'mapPackTop3',
       {
         type: DataTypes.BOOLEAN,
         allowNull: false,
@@ -86,8 +86,8 @@ describe('Map Pack Top3 Migration', () => {
         query: jest.fn().mockResolvedValue(undefined),
       },
       describeTable: jest.fn().mockResolvedValue({
-        // Simulate table WITH the 'map_pack_top3' field already present
-        map_pack_top3: { type: 'BOOLEAN', allowNull: false, defaultValue: false }
+        // Simulate table WITH the 'mapPackTop3' field already present
+        mapPackTop3: { type: 'BOOLEAN', allowNull: false, defaultValue: false }
       }),
       addColumn: jest.fn().mockResolvedValue(undefined),
       changeColumn: jest.fn().mockResolvedValue(undefined),
@@ -102,7 +102,7 @@ describe('Map Pack Top3 Migration', () => {
     expect(mockQueryInterface.changeColumn).not.toHaveBeenCalled();
   });
 
-  test('migration down removes map_pack_top3 column correctly', async () => {
+  test('migration down removes mapPackTop3 column correctly', async () => {
     const migration = require('../../database/migrations/1737307000000-add-keyword-map-pack-flag');
     
     // Create a mock queryInterface for rollback
@@ -111,7 +111,7 @@ describe('Map Pack Top3 Migration', () => {
         transaction: jest.fn(async (callback) => await callback({ transaction: 'mock' })),
       },
       describeTable: jest.fn().mockResolvedValue({
-        map_pack_top3: { type: 'BOOLEAN', allowNull: false, defaultValue: false }
+        mapPackTop3: { type: 'BOOLEAN', allowNull: false, defaultValue: false }
       }),
       removeColumn: jest.fn().mockResolvedValue(undefined),
     };
@@ -120,11 +120,9 @@ describe('Map Pack Top3 Migration', () => {
     await expect(migration.down({ context: mockQueryInterface })).resolves.not.toThrow();
     
     // Verify column is removed
-    expect(mockQueryInterface.removeColumn).toHaveBeenCalledWith(
-      'keyword',
-      'map_pack_top3',
-      { transaction: { transaction: 'mock' } }
-    );
+    expect(mockQueryInterface.removeColumn).toHaveBeenCalledWith('keyword', 'mapPackTop3', {
+      transaction: { transaction: 'mock' },
+    });
   });
 
   test('migration handles errors and re-throws them', async () => {

--- a/database/migrations/1737307000000-add-keyword-map-pack-flag.js
+++ b/database/migrations/1737307000000-add-keyword-map-pack-flag.js
@@ -1,4 +1,4 @@
-// Migration: Adds map_pack_top3 field to keyword table to track whether a keyword appears in top 3 map pack results
+// Migration: Adds mapPackTop3 field to keyword table to track whether a keyword appears in top 3 map pack results
 
 module.exports = {
    up: async function up(params = {}, legacySequelize) {
@@ -12,10 +12,10 @@ module.exports = {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');
 
-            if (!keywordTableDefinition?.map_pack_top3) {
+            if (!keywordTableDefinition?.mapPackTop3) {
                await queryInterface.addColumn(
                   'keyword',
-                  'map_pack_top3',
+                  'mapPackTop3',
                   {
                      type: SequelizeLib.DataTypes.BOOLEAN,
                      allowNull: true, // Add as nullable first to avoid table locks
@@ -27,8 +27,8 @@ module.exports = {
                await queryInterface.sequelize.query(
                   [
                      'UPDATE keyword',
-                     'SET map_pack_top3 = 0',
-                     'WHERE map_pack_top3 IS NULL',
+                     'SET mapPackTop3 = 0',
+                     'WHERE mapPackTop3 IS NULL',
                   ].join(' '),
                   { transaction }
                );
@@ -36,7 +36,7 @@ module.exports = {
                // Now that values are backfilled, enforce NOT NULL
                await queryInterface.changeColumn(
                   'keyword',
-                  'map_pack_top3',
+                  'mapPackTop3',
                   {
                      type: SequelizeLib.DataTypes.BOOLEAN,
                      allowNull: false,
@@ -59,8 +59,8 @@ module.exports = {
          try {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');
 
-            if (keywordTableDefinition?.map_pack_top3) {
-               await queryInterface.removeColumn('keyword', 'map_pack_top3', { transaction });
+            if (keywordTableDefinition?.mapPackTop3) {
+               await queryInterface.removeColumn('keyword', 'mapPackTop3', { transaction });
             }
          } catch (error) {
             console.log('Migration rollback error:', error);

--- a/database/migrations/1737426000000-rename-legacy-boolean-columns.js
+++ b/database/migrations/1737426000000-rename-legacy-boolean-columns.js
@@ -1,4 +1,4 @@
-// Migration: Renames legacy snake_case boolean columns to camelCase equivalents while preserving constraints
+// Migration: Ensures camelCase boolean columns are authoritative and removes legacy snake_case boolean identifiers
 
 module.exports = {
    up: async function up(params = {}, legacySequelize) {
@@ -14,14 +14,9 @@ module.exports = {
             const keywordTableDefinition = await queryInterface.describeTable('keyword');
             const domainTableDefinition = await queryInterface.describeTable('domain');
 
-            const hasLegacyKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'map_pack_top3');
             const hasCamelKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'mapPackTop3');
 
-            if (hasLegacyKeywordFlag) {
-               await queryInterface.renameColumn('keyword', 'map_pack_top3', 'mapPackTop3', { transaction });
-            }
-
-            if (hasLegacyKeywordFlag || hasCamelKeywordFlag) {
+            if (hasCamelKeywordFlag) {
                await queryInterface.changeColumn(
                   'keyword',
                   'mapPackTop3',
@@ -34,14 +29,9 @@ module.exports = {
                );
             }
 
-            const hasLegacyDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrape_enabled');
             const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
 
-            if (hasLegacyDomainFlag) {
-               await queryInterface.renameColumn('domain', 'scrape_enabled', 'scrapeEnabled', { transaction });
-            }
-
-            if (hasLegacyDomainFlag || hasCamelDomainFlag) {
+            if (hasCamelDomainFlag) {
                await queryInterface.changeColumn(
                   'domain',
                   'scrapeEnabled',
@@ -52,6 +42,14 @@ module.exports = {
                   },
                   { transaction }
                );
+            }
+
+            if (Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'map_pack_top3')) {
+               await queryInterface.removeColumn('keyword', 'map_pack_top3', { transaction });
+            }
+
+            if (Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrape_enabled')) {
+               await queryInterface.removeColumn('domain', 'scrape_enabled', { transaction });
             }
          } catch (error) {
             console.log('Migration error:', error);
@@ -75,13 +73,12 @@ module.exports = {
 
             const hasCamelKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'mapPackTop3');
             if (hasCamelKeywordFlag) {
-               await queryInterface.renameColumn('keyword', 'mapPackTop3', 'map_pack_top3', { transaction });
                await queryInterface.changeColumn(
                   'keyword',
-                  'map_pack_top3',
+                  'mapPackTop3',
                   {
                      type: SequelizeLib.DataTypes.BOOLEAN,
-                     allowNull: false,
+                     allowNull: true,
                      defaultValue: false,
                   },
                   { transaction }
@@ -90,13 +87,12 @@ module.exports = {
 
             const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
             if (hasCamelDomainFlag) {
-               await queryInterface.renameColumn('domain', 'scrapeEnabled', 'scrape_enabled', { transaction });
                await queryInterface.changeColumn(
                   'domain',
-                  'scrape_enabled',
+                  'scrapeEnabled',
                   {
                      type: SequelizeLib.DataTypes.BOOLEAN,
-                     allowNull: false,
+                     allowNull: true,
                      defaultValue: true,
                   },
                   { transaction }

--- a/database/migrations/1737426000000-rename-legacy-boolean-columns.js
+++ b/database/migrations/1737426000000-rename-legacy-boolean-columns.js
@@ -15,8 +15,34 @@ module.exports = {
             const domainTableDefinition = await queryInterface.describeTable('domain');
 
             const hasCamelKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'mapPackTop3');
+            const hasSnakeKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'map_pack_top3');
 
-            if (hasCamelKeywordFlag) {
+            if (!hasCamelKeywordFlag && hasSnakeKeywordFlag) {
+               await queryInterface.renameColumn('keyword', 'map_pack_top3', 'mapPackTop3', { transaction });
+            } else if (hasCamelKeywordFlag && hasSnakeKeywordFlag) {
+               await queryInterface.sequelize.query(
+                  'UPDATE "keyword" SET "mapPackTop3" = COALESCE("map_pack_top3", "mapPackTop3")',
+                  { transaction }
+               );
+               await queryInterface.removeColumn('keyword', 'map_pack_top3', { transaction });
+            }
+
+            const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
+            const hasSnakeDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrape_enabled');
+
+            if (!hasCamelDomainFlag && hasSnakeDomainFlag) {
+               await queryInterface.renameColumn('domain', 'scrape_enabled', 'scrapeEnabled', { transaction });
+            } else if (hasCamelDomainFlag && hasSnakeDomainFlag) {
+               await queryInterface.sequelize.query(
+                  'UPDATE "domain" SET "scrapeEnabled" = COALESCE("scrape_enabled", "scrapeEnabled")',
+                  { transaction }
+               );
+               await queryInterface.removeColumn('domain', 'scrape_enabled', { transaction });
+            }
+
+            const keywordHasCamelAfterMigration =
+               hasCamelKeywordFlag || (!hasCamelKeywordFlag && hasSnakeKeywordFlag);
+            if (keywordHasCamelAfterMigration) {
                await queryInterface.changeColumn(
                   'keyword',
                   'mapPackTop3',
@@ -29,9 +55,9 @@ module.exports = {
                );
             }
 
-            const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
-
-            if (hasCamelDomainFlag) {
+            const domainHasCamelAfterMigration =
+               hasCamelDomainFlag || (!hasCamelDomainFlag && hasSnakeDomainFlag);
+            if (domainHasCamelAfterMigration) {
                await queryInterface.changeColumn(
                   'domain',
                   'scrapeEnabled',
@@ -42,14 +68,6 @@ module.exports = {
                   },
                   { transaction }
                );
-            }
-
-            if (Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'map_pack_top3')) {
-               await queryInterface.removeColumn('keyword', 'map_pack_top3', { transaction });
-            }
-
-            if (Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrape_enabled')) {
-               await queryInterface.removeColumn('domain', 'scrape_enabled', { transaction });
             }
          } catch (error) {
             console.log('Migration error:', error);
@@ -72,10 +90,37 @@ module.exports = {
             const domainTableDefinition = await queryInterface.describeTable('domain');
 
             const hasCamelKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'mapPackTop3');
-            if (hasCamelKeywordFlag) {
+            const hasSnakeKeywordFlag = Object.prototype.hasOwnProperty.call(keywordTableDefinition, 'map_pack_top3');
+
+            if (!hasSnakeKeywordFlag && hasCamelKeywordFlag) {
+               await queryInterface.renameColumn('keyword', 'mapPackTop3', 'map_pack_top3', { transaction });
+            } else if (hasSnakeKeywordFlag && hasCamelKeywordFlag) {
+               await queryInterface.sequelize.query(
+                  'UPDATE "keyword" SET "map_pack_top3" = COALESCE("mapPackTop3", "map_pack_top3")',
+                  { transaction }
+               );
+               await queryInterface.removeColumn('keyword', 'mapPackTop3', { transaction });
+            }
+
+            const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
+            const hasSnakeDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrape_enabled');
+
+            if (!hasSnakeDomainFlag && hasCamelDomainFlag) {
+               await queryInterface.renameColumn('domain', 'scrapeEnabled', 'scrape_enabled', { transaction });
+            } else if (hasSnakeDomainFlag && hasCamelDomainFlag) {
+               await queryInterface.sequelize.query(
+                  'UPDATE "domain" SET "scrape_enabled" = COALESCE("scrapeEnabled", "scrape_enabled")',
+                  { transaction }
+               );
+               await queryInterface.removeColumn('domain', 'scrapeEnabled', { transaction });
+            }
+
+            const keywordHasSnakeAfterRollback =
+               hasSnakeKeywordFlag || (!hasSnakeKeywordFlag && hasCamelKeywordFlag);
+            if (keywordHasSnakeAfterRollback) {
                await queryInterface.changeColumn(
                   'keyword',
-                  'mapPackTop3',
+                  'map_pack_top3',
                   {
                      type: SequelizeLib.DataTypes.BOOLEAN,
                      allowNull: true,
@@ -85,11 +130,12 @@ module.exports = {
                );
             }
 
-            const hasCamelDomainFlag = Object.prototype.hasOwnProperty.call(domainTableDefinition, 'scrapeEnabled');
-            if (hasCamelDomainFlag) {
+            const domainHasSnakeAfterRollback =
+               hasSnakeDomainFlag || (!hasSnakeDomainFlag && hasCamelDomainFlag);
+            if (domainHasSnakeAfterRollback) {
                await queryInterface.changeColumn(
                   'domain',
-                  'scrapeEnabled',
+                  'scrape_enabled',
                   {
                      type: SequelizeLib.DataTypes.BOOLEAN,
                      allowNull: true,


### PR DESCRIPTION
## Summary
- rename the map pack bootstrap migration to create and manage the mapPackTop3 column
- update the cleanup migration to enforce camelCase booleans and drop the legacy snake_case fields
- refresh README and changelog guidance and migrate tests to the new column name

## Testing
- npm run lint
- npm run lint:css
- npm test -- __tests__/database/map-pack-migration.test.ts
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d954f8e220832aae84f510277fabfb