### PR TITLE
feat: email selected keyword ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. Releases no
 ### Features
 - Daily notification email now surfaces a tracker mini-summary ahead of the Search Console tables, styled to match the dashboard tracker card and only showing the Map Pack column when the active scraper supports it.
 - White-label deployments can override the platform name and supply a `/app/data` logo that propagates through the UI, emails, and Docker environment defaults.
+- Keyword ideas banner now offers an email action on both research and domain idea tabs, formatting selected ideas into a rich HTML table and bypassing notification throttling while still enforcing domain-specific recipients.
 
 ### Documentation
 - Documented the fork's stability, security, and performance improvements at the top of the README for quick comparison with upstream SerpBear.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 - Already-tracked keyword ideas now render as disabled for the active device so research flows stay deduplicated when you revisit Google Ads suggestions.
 - When Google Ads cannot supply any ideas that match your filters, the API now responds with a 404 and the UI shows a warning toast instead of a success banner so you can adjust the request immediately.
 - Successful keyword idea imports no longer crash with a reference error and the research table now refreshes instantly because the React Query cache invalidation matches the underlying query key again.
+- Email selected keyword ideas straight from the research table or a domain-specific ideas tab. The research view prompts you to choose a destination domain before sending, while domain idea pages automatically use their notification contacts. The outbound message includes a formatted table with monthly searches, trend history, and competition without touching the scheduled notification throttle.
 
 ### Loading states & accessibility
 

