### PR TITLE
Update notification email keyword layout

### DIFF
--- a/email/email.html
+++ b/email/email.html
@@ -292,6 +292,9 @@
          padding: 14px 18px 12px;
          border-bottom: 1px solid #e7e9f5;
          text-align: left;
+         background: #dee3ff;
+         color: #344dd7;
+         border-radius: 4px 4px 0 0;
       }
       .mini_stats__badge{
          display: inline-block;
@@ -308,7 +311,7 @@
       .mini_stats__title{
          font-size: 13px;
          font-weight: 600;
-         color: #1e293b;
+         color: #344dd7;
       }
       .mini_stats__row td{
          padding: 18px 14px;
@@ -351,9 +354,17 @@
       }
       .keyword_table:not(.keyword_table--sc) th:nth-child(3),
       .keyword_table:not(.keyword_table--sc) th:nth-child(4),
+      .keyword_table:not(.keyword_table--sc) th:nth-child(5),
       .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(3),
-      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4){
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4),
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(5){
          text-align: center;
+      }
+      .keyword_table:not(.keyword_table--sc) th:nth-child(4),
+      .keyword_table:not(.keyword_table--sc) th:nth-child(5),
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4),
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(5){
+         width: 90px;
       }
       .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4){
          font-size: 12px;
@@ -567,7 +578,6 @@
                                  <th>Location</th>
                                  <th>Position</th>
                                  <th>Best</th>
-                                 <th>Updated</th>
                                </tr>
                                {{keywordsTable}}
                            </tbody>

--- a/utils/generateEmail.ts
+++ b/utils/generateEmail.ts
@@ -32,32 +32,6 @@ type SCStatsObject = {
 }
 
 /**
- * Generate Human readable Time string.
- * @param {number} date - Keywords to scrape
- * @returns {string}
- */
-const timeSince = (date:number) : string => {
-   const seconds = Math.floor(((new Date().getTime() / 1000) - date));
-   let interval = Math.floor(seconds / 31536000);
-
-   if (interval > 1) return `${interval} years ago`;
-
-   interval = Math.floor(seconds / 2592000);
-   if (interval > 1) return `${interval} months ago`;
-
-   interval = Math.floor(seconds / 86400);
-   if (interval >= 1) return `${interval} days ago`;
-
-   interval = Math.floor(seconds / 3600);
-   if (interval >= 1) return `${interval} hrs ago`;
-
-   interval = Math.floor(seconds / 60);
-   if (interval > 1) return `${interval} mins ago`;
-
-   return `${Math.floor(seconds)} secs ago`;
-};
-
-/**
  * Returns a Keyword's position change value by comparing the current position with previous position.
  * @param {KeywordHistory} history - Keywords to scrape
  * @param {number} position - Keywords to scrape
@@ -166,7 +140,6 @@ const generateEmail = async (domain:DomainType, keywords:KeywordType[], settings
                            <td>${locationText ? `(${locationText})` : ''}</td>
                            <td>${keyword.position}${posChangeIcon}</td>
                            <td>${getBestKeywordPosition(keyword.history)}</td>
-                           <td>${timeSince(new Date(keyword.lastUpdated).getTime() / 1000)}</td>
                         </tr>`;
    });
 


### PR DESCRIPTION
## Summary
- remove the Updated column from the keyword notification table and rebalance the remaining columns
- update the tracker summary header styling to match the rest of the email headers

## Testing
- npm test -- --runTestsByPath __tests__/utils/generateEmail.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc6f67c118832a9d5e010e2d6f38be