### PR TITLE
Expand email template width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. Releases no
 - Adopted `@stylistic/stylelint-plugin` and upgraded Stylelint tooling to v16 so indentation rules continue working under the plugin namespace.
 
 ### Bug Fixes
+- Expanded the notification email template container so digest tables render wider in supporting clients.
 - Clarified regression coverage to assert the camelCase `mapPackTop3` keyword property rather than the legacy snake_case flag.
 - Ensured keyword refresh cleanup always persists `updating` resets even when Sequelize instances still hold stale values after bulk updates, so failed scrapes no longer leave rows stuck in a loading state.
 - Cleared ESLint warnings by wiring width/min-width props into UI components, surfacing settings errors inline, sanitising SMTP TLS hostnames, and logging caught exceptions throughout Ads/Search Console utilities and API handlers.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 ### Notifications & reporting
 
 - Email digests summarise rank gains/losses, highlight top movers, and include Search Console traffic data when available.
+- Digest layout now uses a wider container so keyword, trend, and competition tables have more breathing room in HTML clients.
 - Notification cadence is fully configurable through `CRON_EMAIL_SCHEDULE`. Disable SMTP variables to skip sending emails entirely.
 - Trigger a manual run from the **Send Notifications Now** button in the Notification settings modal. Inline guidance and assistive-technology announcements walk through the prerequisites so teams can confirm SMTP credentials and email recipients immediately.
 - `/api/notify` now reserves HTTP 401 strictly for authentication issues—misconfigured SMTP hosts return 400 and runtime delivery errors surface as 500 responses with descriptive messages for easier debugging.

--- a/__tests__/email/templateWidth.test.ts
+++ b/__tests__/email/templateWidth.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+const loadTemplate = (): string => {
+  const templatePath = path.join(process.cwd(), 'email', 'email.html');
+  return readFileSync(templatePath, 'utf8');
+};
+
+const extractBlock = (template: string, selector: string): string | undefined => {
+  const regex = new RegExp(String.raw`${selector}\s*\{[\s\S]*?\n\s*\}`, 'm');
+  const match = template.match(regex);
+  return match?.[0];
+};
+
+describe('notification email template layout', () => {
+  const template = loadTemplate();
+
+  it('expands the container width for digest tables', () => {
+    const containerBlock = extractBlock(template, '\\.' + 'container');
+
+    expect(containerBlock).toBeTruthy();
+    expect(containerBlock?.trim()).toBe(`.container {
+        display: block;
+        margin: 0 auto !important;
+        /* makes it centered */
+        max-width: 720px;
+        padding: 10px;
+        width: 100%;
+      }`);
+  });
+
+  it('mirrors the wider layout on the content wrapper', () => {
+    const contentBlock = extractBlock(template, '\\.' + 'content');
+
+    expect(contentBlock).toBeTruthy();
+    expect(contentBlock?.trim()).toBe(`.content {
+        box-sizing: border-box;
+        display: block;
+        margin: 0 auto;
+        max-width: 720px;
+        padding: 10px;
+        width: 100%;
+      }`);
+  });
+});

--- a/email/email.html
+++ b/email/email.html
@@ -52,9 +52,9 @@
         display: block;
         margin: 0 auto !important;
         /* makes it centered */
-        max-width: 580px;
+        max-width: 720px;
         padding: 10px;
-        width: 580px; 
+        width: 100%;
       }
 
       /* This should also be a block element, so that it will fill 100% of the .container */
@@ -62,8 +62,9 @@
         box-sizing: border-box;
         display: block;
         margin: 0 auto;
-        max-width: 580px;
-        padding: 10px; 
+        max-width: 720px;
+        padding: 10px;
+        width: 100%;
       }
 
       /* -------------------------------------


### PR DESCRIPTION
## Summary
- widen the notification email container/content styles to use a 720px max width and full-width layout
- add regression coverage that extracts the template CSS to assert the wider container rules
- document the wider digest layout in the changelog and README

## Testing
- npm run lint
- npm run lint:css
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9b9ef6bd4832ab613039425a7f8f1