--- a/__tests__/api/ideas.email.test.ts
+++ b/__tests__/api/ideas.email.test.ts
@@ -1,0 +1,193 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nodeMailer from 'nodemailer';
+import handler from '../../pages/api/ideas/email';
+import db from '../../database/database';
+import Domain from '../../database/models/domain';
+import verifyUser from '../../utils/verifyUser';
+import { getAppSettings } from '../../pages/api/settings';
+import generateKeywordIdeasEmail from '../../utils/generateKeywordIdeasEmail';
+import { getBranding } from '../../utils/branding';
+
+const { platformName } = getBranding();
+
+type MockedResponse = Partial<NextApiResponse> & {
+   status: jest.Mock;
+   json: jest.Mock;
+};
+
+type DomainRecord = {
+   get: () => DomainType;
+};
+
+jest.mock('../../database/database', () => ({
+   __esModule: true,
+   default: { sync: jest.fn() },
+}));
+
+jest.mock('../../database/models/domain', () => ({
+   __esModule: true,
+   default: { findOne: jest.fn() },
+}));
+
+jest.mock('../../utils/verifyUser');
+
+jest.mock('../../pages/api/settings', () => ({
+   __esModule: true,
+   getAppSettings: jest.fn(),
+}));
+
+jest.mock('../../utils/generateKeywordIdeasEmail');
+
+jest.mock('nodemailer', () => ({
+   __esModule: true,
+   default: { createTransport: jest.fn() },
+}));
+
+describe('/api/ideas/email', () => {
+   let req: Partial<NextApiRequest>;
+   let res: MockedResponse;
+   let sendMailMock: jest.Mock;
+   let domainRecord: DomainRecord;
+
+   const keywordPayload = {
+      keyword: 'new term',
+      avgMonthlySearches: 50,
+      monthlySearchVolumes: { '2024-01': '50' },
+      competition: 'LOW',
+      competitionIndex: 0.21,
+   };
+
+   beforeEach(() => {
+      req = {
+         method: 'POST',
+         body: { domain: 'example.com', keywords: [keywordPayload] },
+         headers: {},
+      } as Partial<NextApiRequest>;
+
+      res = {
+         status: jest.fn().mockReturnThis(),
+         json: jest.fn(),
+      } as MockedResponse;
+
+      domainRecord = {
+         get: () => ({
+            ID: 1,
+            domain: 'example.com',
+            slug: 'example-com',
+            notification: true,
+            notification_interval: 'daily',
+            notification_emails: 'alerts@example.com',
+            lastUpdated: '2024-01-01T00:00:00.000Z',
+            added: '2024-01-01T00:00:00.000Z',
+         } as DomainType),
+      };
+
+      sendMailMock = jest.fn().mockResolvedValue(undefined);
+      (nodeMailer.createTransport as jest.Mock).mockReturnValue({ sendMail: sendMailMock });
+      (db.sync as jest.Mock).mockResolvedValue(undefined);
+      (verifyUser as jest.Mock).mockReturnValue('authorized');
+      (getAppSettings as jest.Mock).mockResolvedValue({
+         smtp_server: 'smtp.example.com',
+         smtp_port: '587',
+         smtp_username: 'user',
+         smtp_password: 'pass',
+         notification_email: 'default@example.com',
+         notification_email_from: 'sender@example.com',
+         notification_email_from_name: platformName,
+         smtp_tls_servername: 'smtp.example.com',
+      });
+      (generateKeywordIdeasEmail as jest.Mock).mockReturnValue('<html></html>');
+      (Domain.findOne as jest.Mock).mockResolvedValue(domainRecord);
+   });
+
+   afterEach(() => {
+      jest.clearAllMocks();
+   });
+
+   it('returns 401 when verification fails', async () => {
+      (verifyUser as jest.Mock).mockReturnValue('Unauthorized');
+
+      await handler(req as NextApiRequest, res as NextApiResponse);
+
+      expect(verifyUser).toHaveBeenCalledWith(req, res);
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Unauthorized' });
+      expect(sendMailMock).not.toHaveBeenCalled();
+   });
+
+   it('rejects requests without a domain', async () => {
+      req.body = { keywords: [keywordPayload] };
+
+      await handler(req as NextApiRequest, res as NextApiResponse);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'A domain is required to email keyword ideas.' });
+      expect(sendMailMock).not.toHaveBeenCalled();
+   });
+
+   it('rejects requests without SMTP configuration', async () => {
+      (getAppSettings as jest.Mock).mockResolvedValueOnce({
+         smtp_server: '',
+         smtp_port: '',
+         notification_email: '',
+         notification_email_from: '',
+         notification_email_from_name: '',
+         smtp_tls_servername: '',
+      });
+
+      await handler(req as NextApiRequest, res as NextApiResponse);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'SMTP has not been setup properly!' });
+      expect(sendMailMock).not.toHaveBeenCalled();
+   });
+
+   it('rejects domains without notification emails', async () => {
+      domainRecord = {
+         get: () => ({
+            ID: 1,
+            domain: 'example.com',
+            slug: 'example-com',
+            notification: true,
+            notification_interval: 'daily',
+            notification_emails: '',
+            lastUpdated: '2024-01-01T00:00:00.000Z',
+            added: '2024-01-01T00:00:00.000Z',
+         } as DomainType),
+      };
+      (Domain.findOne as jest.Mock).mockResolvedValue(domainRecord);
+
+      await handler(req as NextApiRequest, res as NextApiResponse);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ success: false, error: 'Notification email not configured for this domain.' });
+      expect(sendMailMock).not.toHaveBeenCalled();
+   });
+
+   it('sends keyword idea emails when authorized', async () => {
+      await handler(req as NextApiRequest, res as NextApiResponse);
+
+      expect(Domain.findOne).toHaveBeenCalledWith({ where: { domain: 'example.com' } });
+      expect(generateKeywordIdeasEmail).toHaveBeenCalledWith({
+         domain: 'example.com',
+         keywords: [
+            {
+               keyword: 'new term',
+               avgMonthlySearches: 50,
+               monthlySearchVolumes: { '2024-01': 50 },
+               competition: 'LOW',
+               competitionIndex: 0.21,
+            },
+         ],
+         platformName,
+      });
+      expect(sendMailMock).toHaveBeenCalledWith({
+         from: `${platformName} <sender@example.com>`,
+         to: 'alerts@example.com',
+         subject: '[example.com] Keyword Ideas',
+         html: '<html></html>',
+      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ success: true, error: null });
+   });
+});

