### PR TITLE
Persist empty keyword idea arrays when favorites are cleared

### DIFF
--- a/__tests__/api/ideasFavorites.test.ts
+++ b/__tests__/api/ideasFavorites.test.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { readFile, writeFile } from 'fs/promises';
+import db from '../../database/database';
+import handler from '../../pages/api/ideas';
+import verifyUser from '../../utils/verifyUser';
+import type { KeywordIdeasDatabase } from '../../utils/adwords';
+
+jest.mock('../../database/database', () => ({
+   __esModule: true,
+   default: { sync: jest.fn() },
+}));
+
+jest.mock('../../utils/verifyUser', () => ({
+   __esModule: true,
+   default: jest.fn(),
+}));
+
+jest.mock('fs/promises', () => ({
+   __esModule: true,
+   readFile: jest.fn(),
+   writeFile: jest.fn(),
+}));
+
+describe('PUT /api/ideas favorites persistence', () => {
+   beforeEach(() => {
+      jest.clearAllMocks();
+      (db.sync as jest.Mock).mockResolvedValue(undefined);
+      (verifyUser as jest.Mock).mockReturnValue('authorized');
+      (writeFile as jest.Mock).mockResolvedValue(undefined);
+   });
+
+   it('persists an empty favorites array after toggling off a keyword', async () => {
+      const keyword = { uid: 'kw-1', keyword: 'test keyword' } as any;
+      const storedDatabase = {
+         keywords: [keyword],
+         favorites: [keyword],
+         settings: { seedType: 'custom' },
+         updated: Date.now(),
+      } as KeywordIdeasDatabase;
+
+      (readFile as jest.Mock).mockResolvedValue(JSON.stringify(storedDatabase));
+
+      const req = {
+         method: 'PUT',
+         body: { keywordID: 'kw-1', domain: 'example-com' },
+      } as unknown as NextApiRequest;
+
+      const res = {
+         status: jest.fn().mockReturnThis(),
+         json: jest.fn(),
+      } as unknown as NextApiResponse;
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ keywords: [], error: '' });
+      expect(writeFile).toHaveBeenCalledTimes(1);
+
+      const [, contents] = (writeFile as jest.Mock).mock.calls[0];
+      const saved = JSON.parse(contents as string) as KeywordIdeasDatabase;
+      expect(saved.favorites).toEqual([]);
+   });
+});

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -593,10 +593,10 @@ export const updateLocalKeywordIdeas = async (domain: string, data: IdeaDatabase
          throw new Error('Invalid domain value for file access');
       }
       const fileContent = { ...existingIdeas, updated: new Date().getTime() };
-      if (data.keywords && Array.isArray(data.keywords) && data.keywords.length > 0) {
+      if (Array.isArray(data.keywords)) {
          fileContent.keywords = data.keywords;
       }
-      if (data.favorites && Array.isArray(data.favorites) && data.favorites.length > 0) {
+      if (Array.isArray(data.favorites)) {
          fileContent.favorites = data.favorites;
       }
       if (data.settings) {


### PR DESCRIPTION
## Summary
- allow `updateLocalKeywordIdeas` to persist empty keyword and favorites arrays when updates arrive
- add an API handler test that clears a favorite and verifies the stored favorites array is empty

## Testing
- npm test -- --runTestsByPath __tests__/api/ideasFavorites.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc386975e4832a92b3764dcff53350