### PR TITLE
Ensure secure cookie handling for login

### DIFF
--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -72,13 +72,12 @@ const loginUser = async (req: NextApiRequest, res: NextApiResponse<loginResponse
    if (username === userName && password === process.env.PASSWORD) {
       try {
          const token = jwt.sign({ user: userName }, process.env.SECRET);
-         const cookies = new Cookies(req, res);
+         const secureCookie = isRequestSecure(req);
+         const cookies = new Cookies(req, res, { secure: secureCookie });
          const parsedDuration = Number.parseInt(process.env.SESSION_DURATION ?? '', 10);
          const sessionDurationHours = Number.isFinite(parsedDuration) && parsedDuration > 0 ? parsedDuration : 24;
          const sessionDurationMs = sessionDurationHours * 60 * 60 * 1000;
          const expiryDate = new Date(Date.now() + sessionDurationMs);
-         
-         const secureCookie = isRequestSecure(req);
 
          cookies.set('token', token, {
             httpOnly: true,


### PR DESCRIPTION
## Summary
- instantiate the login API cookie helper with the secure flag derived from request context
- extend login API tests to assert the constructor receives the correct secure configuration for HTTP and HTTPS scenarios

## Testing
- npm test -- __tests__/api/login.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dda429a810832aae8bf3186a4c06f5