--- a/pages/api/ideas/email.ts
+++ b/pages/api/ideas/email.ts
@@ -1,0 +1,178 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nodeMailer from 'nodemailer';
+import db from '../../../database/database';
+import Domain from '../../../database/models/domain';
+import verifyUser from '../../../utils/verifyUser';
+import { getAppSettings } from '../settings';
+import { trimStringProperties } from '../../../utils/security';
+import generateKeywordIdeasEmail, { KeywordIdeasEmailKeyword } from '../../../utils/generateKeywordIdeasEmail';
+import { getBranding } from '../../../utils/branding';
+
+const { platformName } = getBranding();
+
+type EmailKeywordIdeasRequest = {
+   domain?: string;
+   keywords?: KeywordIdeasEmailKeyword[];
+};
+
+type EmailKeywordIdeasResponse = {
+   success?: boolean;
+   error?: string | null;
+};
+
+const trimString = (value?: string | null): string => (typeof value === 'string' ? value.trim() : '');
+
+const sanitizeHostname = (host?: string | null): string => {
+   const trimmed = trimString(host);
+   return trimmed.replace(/\.+$/, '');
+};
+
+const normalizeKeywords = (keywords: KeywordIdeasEmailKeyword[] = []): KeywordIdeasEmailKeyword[] => keywords.map((keyword) => {
+   const monthlyVolumes: Record<string, number> = {};
+   const sourceVolumes = keyword.monthlySearchVolumes || {};
+   Object.entries(sourceVolumes).forEach(([period, value]) => {
+      const numeric = typeof value === 'string' ? Number(value) : value;
+      if (typeof numeric === 'number' && Number.isFinite(numeric)) {
+         monthlyVolumes[period] = numeric;
+      }
+   });
+   const parsedCompetitionIndex = typeof keyword.competitionIndex === 'number'
+      ? keyword.competitionIndex
+      : (keyword.competitionIndex !== undefined && keyword.competitionIndex !== null && keyword.competitionIndex !== ''
+         ? Number(keyword.competitionIndex)
+         : undefined);
+   const normalizedCompetitionIndex = typeof parsedCompetitionIndex === 'number' && Number.isFinite(parsedCompetitionIndex)
+      ? parsedCompetitionIndex
+      : undefined;
+   return {
+      keyword: trimString(keyword.keyword),
+      avgMonthlySearches: typeof keyword.avgMonthlySearches === 'number'
+         ? keyword.avgMonthlySearches
+         : Number(keyword.avgMonthlySearches) || 0,
+      monthlySearchVolumes: monthlyVolumes,
+      competition: trimString(keyword.competition) || undefined,
+      competitionIndex: normalizedCompetitionIndex,
+   };
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<EmailKeywordIdeasResponse>) {
+   await db.sync();
+   const authorized = verifyUser(req, res);
+   if (authorized !== 'authorized') {
+      return res.status(401).json({ success: false, error: authorized });
+   }
+
+   if (req.method !== 'POST') {
+      return res.status(405).json({ success: false, error: 'Invalid Method' });
+   }
+
+   return emailKeywordIdeas(req, res);
+}
+
+const emailKeywordIdeas = async (req: NextApiRequest, res: NextApiResponse<EmailKeywordIdeasResponse>) => {
+   const body = (req.body || {}) as EmailKeywordIdeasRequest;
+   const targetDomain = trimString(body.domain);
+   if (!targetDomain) {
+      return res.status(400).json({ success: false, error: 'A domain is required to email keyword ideas.' });
+   }
+
+   if (!Array.isArray(body.keywords) || body.keywords.length === 0) {
+      return res.status(400).json({ success: false, error: 'Select at least one keyword idea to email.' });
+   }
+
+   try {
+      const settings = await getAppSettings();
+      const normalizedSettings: SettingsType = trimStringProperties({ ...settings });
+      const sanitizedHost = sanitizeHostname(normalizedSettings.smtp_server);
+      const sanitizedPort = normalizedSettings.smtp_port;
+      const sanitizedDefaultEmail = normalizedSettings.notification_email;
+
+      normalizedSettings.smtp_server = sanitizedHost;
+      normalizedSettings.smtp_port = sanitizedPort;
+      normalizedSettings.notification_email = sanitizedDefaultEmail;
+      normalizedSettings.smtp_tls_servername = sanitizeHostname(normalizedSettings.smtp_tls_servername);
+
+      if (!sanitizedHost || !sanitizedPort || !sanitizedDefaultEmail) {
+         return res.status(400).json({ success: false, error: 'SMTP has not been setup properly!' });
+      }
+
+      const domainRecord = await Domain.findOne({ where: { domain: targetDomain } })
+         || await Domain.findOne({ where: { slug: targetDomain } });
+
+      if (!domainRecord) {
+         return res.status(404).json({ success: false, error: 'Domain not found.' });
+      }
+
+      const domainPlain = (domainRecord as any).get
+         ? (domainRecord as any).get({ plain: true }) as DomainType
+         : domainRecord as DomainType;
+
+      const notificationEmails = trimString(domainPlain.notification_emails);
+      if (!notificationEmails) {
+         return res.status(400).json({ success: false, error: 'Notification email not configured for this domain.' });
+      }
+
+      const {
+         smtp_server = '',
+         smtp_port = '',
+         smtp_username = '',
+         smtp_password = '',
+         notification_email_from = '',
+         notification_email_from_name = platformName,
+         smtp_tls_servername = '',
+      } = normalizedSettings;
+
+      if (!smtp_server) {
+         return res.status(400).json({ success: false, error: 'SMTP has not been setup properly!' });
+      }
+
+      const mailerSettings: any = {
+         host: smtp_server,
+         port: (() => {
+            const portNum = parseInt(smtp_port, 10);
+            if (Number.isFinite(portNum)) {
+               return Math.max(1, Math.min(65535, portNum));
+            }
+            return 587;
+         })(),
+      };
+
+      const tlsServername = sanitizeHostname(smtp_tls_servername);
+      if (tlsServername) {
+         mailerSettings.tls = { servername: tlsServername };
+      }
+
+      const sanitizedUser = trimString(smtp_username);
+      const sanitizedPass = trimString(smtp_password);
+      if (sanitizedUser || sanitizedPass) {
+         mailerSettings.auth = {};
+         if (sanitizedUser) mailerSettings.auth.user = sanitizedUser;
+         if (sanitizedPass) mailerSettings.auth.pass = sanitizedPass;
+      }
+
+      const transporter = nodeMailer.createTransport(mailerSettings);
+      const normalizedKeywords = normalizeKeywords(body.keywords);
+      const emailHTML = generateKeywordIdeasEmail({
+         domain: domainPlain.domain,
+         keywords: normalizedKeywords,
+         platformName,
+      });
+
+      const fromAddress = trimString(notification_email_from) || 'no-reply@serpbear.com';
+      const fromName = trimString(notification_email_from_name) || platformName;
+      const fromEmail = `${fromName} <${fromAddress}>`;
+
+      await transporter.sendMail({
+         from: fromEmail,
+         to: notificationEmails,
+         subject: `[${domainPlain.domain}] Keyword Ideas`,
+         html: emailHTML,
+      });
+
+      return res.status(200).json({ success: true, error: null });
+   } catch (error) {
+      console.log('[ERROR] Sending keyword ideas email', error);
+      const message = error instanceof Error && error.message ? error.message : 'Error sending keyword ideas email.';
+      return res.status(500).json({ success: false, error: message });
+   }
+};

--- a/pages/api/ideas/email.ts
+++ b/pages/api/ideas/email.ts
@@ -48,7 +48,7 @@ const normalizeKeywords = (keywords: KeywordIdeasEmailKeyword[] = []): KeywordId
       keyword: trimString(keyword.keyword),
       avgMonthlySearches: typeof keyword.avgMonthlySearches === 'number'
          ? keyword.avgMonthlySearches
-         : Number(keyword.avgMonthlySearches) || 0,
+         : (Number.isFinite(Number(keyword.avgMonthlySearches)) ? Number(keyword.avgMonthlySearches) : undefined),
       monthlySearchVolumes: monthlyVolumes,
       competition: trimString(keyword.competition) || undefined,
       competitionIndex: normalizedCompetitionIndex,

--- a/services/ideas.ts
+++ b/services/ideas.ts
@@ -1,0 +1,69 @@
+import toast from 'react-hot-toast';
+import { useMutation } from 'react-query';
+
+type EmailIdeaKeywordPayload = {
+   keyword: string;
+   avgMonthlySearches?: number;
+   monthlySearchVolumes?: Record<string, string | number> | null;
+   competition?: string | null;
+   competitionIndex?: number | string | null;
+};
+
+type EmailKeywordIdeasPayload = {
+   domain: string;
+   keywords: EmailIdeaKeywordPayload[];
+};
+
+type EmailKeywordIdeasResponse = {
+   success?: boolean;
+   error?: string | null;
+};
+
+const parseErrorMessage = async (res: Response): Promise<string> => {
+   try {
+      const contentType = res.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+         const data = await res.json() as EmailKeywordIdeasResponse;
+         if (data?.error) {
+            return data.error;
+         }
+      } else {
+         const text = await res.text();
+         if (text) {
+            return text.slice(0, 200);
+         }
+      }
+   } catch (error) {
+      console.warn('Failed parsing email ideas error response', error);
+   }
+   return `Server error (${res.status}): Please try again later.`;
+};
+
+export function useEmailKeywordIdeas(onSuccess?: () => void) {
+   return useMutation(async (payload: EmailKeywordIdeasPayload) => {
+      const headers = new Headers({ 'Content-Type': 'application/json', Accept: 'application/json' });
+      const response = await fetch(`${window.location.origin}/api/ideas/email`, {
+         method: 'POST',
+         headers,
+         body: JSON.stringify(payload),
+      });
+      if (response.status >= 400) {
+         const errorMessage = await parseErrorMessage(response);
+         throw new Error(errorMessage);
+      }
+      return response.json() as Promise<EmailKeywordIdeasResponse>;
+   }, {
+      onSuccess: () => {
+         toast('Keyword ideas emailed successfully!', { icon: '✔️' });
+         if (onSuccess) {
+            onSuccess();
+         }
+      },
+      onError: (error: unknown) => {
+         const message = error instanceof Error ? error.message : 'Error emailing keyword ideas.';
+         toast(message || 'Error emailing keyword ideas.', { icon: '⚠️' });
+      },
+   });
+}
+
+export type { EmailKeywordIdeasPayload, EmailIdeaKeywordPayload };

