### PR TITLE
Harden domain and keyword workflows

### DIFF
--- a/__tests__/components/AddDomain.test.tsx
+++ b/__tests__/components/AddDomain.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import AddDomain from '../../components/domains/AddDomain';
+import { useAddDomain } from '../../services/domains';
+
+jest.mock('../../services/domains', () => ({
+   useAddDomain: jest.fn(),
+}));
+
+const mockUseAddDomain = useAddDomain as unknown as jest.Mock;
+
+const baseDomain: DomainType = {
+   ID: 1,
+   domain: 'existing.com',
+   slug: 'existing-com',
+   notification: true,
+   notification_interval: 'daily',
+   notification_emails: '',
+   lastUpdated: '2024-01-01T00:00:00.000Z',
+   added: '2024-01-01T00:00:00.000Z',
+};
+
+describe('AddDomain', () => {
+   const mutateMock = jest.fn();
+   const closeModalMock = jest.fn();
+
+   beforeEach(() => {
+      jest.clearAllMocks();
+      mutateMock.mockReset();
+      mockUseAddDomain.mockReturnValue({ mutate: mutateMock, isLoading: false });
+   });
+
+   const renderComponent = (domains: DomainType[] = [baseDomain]) => render(
+      <AddDomain domains={domains} closeModal={closeModalMock} />,
+   );
+
+   it('deduplicates submitted domains before triggering the mutation', () => {
+      renderComponent();
+
+      const textarea = screen.getByPlaceholderText(/Type or Paste URLs here/i);
+      fireEvent.change(textarea, {
+         target: {
+            value: 'https://example.com/\nhttps://example.com/\nhttps://existing.com/',
+         },
+      });
+
+      const addButton = screen.getByText('Add Domain');
+      fireEvent.click(addButton);
+
+      expect(mutateMock).toHaveBeenCalledWith(['example.com']);
+   });
+
+   it('surfaces a warning when all provided domains are duplicates', () => {
+      renderComponent();
+
+      const textarea = screen.getByPlaceholderText(/Type or Paste URLs here/i);
+      fireEvent.change(textarea, {
+         target: { value: 'https://existing.com/' },
+      });
+
+      const addButton = screen.getByText('Add Domain');
+      fireEvent.click(addButton);
+
+      expect(mutateMock).not.toHaveBeenCalled();
+      expect(screen.getByText('All provided domains are already tracked or duplicates.')).toBeInTheDocument();
+   });
+});

--- a/__tests__/components/AddTags.test.tsx
+++ b/__tests__/components/AddTags.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import AddTags from '../../components/keywords/AddTags';
+import { useUpdateKeywordTags } from '../../services/keywords';
+
+jest.mock('../../services/keywords', () => ({
+   useUpdateKeywordTags: jest.fn(),
+}));
+
+const mockUseUpdateKeywordTags = useUpdateKeywordTags as unknown as jest.Mock;
+
+const baseKeyword: KeywordType = {
+   ID: 1,
+   keyword: 'alpha keyword',
+   device: 'desktop',
+   country: 'US',
+   domain: 'example.com',
+   lastUpdated: '2024-01-01T00:00:00.000Z',
+   added: '2024-01-01T00:00:00.000Z',
+   position: 5,
+   volume: 100,
+   sticky: false,
+   history: {},
+   lastResult: [],
+   url: '',
+   tags: [],
+   updating: false,
+   lastUpdateError: false,
+};
+
+describe('AddTags', () => {
+   const mutateMock = jest.fn();
+   const closeModal = jest.fn();
+
+   beforeEach(() => {
+      jest.clearAllMocks();
+      mutateMock.mockReset();
+      mockUseUpdateKeywordTags.mockReturnValue({ mutate: mutateMock });
+   });
+
+   it('filters out blank tag entries before submitting', () => {
+      render(
+         <AddTags keywords={[baseKeyword]} existingTags={[]} closeModal={closeModal} />,
+      );
+
+      const input = screen.getByPlaceholderText('Insert Tags. eg: tag1, tag2');
+      fireEvent.change(input, { target: { value: 'primary, ,  , secondary  ' } });
+
+      const applyButton = screen.getByText('Apply');
+      fireEvent.click(applyButton);
+
+      expect(mutateMock).toHaveBeenCalledWith({ tags: { 1: ['primary', 'secondary'] } });
+   });
+});

--- a/__tests__/components/KeywordDetails.test.tsx
+++ b/__tests__/components/KeywordDetails.test.tsx
@@ -30,4 +30,13 @@ describe('KeywordDetails', () => {
       expect(screen.getByText('1. Compress Image Tool')).toBeInTheDocument();
       expect(screen.getByText('https://compressimage.io/')).toBeInTheDocument();
    });
