### PR TITLE
Handle multi-keyword refresh response and adjust insight sorting

### DIFF
--- a/__tests__/utils/insight.test.ts
+++ b/__tests__/utils/insight.test.ts
@@ -1,4 +1,4 @@
-import { getCountryInsight, getKeywordsInsight, getPagesInsight } from '../../utils/insight';
+import { getCountryInsight, getKeywordsInsight, getPagesInsight, sortInsightItems } from '../../utils/insight';
 
 describe('Insight Functions', () => {
   const mockSCData: SCDomainDataType = {
@@ -213,6 +213,22 @@ describe('Insight Functions', () => {
       expect(pageResult).toHaveLength(1);
       expect(pageResult[0].clicks).toBe(0); // Should default to 0
       expect(pageResult[0].impressions).toBe(0); // Should default to 0
+    });
+  });
+
+  describe('sortInsightItems', () => {
+    it('sorts position values in ascending order placing undefined at the end', () => {
+      const items: SCInsightItem[] = [
+        { clicks: 0, impressions: 0, ctr: 0, position: 5 },
+        { clicks: 0, impressions: 0, ctr: 0, position: 1 },
+        { clicks: 0, impressions: 0, ctr: 0, position: undefined as unknown as number },
+      ];
+
+      const sorted = sortInsightItems([...items], 'position');
+
+      expect(sorted[0].position).toBe(1);
+      expect(sorted[1].position).toBe(5);
+      expect(sorted[2].position).toBeUndefined();
     });
   });
 });

--- a/utils/insight.ts
+++ b/utils/insight.ts
@@ -15,7 +15,7 @@ export const sortInsightItems = (items:SCInsightItem[], sortBy: string = 'clicks
          sortedItems = items.sort((a, b) => (b.impressions ?? 0) - (a.impressions ?? 0));
          break;
       case 'position':
-         sortedItems = items.sort((a, b) => (b.position ?? 0) - (a.position ?? 0));
+         sortedItems = items.sort((a, b) => (a.position ?? Infinity) - (b.position ?? Infinity));
          break;
       default:
          sortedItems = items;


### PR DESCRIPTION
## Summary
- ensure multi-keyword refresh requests return database state with updating flags held true while handling the refresh promise
- add regression coverage for the refresh API response and insight sorting behaviour
- sort Search Console insight items by position in ascending order

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2faf65bc832abe9114d810c9556f