### PR TITLE
Improve queue error handling and CSV export escaping

### DIFF
--- a/__tests__/api/clearfailed.test.ts
+++ b/__tests__/api/clearfailed.test.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../../pages/api/clearfailed';
+import verifyUser from '../../utils/verifyUser';
+import { writeFile } from 'fs/promises';
+
+jest.mock('../../utils/verifyUser');
+jest.mock('fs/promises', () => ({
+   __esModule: true,
+   writeFile: jest.fn(),
+}));
+
+describe('/api/clearfailed', () => {
+   const req = { method: 'PUT', headers: {} } as unknown as NextApiRequest;
+   let res: NextApiResponse;
+
+   beforeEach(() => {
+      res = {
+         status: jest.fn().mockReturnThis(),
+         json: jest.fn(),
+      } as unknown as NextApiResponse;
+
+      (verifyUser as jest.Mock).mockReturnValue('authorized');
+      (writeFile as jest.Mock).mockResolvedValue(undefined);
+   });
+
+   afterEach(() => {
+      jest.clearAllMocks();
+   });
+
+   it('responds with error status when clearing the queue fails', async () => {
+      (writeFile as jest.Mock).mockRejectedValue(new Error('disk full'));
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: 'disk full' });
+   });
+});

--- a/__tests__/components/Insight.test.tsx
+++ b/__tests__/components/Insight.test.tsx
@@ -1,0 +1,64 @@
+/// <reference path="../../types.d.ts" />
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Insight from '../../components/insight/Insight';
+
+jest.mock('react-chartjs-2', () => ({
+   Line: () => null,
+}));
+
+describe('Insight component', () => {
+   const insightData: InsightDataType = {
+      stats: [],
+      keywords: [
+         {
+            keyword: 'first keyword',
+            clicks: 10,
+            impressions: 100,
+            ctr: 5,
+            position: 2,
+         },
+         {
+            keyword: 'second keyword',
+            clicks: 20,
+            impressions: 200,
+            ctr: 10,
+            position: 3,
+         },
+      ],
+      countries: [],
+      pages: [],
+   };
+
+   const domain = {
+      domain: 'example.com',
+   } as unknown as DomainType;
+
+   it('omits the bottom border on the final insight row', () => {
+      const { container } = render(
+         <Insight
+            domain={domain}
+            insight={insightData}
+            isLoading={false}
+            isConsoleIntegrated={false}
+         />,
+      );
+
+      const keywordsTab = screen.getAllByText(/keywords/i).find((element) => element.tagName.toLowerCase() === 'i');
+      expect(keywordsTab).toBeDefined();
+      fireEvent.click(keywordsTab as HTMLElement);
+
+      const table = container.querySelector('.domKeywords_keywords');
+      const rows = table ? table.querySelectorAll('div.keyword') : null;
+      expect(rows && rows.length).toBe(2);
+
+      const firstRow = rows?.[0] as HTMLElement;
+      const lastRow = rows?.[rows.length - 1] as HTMLElement;
+      expect(firstRow).toBeTruthy();
+      expect(lastRow).toBeTruthy();
+
+      expect(firstRow.className).not.toContain('border-b-0');
+      expect(lastRow.className).toContain('border-b-0');
+   });
+});

