### PR TITLE
Guard settings access in keyword ideas updater

### DIFF
--- a/components/ideas/KeywordIdeasUpdater.tsx
+++ b/components/ideas/KeywordIdeasUpdater.tsx
@@ -23,21 +23,26 @@ interface KeywordIdeasUpdaterProps {
 
 const KeywordIdeasUpdater = ({ onUpdate, settings, domain, searchConsoleConnected = false, adwordsConnected = false }: KeywordIdeasUpdaterProps) => {
    const router = useRouter();
-   const [seedType, setSeedType] = useState(() => (settings?.seedType ? settings.seedType : 'auto'));
-   const [language, setLanguage] = useState(() => (settings?.language ? settings.language.toString() : '1000'));
+   const seedTypeSetting = settings?.seedType;
+   const languageSetting = settings?.language;
+   const countriesSetting = settings?.countries;
+   const keywordsSetting = settings?.keywords;
+
+   const [seedType, setSeedType] = useState(() => (seedTypeSetting ? seedTypeSetting : 'auto'));
+   const [language, setLanguage] = useState(() => (languageSetting ? languageSetting.toString() : '1000'));
    const [countries, setCountries] = useState<string[]>(() => {
-      if (Array.isArray(settings?.countries) && settings.countries.length > 0) {
-         return settings.countries;
+      if (Array.isArray(countriesSetting) && countriesSetting.length > 0) {
+         return countriesSetting;
       }
       return ['US'];
    });
    const [keywords, setKeywords] = useState(() => {
-      if (!settings?.keywords) { return ''; }
-      if (Array.isArray(settings.keywords)) {
-         return settings.keywords.join(',');
+      if (!keywordsSetting) { return ''; }
+      if (Array.isArray(keywordsSetting)) {
+         return keywordsSetting.join(',');
       }
-      if (typeof settings.keywords === 'string') {
-         return settings.keywords;
+      if (typeof keywordsSetting === 'string') {
+         return keywordsSetting;
       }
       return '';
    });

--- a/pages/api/keywords.ts
+++ b/pages/api/keywords.ts
@@ -187,7 +187,7 @@ const addKeywords = async (req: NextApiRequest, res: NextApiResponse<KeywordsGet
       const tagsArray = tags ? tags.split(',').map((item:string) => item.trim()).filter((tag: string) => tag.length > 0) : [];
       const dedupedTags: string[] = [];
       const seenTags = new Set<string>();
-      tagsArray.forEach((tag) => {
+      tagsArray.forEach((tag: string) => {
          const normalized = tag.toLowerCase();
          if (!seenTags.has(normalized)) {
             seenTags.add(normalized);

--- a/pages/api/volume.ts
+++ b/pages/api/volume.ts
@@ -56,16 +56,18 @@ const updatekeywordVolume = async (req: NextApiRequest, res: NextApiResponse<Key
          return res.status(400).json({ error: 'Error Fetching Keywords Volume Data from Google Ads' });
       }
 
+      const volumesMap = keywordsVolumeData.volumes as Record<number, number>;
+
       const enrichedKeywords = keywordsToSend.map((keywordItem) => ({
          ...keywordItem,
-         volume: keywordsVolumeData.volumes?.[keywordItem.ID] ?? keywordItem.volume ?? 0,
+         volume: volumesMap[keywordItem.ID] ?? keywordItem.volume ?? 0,
       }));
 
       if (!update) {
-         return res.status(200).json({ keywords: enrichedKeywords, volumes: keywordsVolumeData.volumes });
+         return res.status(200).json({ keywords: enrichedKeywords, volumes: volumesMap });
       }
 
-      const updated = await updateKeywordsVolumeData(keywordsVolumeData.volumes);
+      const updated = await updateKeywordsVolumeData(volumesMap);
       if (updated) {
          return res.status(200).json({ keywords: enrichedKeywords, volumes: keywordsVolumeData.volumes });
       }

--- a/utils/refresh.ts
+++ b/utils/refresh.ts
@@ -313,12 +313,12 @@ const refreshParallel = async (keywords:KeywordType[], settings:SettingsType) : 
    const promises = keywords.map(async (keyword) => {
       try {
          const result = await scrapeKeywordFromGoogle(keyword, settings);
-         if (result && result !== false) {
-            return result;
-         }
-
          if (result === false) {
             return buildErrorResult(keyword, 'Scraper returned no data');
+         }
+
+         if (result) {
+            return result;
          }
 
          return buildErrorResult(keyword, 'Unknown scraper response');


### PR DESCRIPTION
## Summary
- guard optional keyword idea settings in the initializer by caching the optional props in local constants
- annotate keyword tag iteration to satisfy strict TypeScript checks
- harden volume enrichment and refresh parallel logic for strict union handling during the build

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc6716bf70832aac83cff4b2dd2b2c