### PR TITLE
docs: clarify Node.js 20.18.1 requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Releases no
 
 ### Documentation
 - Documented the fork's stability, security, and performance improvements at the top of the README for quick comparison with upstream SerpBear.
+- Clarified that local development must use Node.js 20.18.1+ to align with the `.nvmrc` pin and dependency requirements.
 
 ### Bug Fixes
 - Clarified regression coverage to assert the camelCase `mapPackTop3` keyword property rather than the legacy snake_case flag.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,14 @@ The default compose stack maps `./data` to the container so your SQLite database
 
 ### Option 2 – Node.js runtime
 
-1. Install Node.js **18.18+** (the project ships an `.nvmrc` pinning `20.18.0`).
+1. Install Node.js **20.18.1 or newer**, matching the version pinned in [`.nvmrc`](./.nvmrc).
 2. Install dependencies with `npm install` (or `npm ci`).
 3. Copy `.env.example` to `.env.local` and fill in the required keys.
 4. **Apply database migrations:** `npm run db:migrate` to set up the SQLite database schema.
 5. Start the development server via `npm run dev` or build and serve production assets with `npm run build && npm run start`.
+
+> [!NOTE]
+> Node.js 18 is no longer supported because core dependencies—such as `better-sqlite3`, `happy-dom`, and `cheerio`—now require Node.js 20+ runtime features.
 
 ### Database & migrations
 


### PR DESCRIPTION
## Summary
- document that local development must use Node.js 20.18.1 or newer to match the `.nvmrc` pin and dependency requirements
- note that Node 18 is no longer supported because packages such as better-sqlite3, happy-dom, and cheerio require Node 20
- record the clarified Node version guidance in the Unreleased changelog

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d969c3f6f4832aa0de347ef10d6d6f