--- a/__tests__/utils/exportcsv.test.ts
+++ b/__tests__/utils/exportcsv.test.ts
@@ -1,0 +1,98 @@
+/// <reference path="../../types.d.ts" />
+
+import { createKeywordCsvPayload, createKeywordIdeasCsvPayload } from '../../utils/client/exportcsv';
+
+const parseCsvRow = (row: string): string[] => {
+   const sanitizedRow = row.replace(/\r?$/, '');
+   const values: string[] = [];
+   let current = '';
+   let inQuotes = false;
+
+   for (let i = 0; i < sanitizedRow.length; i += 1) {
+      const char = sanitizedRow[i];
+      if (char === '"') {
+         if (inQuotes && sanitizedRow[i + 1] === '"') {
+            current += '"';
+            i += 1;
+         } else {
+            inQuotes = !inQuotes;
+         }
+      } else if (char === ',' && !inQuotes) {
+         values.push(current);
+         current = '';
+      } else {
+         current += char;
+      }
+   }
+
+   values.push(current);
+   return values;
+};
+
+describe('CSV export utilities', () => {
+   it('escapes tracked keyword exports that contain commas or quotes', () => {
+      const keyword = {
+         ID: 1,
+         keyword: 'hello, "world"',
+         position: 0,
+         url: 'https://example.com/path,1',
+         country: 'ZZ',
+         state: '',
+         city: '',
+         device: 'desktop',
+         lastUpdated: '2024-01-01',
+         added: '2024-01-02',
+         tags: ['tag,one', 'tag"two'],
+         domain: 'example.com',
+         volume: 0,
+         sticky: false,
+         history: {},
+         lastResult: [],
+         updating: false,
+         lastUpdateError: false,
+      } as unknown as KeywordType;
+
+      const payload = createKeywordCsvPayload([keyword], 'example.com');
+      expect(payload).not.toBeNull();
+
+      const [row] = payload!.body.trim().split('\n');
+      const parsedRow = parseCsvRow(row);
+
+      expect(parsedRow[0]).toBe('1');
+      expect(parsedRow[1]).toBe('hello, "world"');
+      expect(parsedRow[2]).toBe('-');
+      expect(parsedRow[3]).toBe('https://example.com/path,1');
+      expect(parsedRow[4]).toBe('Unknown');
+      expect(parsedRow[10]).toBe('tag,one,tag"two');
+   });
+
+   it('escapes keyword idea exports and preserves quotes and commas', () => {
+      const keywordIdeas: IdeaKeyword[] = [
+         {
+            uid: 'idea-1',
+            keyword: 'alpha, "beta"',
+            competition: 'HIGH',
+            competitionIndex: 75,
+            avgMonthlySearches: 500,
+            monthlySearchVolumes: { '2024-01': '500' },
+            country: 'AA',
+            domain: 'example.com',
+            added: new Date('2024-01-10').getTime(),
+            updated: new Date('2024-01-10').getTime(),
+            position: 0,
+         },
+      ];
+
+      const payload = createKeywordIdeasCsvPayload(keywordIdeas, 'example.com');
+      expect(payload).not.toBeNull();
+
+      const [row] = payload!.body.trim().split('\n');
+      const parsedRow = parseCsvRow(row);
+
+      expect(parsedRow[0]).toBe('alpha, "beta"');
+      expect(parsedRow[1]).toBe('500');
+      expect(parsedRow[2]).toBe('HIGH');
+      expect(parsedRow[3]).toBe('75');
+      expect(parsedRow[4]).toBe('AA');
+   });
+});

--- a/components/ideas/KeywordIdea.tsx
+++ b/components/ideas/KeywordIdea.tsx
@@ -45,7 +45,7 @@ const KeywordIdea = (props: KeywordIdeaProps) => {
 
    return (
       <div
-      key={keyword}
+      key={uid}
       style={style}
       className={`keyword relative py-5 px-4 text-gray-600 border-b-[1px] border-gray-200 lg:py-4 lg:px-6 lg:border-0
       lg:flex lg:justify-between lg:items-center ${selected ? ' bg-indigo-50 keyword--selected' : ''} ${lastItem ? 'border-b-0' : ''}`}>

--- a/components/insight/Insight.tsx
+++ b/components/insight/Insight.tsx
@@ -107,7 +107,7 @@ const SCInsight = ({ insight, isLoading = true, isConsoleIntegrated = true, doma
                            && (activeTab === 'stats' ? [...insightItems].reverse() : sortInsightItems(insightItems)).map(
                               (item:SCInsightItem, index: number) => {
                               const insightItemCount = insight ? insightItems : [];
-                              const lastItem = !!(insightItemCount && (index === insightItemCount.length));
+                              const lastItem = !!(insightItemCount && (index === insightItemCount.length - 1));
                               return <InsightItem key={index} item={item} type={activeTab} lastItem={lastItem} domain={domain?.domain || ''} />;
                            },
                         )

--- a/pages/api/clearfailed.ts
+++ b/pages/api/clearfailed.ts
@@ -23,7 +23,8 @@ const clearFailedQueue = async (req: NextApiRequest, res: NextApiResponse<Settin
       await writeFile(`${process.cwd()}/data/failed_queue.json`, JSON.stringify([]), { encoding: 'utf-8' });
       return res.status(200).json({ cleared: true });
    } catch (error) {
-      console.log('[ERROR] Cleraring Failed Queue File.', error);
-      return res.status(200).json({ error: 'Error Cleraring Failed Queue!' });
+      console.log('[ERROR] Clearing Failed Queue File.', error);
+      const message = error instanceof Error && error.message ? error.message : 'Error Clearing Failed Queue!';
+      return res.status(500).json({ error: message });
    }
 };


### PR DESCRIPTION
## Summary
- return a 500 response with the original error message when clearing the failed queue file fails
- escape CSV exports for keywords and ideas, adding helpers that wrap fields in quotes and handle missing country metadata
- ensure keyword idea rows use stable uids, compute the last insight row correctly, and extend Jest coverage for the API, CSV helpers, and UI components

## Testing
- npx jest __tests__/api/clearfailed.test.ts __tests__/utils/exportcsv.test.ts __tests__/components/KeywordIdeasTable.test.tsx __tests__/components/Insight.test.tsx
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc3d9dfe8c832ab6cde79a571996d9