### PR TITLE
Improve domain validation, keyword retry handling, and cron auth guards

### DIFF
--- a/__tests__/cron.worker.test.ts
+++ b/__tests__/cron.worker.test.ts
@@ -1,0 +1,43 @@
+describe('cron worker helpers', () => {
+  let makeCronApiCall: (apiKey: string | undefined | null, baseUrl: string, endpoint: string, successMessage: string) => Promise<void>;
+  const originalFetch = global.fetch;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    global.fetch = jest.fn();
+    const cronModule = require('../cron.js');
+    makeCronApiCall = cronModule.makeCronApiCall;
+  });
+
+  afterEach(() => {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // @ts-expect-error - allow cleaning up mock fetch
+      delete global.fetch;
+    }
+    jest.restoreAllMocks();
+  });
+
+  it('skips API calls when the API key is missing', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await makeCronApiCall(undefined, 'http://localhost:3000', '/api/cron', 'ignored');
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith('[CRON] Skipping API call to /api/cron: API key not configured.');
+  });
+
+  it('sends the authorization header when API key is available', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    (global.fetch as jest.Mock).mockResolvedValue({ json: () => Promise.resolve({ ok: true }) });
+
+    await makeCronApiCall('secret', 'http://localhost:3000', '/api/cron', 'Success:');
+
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:3000/api/cron', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer secret' },
+    });
+    expect(consoleSpy).toHaveBeenCalledWith('Success:', { ok: true });
+  });
+});

--- a/pages/api/keywords.ts
+++ b/pages/api/keywords.ts
@@ -185,7 +185,16 @@ const addKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsGet
       
       const { keyword, domain, device, country, location, tags } = validation.sanitized!;
       const tagsArray = tags ? tags.split(',').map((item:string) => item.trim()).filter((tag: string) => tag.length > 0) : [];
-      
+      const dedupedTags: string[] = [];
+      const seenTags = new Set<string>();
+      tagsArray.forEach((tag) => {
+         const normalized = tag.toLowerCase();
+         if (!seenTags.has(normalized)) {
+            seenTags.add(normalized);
+            dedupedTags.push(tag);
+         }
+      });
+
       const newKeyword = {
          keyword,
          device,
@@ -197,7 +206,7 @@ const addKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsGet
          history: JSON.stringify({}),
          lastResult: JSON.stringify([]),
          url: '',
-         tags: JSON.stringify(tagsArray.slice(0, 10)), // Limit to 10 tags
+         tags: JSON.stringify(dedupedTags.slice(0, 10)), // Limit to 10 tags
          sticky: false,
          lastUpdated: new Date().toJSON(),
          added: new Date().toJSON(),

--- a/pages/api/refresh.ts
+++ b/pages/api/refresh.ts
@@ -23,6 +23,7 @@ type KeywordSearchResultRes = {
       keyword: string,
       position: number,
       country: string,
+      device: string,
    },
    error?: string|null,
 }
