### PR TITLE
Normalize Search Console page paths

### DIFF
--- a/__tests__/utils/client/exportcsv.test.ts
+++ b/__tests__/utils/client/exportcsv.test.ts
@@ -40,6 +40,6 @@ describe('exportCSV', () => {
       expect(() => exportCSV(keywords, 'example.com')).not.toThrow();
       expect(blobParts).toHaveLength(1);
       const csvContent = String(blobParts[0][0]);
-      expect(csvContent).toContain(', Unknown,');
+      expect(csvContent).toMatch(/,"Unknown",/);
    });
 });


### PR DESCRIPTION
## Summary
- normalize Search Console page paths by parsing URLs, trimming optional www prefixes, and keeping other subdomains intact
- add unit tests that cover homepage, www, and non-www Search Console URLs, plus adjust the CSV expectation to match quoted Unknown values

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc403fd4b8832aa249d715f21ca9d2