+
+   it('falls back to keyword.lastResult when fetched data omits search results', () => {
+      useFetchSingleKeywordMock.mockReturnValue({ data: { history: dummyKeywords[0].history } });
+
+      render(<KeywordDetails keyword={dummyKeywords[0] as KeywordType} closeDetails={jest.fn()} />);
+
+      expect(screen.getByText('1. Compress Image Tool')).toBeInTheDocument();
+      expect(screen.getByText('https://compressimage.io/')).toBeInTheDocument();
+   });
 });

--- a/__tests__/services/domains.fetchDomain.test.ts
+++ b/__tests__/services/domains.fetchDomain.test.ts
@@ -47,13 +47,25 @@ describe('fetchDomain', () => {
       const payload = { domain: null };
       mockSuccessfulFetch(payload);
 
-      const response = await fetchDomain(router, '');
+   const response = await fetchDomain(router, '');
 
-      const fetchMock = global.fetch as unknown as jest.Mock;
-      expect(fetchMock).toHaveBeenCalledWith(
-         `${window.location.origin}/api/domain?domain=`,
-         { method: 'GET' },
-      );
-      expect(response).toBe(payload);
-   });
+   const fetchMock = global.fetch as unknown as jest.Mock;
+   expect(fetchMock).toHaveBeenCalledWith(
+      `${window.location.origin}/api/domain?domain=`,
+      { method: 'GET' },
+   );
+   expect(response).toBe(payload);
+ });
+
+  it('throws a descriptive error when the API returns 404', async () => {
+    const fetchMock = global.fetch as unknown as jest.Mock;
+    fetchMock.mockResolvedValueOnce({
+      status: 404,
+      headers: { get: jest.fn().mockReturnValue('application/json') },
+      json: jest.fn().mockResolvedValue({ error: 'Domain not found' }),
+    });
+
+    await expect(fetchDomain(router, 'unknown.example.com')).rejects.toThrow('Domain not found');
+    expect(pushMock).not.toHaveBeenCalled();
+  });
 });

--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -6,6 +6,7 @@ import { useDeleteDomain, useFetchDomain, useUpdateDomain } from '../../services
 import InputField from '../common/InputField';
 import SelectField from '../common/SelectField';
 import { TOGGLE_TRACK_CLASS_NAME } from '../common/toggleStyles';