@@ -155,10 +156,11 @@ const getKeywordSearchResults = async (req: NextApiRequest, res: NextApiResponse
       if (!settings || (settings && settings.scraper_type === 'none')) {
          return res.status(400).json({ error: 'Scraper has not been set up yet.' });
       }
+      const requestedDevice = typeof req.query.device === 'string' ? req.query.device : 'desktop';
       const dummyKeyword:KeywordType = {
          ID: 99999999999999,
          keyword: req.query.keyword as string,
-         device: 'desktop',
+         device: requestedDevice,
          country: req.query.country as string,
          domain: '',
          lastUpdated: '',
@@ -181,6 +183,7 @@ const getKeywordSearchResults = async (req: NextApiRequest, res: NextApiResponse
             keyword: scrapeResult.keyword,
             position: scrapeResult.position !== 111 ? scrapeResult.position : 0,
             country: req.query.country as string,
+            device: requestedDevice,
          };
          return res.status(200).json({ error: '', searchResult });
       }

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -279,7 +279,13 @@ export const getAdwordsKeywordIdeas = async (credentials: AdwordsCredentials, ad
       try {
          // API: https://developers.google.com/google-ads/api/rest/reference/rest/v21/customers/generateKeywordIdeas
          const customerID = account_id.replaceAll('-', '');
-         const geoTargetConstants = countries[country][3]; // '2840';
+         const countryData = countries[country];
+         const geoTargetConstants = countryData ? countryData[3] : undefined;
+
+         if (!geoTargetConstants || Number(geoTargetConstants) === 0) {
+            console.warn(`[ADWORDS] Skipping keyword idea lookup for ${country}: missing geo target constant.`);
+            return [];
+         }
          const reqPayload: Record<string, any> = {
             geoTargetConstants: [`geoTargetConstants/${geoTargetConstants}`],
             language: `languageConstants/${language}`,
@@ -446,7 +452,13 @@ export const getKeywordsVolume = async (keywords: KeywordType[]): Promise<{ erro
             try {
                // API: https://developers.google.com/google-ads/api/rest/reference/rest/v21/customers/generateKeywordHistoricalMetrics
                const customerID = account_id.replaceAll('-', '');
-               const geoTargetConstants = countries[country][3]; // '2840';
+               const countryData = countries[country];
+               const geoTargetConstants = countryData ? countryData[3] : undefined;
+
+               if (!geoTargetConstants || Number(geoTargetConstants) === 0) {
+                  console.warn(`[ADWORDS] Skipping keyword volume lookup for ${country}: missing geo target constant.`);
+                  continue;
+               }
                const reqKeywords = keywordRequests[country].map((kw) => kw.keyword);
                const reqPayload: Record<string, any> = {
                   keywords: [...new Set(reqKeywords)],

--- a/utils/client/validators.ts
+++ b/utils/client/validators.ts
@@ -1,37 +1,6 @@
-export const isValidDomain = (domain:string): boolean => {
-   if (typeof domain !== 'string') return false;
-   if (!domain.includes('.')) return false;
-   let value = domain;
-   const validHostnameChars = /^[a-zA-Z0-9-.]{1,253}\.?$/;
-   if (!validHostnameChars.test(value)) {
-     return false;
-   }
+import { isValidHostname } from '../validators/hostname';
 
-   if (value.endsWith('.')) {
-     value = value.slice(0, value.length - 1);
-   }
-
-   if (value.length > 253) {
-     return false;
-   }
-
-   const labels = value.split('.');
-
-   const isValid = labels.every((label) => {
-     const validLabelChars = /^([a-zA-Z0-9-]+)$/;
-
-     const validLabel = (
-       validLabelChars.test(label)
-       && label.length < 64
-       && !label.startsWith('-')
-       && !label.endsWith('-')
-     );
-
-     return validLabel;
-   });
-
-   return isValid;
- };
+export const isValidDomain = (domain:string): boolean => isValidHostname(domain);
 
 export const isValidUrl = (str: string) => {
    let url;

--- a/utils/refresh.ts
+++ b/utils/refresh.ts
@@ -160,8 +160,22 @@ const refreshAndUpdateKeyword = async (keyword: Keyword, settings: SettingsType)
       }
    }
 
-   const updatedkeyword = refreshedkeywordData ? await updateKeywordPosition(keyword, refreshedkeywordData, settings) : currentkeyword;
-   return updatedkeyword;
+   if (refreshedkeywordData) {
+      const updatedkeyword = await updateKeywordPosition(keyword, refreshedkeywordData, settings);
+      return updatedkeyword;
+   }
+
+   try {
+      if (settings?.scrape_retry) {
+         await retryScrape(keyword.ID);
+      } else {
+         await removeFromRetryQueue(keyword.ID);
+      }
+   } catch (queueError) {
+      console.log('[ERROR] Failed to update retry queue for keyword:', keyword.ID, queueError);
+   }
+
+   return currentkeyword;
 };
 
 /**

--- a/utils/validators/hostname.ts
+++ b/utils/validators/hostname.ts
@@ -1,0 +1,61 @@
+const HOSTNAME_CHARS = /^[a-zA-Z0-9-.]{1,253}\.?$/;
+const HOSTNAME_LABEL = /^([a-zA-Z0-9-]+)$/;
+
+const normalizeInput = (value: string): string => {
+   const trimmed = value.trim();
+   if (!trimmed) {
+      return '';
+   }
+
+   const withoutTrailingDot = trimmed.endsWith('.')
+      ? trimmed.slice(0, trimmed.length - 1)
+      : trimmed;
+
+   return withoutTrailingDot.toLowerCase();
+};
+
+export const isValidHostname = (value: unknown): value is string => {
+   if (typeof value !== 'string') {
+      return false;
+   }
+
+   if (!value.includes('.')) {
+      return false;
+   }
+
+   const normalized = normalizeInput(value);
+   if (!normalized) {
+      return false;
+   }
+
+   if (!HOSTNAME_CHARS.test(normalized)) {
+      return false;
+   }
+
+   if (normalized.length > 253) {
+      return false;
+   }
+
+   const labels = normalized.split('.');
+   return labels.every((label) => (
+      HOSTNAME_LABEL.test(label)
+      && label.length < 64
+      && !label.startsWith('-')
+      && !label.endsWith('-')
+   ));
+};
+
+export const validateHostname = (value: unknown): { isValid: boolean; hostname: string } => {
+   if (!isValidHostname(value)) {
+      return { isValid: false, hostname: '' };
+   }
+
+   return { isValid: true, hostname: normalizeInput(value as string) };
+};
+
+export const sanitizeHostname = (value: unknown): string => {
+   const { hostname } = validateHostname(value);
+   return hostname;
+};
+
+export default isValidHostname;


### PR DESCRIPTION
## Summary
- guard the AddKeywords modal against SSR localStorage access and add a shared hostname validator for API/client use
- validate and deduplicate domains on POST, dedupe keyword tags, propagate preview device selection, harden settings/refresh/adwords flows, and skip cron API calls without an API key
- add targeted tests covering domains API validation, keyword tag handling, refresh retry bookkeeping, cron helper auth, and failed queue recreation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc5dff9c3c832aa67978e76a97e45f