--- a/utils/generateKeywordIdeasEmail.ts
+++ b/utils/generateKeywordIdeasEmail.ts
@@ -1,0 +1,152 @@
+import dayjs from 'dayjs';
+
+export type KeywordIdeasEmailKeyword = {
+   keyword: string;
+   avgMonthlySearches?: number;
+   monthlySearchVolumes?: Record<string, number>;
+   competition?: string;
+   competitionIndex?: number;
+};
+
+type GenerateKeywordIdeasEmailParams = {
+   domain: string;
+   keywords: KeywordIdeasEmailKeyword[];
+   platformName?: string;
+};
+
+const escapeHtml = (value: string): string => value
+   .replace(/&/g, '&amp;')
+   .replace(/</g, '&lt;')
+   .replace(/>/g, '&gt;')
+   .replace(/"/g, '&quot;')
+   .replace(/'/g, '&#39;');
+
+const formatNumber = (value?: number): string => {
+   if (typeof value === 'number' && Number.isFinite(value)) {
+      return value.toLocaleString('en-US');
+   }
+   return '—';
+};
+
+const parsePeriodOrder = (period: string): number => {
+   const strictMonth = dayjs(period, 'YYYY-MM', true);
+   if (strictMonth.isValid()) {
+      return strictMonth.valueOf();
+   }
+   const looseDate = dayjs(period);
+   if (looseDate.isValid()) {
+      return looseDate.valueOf();
+   }
+   return Number.MAX_SAFE_INTEGER;
+};
+
+const formatPeriodLabel = (period: string): string => {
+   const strictMonth = dayjs(period, 'YYYY-MM', true);
+   if (strictMonth.isValid()) {
+      return strictMonth.format('MMM YYYY');
+   }
+   const looseDate = dayjs(period);
+   if (looseDate.isValid()) {
+      return looseDate.format('MMM YYYY');
+   }
+   return period;
+};
+
+const buildTrendList = (monthlyVolumes: Record<string, number> = {}): string => {
+   const entries = Object.entries(monthlyVolumes);
+   if (entries.length === 0) {
+      return '<em style="color:#6b7280;">No data</em>';
+   }
+   const sortedEntries = entries.sort((a, b) => parsePeriodOrder(a[0]) - parsePeriodOrder(b[0]));
+   const listItems = sortedEntries.map(([period, value]) => {
+      const label = escapeHtml(formatPeriodLabel(period));
+      const formattedValue = formatNumber(value);
+      return `<li style="margin:0; padding:0;">${label}: <strong>${formattedValue}</strong></li>`;
+   }).join('');
+   return `<ul style="margin:0; padding-left:16px; color:#111827;">${listItems}</ul>`;
+};
+
+const formatCompetition = (competition?: string, index?: number): string => {
+   const pieces: string[] = [];
+   if (competition) {
+      pieces.push(escapeHtml(competition));
+   }
+   if (typeof index === 'number' && Number.isFinite(index)) {
+      const formattedIndex = index.toFixed(2).replace(/\.00$/, '');
+      pieces.push(`Index ${formattedIndex}`);
+   }
+   if (pieces.length === 0) {
+      return '—';
+   }
+   return pieces.join(' · ');
+};
+
+const buildRows = (keywords: KeywordIdeasEmailKeyword[]): string => {
+   if (!keywords.length) {
+      return `<tr>
+         <td colspan="4" style="padding:16px; border-top:1px solid #e5e7eb; text-align:center; color:#6b7280;">
+            No keyword ideas were selected.
+         </td>
+      </tr>`;
+   }
+
+   return keywords.map((keyword) => {
+      const keywordLabel = keyword.keyword ? escapeHtml(keyword.keyword) : '—';
+      const averageSearches = formatNumber(keyword.avgMonthlySearches);
+      const trendHtml = buildTrendList(keyword.monthlySearchVolumes);
+      const competition = formatCompetition(keyword.competition, keyword.competitionIndex);
+
+      return `<tr>
+         <td style="padding:12px 16px; border-top:1px solid #e5e7eb; vertical-align:top;">${keywordLabel}</td>
+         <td style="padding:12px 16px; border-top:1px solid #e5e7eb; vertical-align:top; text-align:right;">${averageSearches}</td>
+         <td style="padding:12px 16px; border-top:1px solid #e5e7eb; vertical-align:top;">${trendHtml}</td>
+         <td style="padding:12px 16px; border-top:1px solid #e5e7eb; vertical-align:top;">${competition}</td>
+      </tr>`;
+   }).join('');
+};
+
+const generateKeywordIdeasEmail = ({ domain, keywords, platformName }: GenerateKeywordIdeasEmailParams): string => {
+   const safeDomain = escapeHtml(domain);
+   const headerTitle = platformName ? `${escapeHtml(platformName)} Keyword Ideas` : 'Keyword Ideas';
+   const keywordCount = keywords.length;
+   const subtitle = keywordCount === 1
+      ? 'You selected 1 keyword idea. Review the details below.'
+      : `You selected ${keywordCount} keyword ideas. Review the details below.`;
+
+   const tableRows = buildRows(keywords);
+
+   return `<!DOCTYPE html>
+<html lang="en">
+<head>
+   <meta charSet="utf-8" />
+   <title>${headerTitle}</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f3f4f6; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color:#111827;">
+   <div style="max-width:720px; margin:0 auto; padding:24px;">
+      <div style="background-color:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 10px 30px rgba(15,23,42,0.08);">
+         <div style="background-color:#1f2937; color:#f9fafb; padding:24px;">
+            <h1 style="margin:0; font-size:22px;">${headerTitle} for ${safeDomain}</h1>
+            <p style="margin:8px 0 0; font-size:16px; color:#e5e7eb;">${escapeHtml(subtitle)}</p>
+         </div>
+         <div style="padding:24px;">
+            <table style="width:100%; border-collapse:collapse;">
+               <thead>
+                  <tr style="background-color:#f9fafb; text-align:left;">
+                     <th style="padding:12px 16px; font-size:14px; text-transform:uppercase; letter-spacing:0.08em; color:#6b7280;">Keyword</th>
+                     <th style="padding:12px 16px; font-size:14px; text-transform:uppercase; letter-spacing:0.08em; color:#6b7280; text-align:right;">Monthly Search</th>
+                     <th style="padding:12px 16px; font-size:14px; text-transform:uppercase; letter-spacing:0.08em; color:#6b7280;">Search Trend</th>
+                     <th style="padding:12px 16px; font-size:14px; text-transform:uppercase; letter-spacing:0.08em; color:#6b7280;">Competition</th>
+                  </tr>
+               </thead>
+               <tbody>
+                  ${tableRows}
+               </tbody>
+            </table>
+         </div>
+      </div>
+   </div>
+</body>
+</html>`;
+};
+
+export default generateKeywordIdeasEmail;

--- a/utils/generateKeywordIdeasEmail.ts
+++ b/utils/generateKeywordIdeasEmail.ts
@@ -118,7 +118,7 @@ const generateKeywordIdeasEmail = ({ domain, keywords, platformName }: GenerateK
    return `<!DOCTYPE html>
 <html lang="en">
 <head>
-   <meta charSet="utf-8" />
+   <meta charset="utf-8" />
    <title>${headerTitle}</title>
 </head>
 <body style="margin:0; padding:0; background-color:#f3f4f6; font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color:#111827;">


### PR DESCRIPTION
## Summary
- add an Email Keywords action to the keyword ideas selection banner for both the research and domain idea views, including toast messaging for missing domain picks
- introduce a client mutation hook and `/api/ideas/email` endpoint that bypass throttling and deliver formatted idea tables to domain notification contacts
- generate the HTML email markup for keyword ideas and extend component/API tests alongside updated documentation about the workflow

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d948356fa4832a9d11d9baa8d4f383