### PR TITLE
Add location query support to Serper scraper

### DIFF
--- a/__tests__/scrapers/serper.test.ts
+++ b/__tests__/scrapers/serper.test.ts
@@ -1,0 +1,53 @@
+import serper from '../../scrapers/services/serper';
+
+describe('serper scraper', () => {
+  const settings: Partial<SettingsType> = { scraping_api: 'secret-token' };
+  const countryData = {
+    US: ['United States', 'Washington, D.C.', 'en', 2840],
+    CA: ['Canada', 'Ottawa', 'en', 2392],
+  } as any;
+
+  it('appends the encoded location parameter when city and state are provided', () => {
+    const keyword: Partial<KeywordType> = {
+      keyword: 'plumber near me',
+      country: 'US',
+      location: 'Austin,TX,US',
+    };
+
+    const url = serper.scrapeURL!(
+      keyword as KeywordType,
+      settings as SettingsType,
+      countryData
+    );
+
+    const parsed = new URL(url);
+
+    expect(parsed.origin).toBe('https://google.serper.dev');
+    expect(parsed.pathname).toBe('/search');
+    expect(parsed.searchParams.get('q')).toBe(keyword.keyword);
+    expect(parsed.searchParams.get('gl')).toBe('US');
+    expect(parsed.searchParams.get('hl')).toBe('en');
+    expect(parsed.searchParams.get('location')).toBe('Austin,TX,United States');
+    expect(parsed.searchParams.get('apiKey')).toBe(settings.scraping_api);
+  });
+
+  it('does not emit console.log output when generating the URL', () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const keyword: Partial<KeywordType> = {
+      keyword: 'coffee roasters',
+      country: 'CA',
+      location: 'Toronto,ON,CA',
+    };
+
+    serper.scrapeURL!(
+      keyword as KeywordType,
+      settings as SettingsType,
+      countryData
+    );
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/scrapers/services/serper.ts
+++ b/scrapers/services/serper.ts
@@ -1,4 +1,5 @@
 import { resolveCountryCode } from '../../utils/scraperHelpers';
+import { parseLocation } from '../../utils/location';
 import { computeMapPackTop3 } from '../../utils/mapPack';
 
 interface SerperResult {
@@ -13,10 +14,21 @@ const serper:ScraperSettings = {
    website: 'serper.dev',
    allowsCity: true,
    scrapeURL: (keyword, settings, countryData) => {
-      const country = resolveCountryCode(keyword.country);
-      const lang = countryData[country][2];
-      console.log('Serper URL :', `https://google.serper.dev/search?q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}&num=100&apiKey=${settings.scraping_api}`);
-      return `https://google.serper.dev/search?q=${encodeURIComponent(keyword.keyword)}&gl=${country}&hl=${lang}&num=100&apiKey=${settings.scraping_api}`;
+      const countryCode = resolveCountryCode(keyword.country);
+      const normalizedCountry = countryCode.toUpperCase();
+      const gl = countryCode || normalizedCountry;
+      const fallbackInfo = countryData[normalizedCountry]
+         ?? countryData.US
+         ?? Object.values(countryData)[0];
+      const lang = fallbackInfo?.[2] ?? 'en';
+      const countryName = fallbackInfo?.[0];
+      const { city, state } = parseLocation(keyword.location, keyword.country);
+      const hasCityOrState = Boolean(city || state);
+      const location = hasCityOrState && countryName
+         ? `&location=${encodeURIComponent([city, state, countryName].filter(Boolean).join(','))}`
+         : '';
+
+      return `https://google.serper.dev/search?q=${encodeURIComponent(keyword.keyword)}&gl=${gl}&hl=${lang}&num=100${location}&apiKey=${settings.scraping_api}`;
    },
    resultObjectKey: 'organic',
    supportsMapPack: true,


### PR DESCRIPTION
## Summary
- remove the Serper debug logging that exposed the API key
- build the Serper request URL with encoded location metadata when city/state data is provided
- add Jest tests covering URL construction and ensuring no console logging occurs

## Testing
- npm test -- serper
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda583bf6c832a9827f61ee73a3a62