### PR TITLE
Handle unknown countries in CSV exports

### DIFF
--- a/__tests__/utils/client/exportcsv.test.ts
+++ b/__tests__/utils/client/exportcsv.test.ts
@@ -1,0 +1,45 @@
+import exportCSV from '../../../utils/client/exportcsv';
+
+describe('exportCSV', () => {
+   const OriginalBlob = global.Blob;
+   const blobParts: unknown[][] = [];
+
+   beforeEach(() => {
+      blobParts.length = 0;
+      // @ts-expect-error - Mock Blob for capturing CSV content
+      global.Blob = class MockBlob {
+         public parts: unknown[];
+         constructor(parts: unknown[], _options?: unknown) {
+            this.parts = parts;
+            blobParts.push(parts);
+         }
+      };
+      jest.spyOn(URL, 'createObjectURL').mockReturnValue('mock-url');
+   });
+
+   afterEach(() => {
+      jest.restoreAllMocks();
+      global.Blob = OriginalBlob;
+   });
+
+   it('falls back to the raw country code when the Search Console country is unknown', () => {
+      const keywords: SCKeywordType[] = [
+         {
+            keyword: 'example keyword',
+            uid: 'abc123',
+            device: 'desktop',
+            page: '/example',
+            country: 'ZZ',
+            clicks: 5,
+            impressions: 50,
+            ctr: 0.1,
+            position: 3,
+         },
+      ];
+
+      expect(() => exportCSV(keywords, 'example.com')).not.toThrow();
+      expect(blobParts).toHaveLength(1);
+      const csvContent = String(blobParts[0][0]);
+      expect(csvContent).toContain(', Unknown,');
+   });
+});

--- a/utils/client/exportcsv.ts
+++ b/utils/client/exportcsv.ts
@@ -1,5 +1,12 @@
 import countries from '../countries';
 
+const getCountryLabel = (countryCode?: string) => {
+   if (!countryCode) { return 'Unknown'; }
+   const countryData = countries[countryCode];
+   if (countryData && countryData[0]) { return countryData[0]; }
+   return countryCode || 'Unknown';
+};
+
   /**
    * Generates CSV File form the given domain & keywords, and automatically downloads it.
    * @param {KeywordType[]}  keywords - The keywords of the domain
@@ -25,7 +32,7 @@ const exportCSV = (keywords: KeywordType[] | SCKeywordType[], domain:string, scD
             impressions,
             clicks,
             ctr,
-            countries[country][0],
+            getCountryLabel(country),
             device,
          ].join(', ');
          csvBody += `${row}\r\n`;
@@ -38,7 +45,7 @@ const exportCSV = (keywords: KeywordType[] | SCKeywordType[], domain:string, scD
             keyword,
             position === 0 ? '-' : position,
             url || '-',
-            countries[country][0],
+            getCountryLabel(country),
             state || '-',
             city || '-',
             device,
@@ -67,10 +74,33 @@ export const exportKeywordIdeas = (keywords: IdeaKeyword[], domainName:string) =
    keywords.forEach((keywordData) => {
       const { keyword, competition, country, competitionIndex, avgMonthlySearches, added } = keywordData;
       const addedDate = new Intl.DateTimeFormat('en-US').format(new Date(added));
-      csvBody += `${keyword}, ${avgMonthlySearches}, ${competition}, ${competitionIndex}, ${countries[country][0]}, ${addedDate}\r\n`;
+      csvBody += formatKeywordIdeaRow({
+         keyword,
+         competition,
+         country,
+         competitionIndex,
+         avgMonthlySearches,
+         addedDate,
+      });
    });
    downloadCSV(csvHeader, csvBody, fileName);
 };
+
+const formatKeywordIdeaRow = ({
+   keyword,
+   competition,
+   country,
+   competitionIndex,
+   avgMonthlySearches,
+   addedDate,
+}:{
+   keyword: string,
+   competition: IdeaKeyword['competition'],
+   country: string,
+   competitionIndex: number,
+   avgMonthlySearches: number,
+   addedDate: string,
+}) => `${keyword}, ${avgMonthlySearches}, ${competition}, ${competitionIndex}, ${getCountryLabel(country)}, ${addedDate}\r\n`;
 
 /**
  * generates a CSV file with a specified header and body content and automatically downloads it.


### PR DESCRIPTION
## Summary
- add a reusable helper to provide fallback labels when CSV exports encounter unmapped country codes
- apply the fallback to Search Console, tracked keyword, and keyword idea CSV generation paths
- add a regression test covering Search Console exports with the ZZ country code

## Testing
- npm test -- exportcsv.test.ts
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc3aaf958c832ab3b6da7c555e73f7