### PR TITLE
Fix Search Console email table alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. Releases no
 - Adopted `@stylistic/stylelint-plugin` and upgraded Stylelint tooling to v16 so indentation rules continue working under the plugin namespace.
 
 ### Bug Fixes
+- Search Console digest tables now scope tracker-specific keyword column styles and apply dedicated widths so the label column stays left-aligned while Clicks, Views, and Position stack neatly.
 - Clarified regression coverage to assert the camelCase `mapPackTop3` keyword property rather than the legacy snake_case flag.
 - Ensured keyword refresh cleanup always persists `updating` resets even when Sequelize instances still hold stale values after bulk updates, so failed scrapes no longer leave rows stuck in a loading state.
 - Cleared ESLint warnings by wiring width/min-width props into UI components, surfacing settings errors inline, sanitising SMTP TLS hostnames, and logging caught exceptions throughout Ads/Search Console utilities and API handlers.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 ### Notifications & reporting
 
 - Email digests summarise rank gains/losses, highlight top movers, and include Search Console traffic data when available.
+- Search Console email tables now reserve a wider, left-aligned label column with right-aligned Clicks, Views, and Position totals so metrics remain vertically aligned across rows.
 - Notification cadence is fully configurable through `CRON_EMAIL_SCHEDULE`. Disable SMTP variables to skip sending emails entirely.
 - Trigger a manual run from the **Send Notifications Now** button in the Notification settings modal. Inline guidance and assistive-technology announcements walk through the prerequisites so teams can confirm SMTP credentials and email recipients immediately.
 - `/api/notify` now reserves HTTP 401 strictly for authentication issues—misconfigured SMTP hosts return 400 and runtime delivery errors surface as 500 responses with descriptive messages for easier debugging.

--- a/__tests__/email/email-template.test.ts
+++ b/__tests__/email/email-template.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+describe('email template Search Console styles', () => {
+  const templatePath = path.join(__dirname, '..', '..', 'email', 'email.html');
+  const template = readFileSync(templatePath, 'utf-8');
+
+  it('scopes tracker keyword column styles away from Search Console tables', () => {
+    expect(template).toContain('.keyword_table:not(.keyword_table--sc) .keyword td:nth-child(1){');
+    expect(template).toContain('.keyword_table:not(.keyword_table--sc) .keyword td:nth-child(2){');
+    expect(template).toContain('.keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4){');
+  });
+
+  it('widens and left-aligns the Search Console label column', () => {
+    const firstColumnBlock = template.match(/\.keyword_table--sc th:first-child,[\s\S]*?\.keyword_table--sc td:first-child\{[\s\S]*?\}/);
+
+    expect(firstColumnBlock).toBeTruthy();
+    expect(firstColumnBlock?.[0]).toContain('text-align: left;');
+    expect(firstColumnBlock?.[0]).toContain('width: 220px;');
+    expect(firstColumnBlock?.[0]).toContain('padding-right: 16px;');
+  });
+
+  it('right-aligns Search Console metric columns for consistent number stacking', () => {
+    const metricColumnsBlock = template.match(/\.keyword_table--sc th:nth-child\(2\),[\s\S]*?\.keyword_table--sc td:nth-child\(4\)\{[\s\S]*?\}/);
+
+    expect(metricColumnsBlock).toBeTruthy();
+    expect(metricColumnsBlock?.[0]).toContain('text-align: right;');
+    expect(metricColumnsBlock?.[0]).toContain('width: 90px;');
+  });
+});

--- a/email/email.html
+++ b/email/email.html
@@ -335,20 +335,38 @@
          color: #888;
          padding-bottom: 10px;
       }
-      .keyword td:nth-child(1){
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(1){
          text-align: center;
          width: 40px;
          padding-right: 5px;
       }
-      .keyword td:nth-child(2){
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(2){
          font-weight: bold;
       }
-      .keyword_table th:nth-child(3), .keyword_table th:nth-child(4), .keyword td:nth-child(3), .keyword td:nth-child(4), .keyword_table--sc th:nth-child(5), .keyword_table--sc td:nth-child(5){
+      .keyword_table:not(.keyword_table--sc) th:nth-child(3),
+      .keyword_table:not(.keyword_table--sc) th:nth-child(4),
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(3),
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4){
          text-align: center;
       }
-      .keyword td:nth-child(4){
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4){
          font-size: 12px;
          color: #888;
+      }
+      .keyword_table--sc th:first-child,
+      .keyword_table--sc td:first-child{
+         text-align: left;
+         width: 220px;
+         padding-right: 16px;
+      }
+      .keyword_table--sc th:nth-child(2),
+      .keyword_table--sc th:nth-child(3),
+      .keyword_table--sc th:nth-child(4),
+      .keyword_table--sc td:nth-child(2),
+      .keyword_table--sc td:nth-child(3),
+      .keyword_table--sc td:nth-child(4){
+         text-align: right;
+         width: 90px;
       }
       .keyword_table--sc td:nth-child(4){
          color:inherit;


### PR DESCRIPTION
## Summary
- scope tracker keyword column styles away from Search Console tables and add dedicated alignment for the Search Console metrics
- document the Search Console email alignment update in the README and changelog
- add a regression test that asserts the Search Console email styles stay in place

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9af0a2bf8832aa43e7e71017fd397