+import { isValidEmail } from '../../utils/client/validators';
 
 type DomainSettingsProps = {
    domain:DomainType|null,
@@ -64,15 +65,16 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
    const updateDomain = () => {
       let error: DomainSettingsError | null = null;
       if (domainSettings.notification_emails) {
-         const notification_emails = domainSettings.notification_emails.split(',');
-         const invalidEmails = notification_emails.find((x) => /^\w+(?:[.-]\w+)*@\w+(?:[.-]\w+)*(\.\w{2,15})+$/.test(x) === false);
-         console.log('invalidEmails: ', invalidEmails);
+         const emailList = domainSettings.notification_emails
+            .split(',')
+            .map((email) => email.trim())
+            .filter((email) => email.length > 0);
+         const invalidEmails = emailList.find((email) => !isValidEmail(email));
          if (invalidEmails) {
             error = { type: 'email', msg: 'Invalid Email' };
          }
       }
       if (error && error.type) {
-         console.log('Error!!!!!');
          setSettingsError(error);
          setTimeout(() => {
             setSettingsError({ type: '', msg: '' });

--- a/components/keywords/AddTags.tsx
+++ b/components/keywords/AddTags.tsx
@@ -24,10 +24,17 @@ const AddTags = ({ keywords = [], existingTags = [], closeModal }: AddTagsProps)
          return;
       }
 
-      const tagsArray = tagInput.split(',').map((t) => t.trim());
+      const tagsArray = Array.from(new Set(
+         tagInput
+            .split(',')
+            .map((t) => t.trim())
+            .filter((tag) => tag.length > 0),
+      ));
       const tagsPayload:any = {};
       keywords.forEach((keyword:KeywordType) => {
-         tagsPayload[keyword.ID] = keywords.length === 1 ? tagsArray : [...(new Set([...keyword.tags, ...tagsArray]))];
+         tagsPayload[keyword.ID] = keywords.length === 1
+            ? tagsArray
+            : Array.from(new Set([...keyword.tags, ...tagsArray]));
       });
       updateMutate({ tags: tagsPayload });
    };

--- a/components/keywords/KeywordDetails.tsx
+++ b/components/keywords/KeywordDetails.tsx
@@ -20,7 +20,11 @@ const KeywordDetails = ({ keyword, closeDetails }:KeywordDetailsProps) => {
    const searchResultFound = useRef<HTMLDivElement>(null);
    const { data: keywordData } = useFetchSingleKeyword(keyword.ID);
    const keywordHistory: KeywordHistory = keywordData?.history || keyword.history;
-   const keywordSearchResult: KeywordLastResult[] = keywordData?.searchResult || keyword.lastResult || [];
+   const fallbackResults = Array.isArray(keyword.lastResult) ? keyword.lastResult : [];
+   const keywordSearchResultRaw = keywordData?.searchResult;
+   const keywordSearchResult: KeywordLastResult[] = Array.isArray(keywordSearchResultRaw)
+      ? keywordSearchResultRaw
+      : fallbackResults;
    const mapPackTop3 = (keywordData?.mapPackTop3 ?? keyword.mapPackTop3) === true;
    const dateOptions = [
       { label: 'Last 7 Days', value: '7' },

--- a/pages/api/domain.ts
+++ b/pages/api/domain.ts
@@ -28,9 +28,14 @@ const getDomain = async (req: NextApiRequest, res: NextApiResponse<DomainGetResp
    try {
       const query = { domain: req.query.domain as string };
       const foundDomain:Domain| null = await Domain.findOne({ where: query });
-      const parsedDomain = foundDomain?.get({ plain: true }) || false;
 
-      if (parsedDomain && parsedDomain.search_console) {
+      if (!foundDomain) {
+         return res.status(404).json({ domain: null, error: 'Domain not found' });
+      }
+
+      const parsedDomain = foundDomain.get({ plain: true }) as DomainType;
+
+      if (parsedDomain.search_console) {
          try {
             const cryptr = new Cryptr(process.env.SECRET as string);
             const scData = JSON.parse(parsedDomain.search_console);

--- a/pages/api/keywords.ts
+++ b/pages/api/keywords.ts
@@ -289,29 +289,50 @@ const updateKeywords = async (req: NextApiRequest, res: NextApiResponse<Keywords
          keywords = parseKeywords(formattedKeywords);
          return res.status(200).json({ keywords });
       }
-      if (tags) {
+      if (tags !== undefined) {
+         if (!tags || typeof tags !== 'object' || Array.isArray(tags)) {
+            return res.status(400).json({ error: 'Invalid Payload!' });
+         }
+
          const tagsKeywordIDs = Object.keys(tags);
+         if (tagsKeywordIDs.length === 0) {
+            return res.status(200).json({ keywords: [] });
+         }
+
          const multipleKeywords = tagsKeywordIDs.length > 1;
          const updatedKeywordIDs = new Set<number>();
+
          for (const keywordID of tagsKeywordIDs) {
             const numericId = Number(keywordID);
             if (!Number.isFinite(numericId)) {
                continue;
             }
+
+            const tagsForKeywordRaw = tags[keywordID];
+            const tagsForKeyword = Array.isArray(tagsForKeywordRaw)
+               ? tagsForKeywordRaw
+               : [];
+            const sanitizedTags = tagsForKeyword
+               .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+               .filter((tag) => tag.length > 0);
+
             const selectedKeyword = await Keyword.findOne({ where: { ID: numericId } });
             const currentTags = selectedKeyword && selectedKeyword.tags ? JSON.parse(selectedKeyword.tags) : [];
-            const mergedTags = Array.from(new Set([...currentTags, ...tags[keywordID]])).sort();
+            const mergedTags = Array.from(new Set([...currentTags, ...sanitizedTags])).sort();
+
             if (selectedKeyword) {
-               const tagsToSave = multipleKeywords ? mergedTags : [...tags[keywordID]].sort();
+               const tagsToSave = multipleKeywords ? mergedTags : sanitizedTags.sort();
                await selectedKeyword.update({ tags: JSON.stringify(tagsToSave) });
                updatedKeywordIDs.add(numericId);
             }
          }
+
          if (updatedKeywordIDs.size > 0) {
             const updatedKeywords:Keyword[] = await Keyword.findAll({ where: { ID: { [Op.in]: Array.from(updatedKeywordIDs) } } });
             const formattedKeywords = updatedKeywords.map((el) => el.get({ plain: true }));
             keywords = parseKeywords(formattedKeywords);
          }
+
          return res.status(200).json({ keywords });
       }
       return res.status(400).json({ error: 'Invalid Payload!' });

--- a/pages/api/keywords.ts
+++ b/pages/api/keywords.ts
@@ -313,7 +313,8 @@ const updateKeywords = async (req: NextApiRequest, res: NextApiResponse<Keywords
                ? tagsForKeywordRaw
                : [];
             const sanitizedTags = tagsForKeyword
-               .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+               .filter((tag): tag is string => typeof tag === 'string')
+               .map((tag) => tag.trim())
                .filter((tag) => tag.length > 0);
 
             const selectedKeyword = await Keyword.findOne({ where: { ID: numericId } });

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import jwt from 'jsonwebtoken';
 import Cookies from 'cookies';
 import { logger } from '../../utils/logger';
+import isRequestSecure from '../../utils/api/isRequestSecure';
 
 type loginResponse = {
    success?: boolean
@@ -77,11 +78,15 @@ const loginUser = async (req: NextApiRequest, res: NextApiResponse<loginResponse
          const sessionDurationMs = sessionDurationHours * 60 * 60 * 1000;
          const expiryDate = new Date(Date.now() + sessionDurationMs);
          
+         const secureCookie = isRequestSecure(req);
+
          cookies.set('token', token, {
             httpOnly: true,
             sameSite: 'lax',
             maxAge: sessionDurationMs,
             expires: expiryDate,
+            secure: secureCookie,
+            path: '/',
          });
 
          logger.info('Login successful', {

--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -5,6 +5,7 @@ import Cookies from 'cookies';
 import verifyUser from '../../utils/verifyUser';
 import { withApiLogging } from '../../utils/apiLogging';
 import { logger } from '../../utils/logger';
+import isRequestSecure from '../../utils/api/isRequestSecure';
 
 type logoutResponse = {
    success?: boolean
@@ -58,12 +59,15 @@ const logout = async (req: NextApiRequest, res: NextApiResponse<logoutResponse>,
       }
 
       // Clear the token cookie
+      const secureCookie = isRequestSecure(req);
+
       cookies.set('token', '', {
          httpOnly: true,
          sameSite: 'lax',
          maxAge: 0,
          expires: new Date(0),
          path: '/',
+         secure: secureCookie,
       });
 
       logger.info('User logged out successfully', {

--- a/utils/api/isRequestSecure.ts
+++ b/utils/api/isRequestSecure.ts
@@ -20,11 +20,6 @@ const isRequestSecure = (req: NextApiRequest): boolean => {
       return true;
    }
 
-   const connection = req.connection as { encrypted?: boolean } | undefined;
-   if (connection?.encrypted) {
-      return true;
-   }
-
    const socket = req.socket as { encrypted?: boolean } | undefined;
    return socket?.encrypted === true;
 };

--- a/utils/api/isRequestSecure.ts
+++ b/utils/api/isRequestSecure.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest } from 'next';
+
+const isRequestSecure = (req: NextApiRequest): boolean => {
+   const protoHeader = req.headers['x-forwarded-proto'];
+   if (Array.isArray(protoHeader)) {
+      if (protoHeader.some((value) => value?.toLowerCase() === 'https')) {
+         return true;
+      }
+   } else if (typeof protoHeader === 'string' && protoHeader.toLowerCase() === 'https') {
+      return true;
+   }
+
+   const forwardedProtocol = req.headers['x-forwarded-protocol'];
+   if (typeof forwardedProtocol === 'string' && forwardedProtocol.toLowerCase() === 'https') {
+      return true;
+   }
+
+   const forwardedSsl = req.headers['x-forwarded-ssl'];
+   if (typeof forwardedSsl === 'string' && forwardedSsl.toLowerCase() === 'on') {
+      return true;
+   }
+
+   const connection = req.connection as { encrypted?: boolean } | undefined;
+   if (connection?.encrypted) {
+      return true;
+   }
+
+   const socket = req.socket as { encrypted?: boolean } | undefined;
+   return socket?.encrypted === true;
+};
+
+export default isRequestSecure;

--- a/utils/client/validators.ts
+++ b/utils/client/validators.ts
@@ -43,3 +43,18 @@ export const isValidUrl = (str: string) => {
   }
    return url.protocol === 'http:' || url.protocol === 'https:';
  };
+
+export const isValidEmail = (email: string): boolean => {
+   if (typeof email !== 'string') {
+      return false;
+   }
+
+   const trimmed = email.trim();
+   if (trimmed.length === 0) {
+      return false;
+   }
+
+   const emailPattern = /^(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+))$/;
+
+   return emailPattern.test(trimmed);
+};


### PR DESCRIPTION
## Summary
- Relax domain notification email validation by introducing a shared RFC-compliant helper and expand DomainSettings coverage
- Deduplicate domain entries and trim blank keyword tags before submission while enhancing related unit tests
- Treat empty tag updates as successful, improve keyword fetch error handling, return 404s for missing domains, and secure auth cookies
- Ensure keyword refresh clears updating flags on parallel errors and adjust Keyword Details to favour lastResult data

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dc536fb93c832aabadb998ca3c5695