### PR TITLE
Refine ValueSerp parameter handling

### DIFF
--- a/__tests__/scrapers/valueserp.test.ts
+++ b/__tests__/scrapers/valueserp.test.ts
@@ -45,14 +45,16 @@ describe('valueSerp scraper', () => {
     expect(parsed.origin).toBe('https://api.valueserp.com');
     expect(parsed.pathname).toBe('/search');
     expect(parsed.searchParams.get('q')).toBe(keyword.keyword);
-    expect(parsed.searchParams.get('gl')).toBe('US');
+    expect(parsed.searchParams.get('gl')).toBe('us');
     expect(parsed.searchParams.get('hl')).toBe('en');
     expect(parsed.searchParams.get('device')).toBe('mobile');
     expect(parsed.searchParams.get('location')).toBe('Miami,FL,United States');
     expect(parsed.searchParams.get('output')).toBe('json');
     expect(parsed.searchParams.get('include_answer_box')).toBe('false');
     expect(parsed.searchParams.get('include_advertiser_info')).toBe('false');
+    expect(parsed.searchParams.get('google_domain')).toBe('google.com');
     expect(parsed.searchParams.has('num')).toBe(false);
+    expect(parsed.toString()).toContain('q=best+coffee+beans');
   });
 
   it('has a timeout override of 35 seconds to handle longer response times', () => {

--- a/scrapers/services/valueserp.ts
+++ b/scrapers/services/valueserp.ts
@@ -21,10 +21,27 @@ const valueSerp:ScraperSettings = {
       const countryName = countries[country][0];
       const { city, state } = parseLocation(keyword.location, keyword.country);
       const locationParts = [city, state, countryName].filter(Boolean);
-      const location = city || state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
-      const device = keyword.device === 'mobile' ? '&device=mobile' : '';
       const lang = countryData[country][2];
-      return `https://api.valueserp.com/search?api_key=${settings.scraping_api}&q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}${device}${location}&output=json&include_answer_box=false&include_advertiser_info=false`;
+
+      const params = new URLSearchParams();
+      params.set('api_key', settings.scraping_api ?? '');
+      params.set('q', keyword.keyword);
+      params.set('gl', country.toLowerCase());
+      params.set('hl', lang);
+      params.set('output', 'json');
+      params.set('include_answer_box', 'false');
+      params.set('include_advertiser_info', 'false');
+      params.set('google_domain', 'google.com');
+
+      if (keyword.device === 'mobile') {
+         params.set('device', 'mobile');
+      }
+
+      if (locationParts.length) {
+         params.set('location', locationParts.join(','));
+      }
+
+      return `https://api.valueserp.com/search?${params.toString()}`;
    },
    resultObjectKey: 'organic_results',
    supportsMapPack: true,


### PR DESCRIPTION
## Summary
- build ValueSerp search URLs with URLSearchParams to ensure proper encoding and lowercase geolocation settings
- add the google.com domain parameter while preserving conditional device and location options
- extend the ValueSerp scraper test to cover the new query string expectations

## Testing
- npm test -- __tests__/scrapers/valueserp.test.ts
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9bad91a4832a9766ecd3eca2190f