### PR TITLE
Ensure scrapers handle unsupported countries gracefully

### DIFF
--- a/__tests__/scrapers/scrapingrobot.test.ts
+++ b/__tests__/scrapers/scrapingrobot.test.ts
@@ -27,4 +27,29 @@ describe('scrapingRobot scraper', () => {
     expect(googleUrlParsed.searchParams.get('gl')).toBe('US');
     expect(googleUrlParsed.searchParams.get('q')).toBe(keyword.keyword);
   });
+
+  it('falls back gracefully when provided an unknown country', () => {
+    const keyword = {
+      keyword: 'best coffee beans',
+      country: 'zz',
+      device: 'desktop',
+    } as any;
+    const settings = { scraping_api: 'token-123' } as any;
+    const countryData = {
+      US: ['United States', 'Washington, D.C.', 'en', 2840],
+    } as any;
+
+    const url = scrapingRobot.scrapeURL(keyword, settings, countryData);
+
+    const scrapingRobotUrl = new URL(url);
+    expect(scrapingRobotUrl.searchParams.get('proxyCountry')).toBe('US');
+
+    const googleUrlEncoded = scrapingRobotUrl.searchParams.get('url');
+    expect(googleUrlEncoded).not.toBeNull();
+
+    const googleUrlDecoded = decodeURIComponent(googleUrlEncoded!);
+    const googleUrlParsed = new URL(googleUrlDecoded);
+    expect(googleUrlParsed.searchParams.get('gl')).toBe('US');
+    expect(googleUrlParsed.searchParams.get('hl')).toBe('en');
+  });
 });

--- a/__tests__/utils/scraperHelpers.test.ts
+++ b/__tests__/utils/scraperHelpers.test.ts
@@ -1,0 +1,23 @@
+import { resolveCountryCode } from '../../utils/scraperHelpers';
+
+describe('resolveCountryCode', () => {
+   it('uppercases valid country codes', () => {
+      expect(resolveCountryCode('us')).toBe('US');
+   });
+
+   it('falls back to default for unsupported codes without allowed list', () => {
+      expect(resolveCountryCode('ZZ')).toBe('US');
+   });
+
+   it('uses provided fallback when valid', () => {
+      expect(resolveCountryCode('zz', undefined, 'gb')).toBe('GB');
+   });
+
+   it('prefers fallback when allowed countries provided and contains fallback', () => {
+      expect(resolveCountryCode('zz', ['US', 'CA'], 'us')).toBe('US');
+   });
+
+   it('falls back to first valid allowed country when fallback is not permitted', () => {
+      expect(resolveCountryCode('zz', ['DE', 'FR'], 'BR')).toBe('DE');
+   });
+});

--- a/scrapers/services/hasdata.ts
+++ b/scrapers/services/hasdata.ts
@@ -20,7 +20,8 @@ const hasdata:ScraperSettings = {
       }),
    scrapeURL: (keyword, _settings) => {
       const country = resolveCountryCode(keyword.country);
-      const countryName = countries[country][0];
+      const countryInfo = countries[country] ?? countries.US;
+      const countryName = countryInfo?.[0] ?? countries.US[0];
       const { city, state } = parseLocation(keyword.location, keyword.country);
       const locationParts = [city, state, countryName].filter(Boolean);
       const location = city || state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';

--- a/scrapers/services/scrapingant.ts
+++ b/scrapers/services/scrapingant.ts
@@ -12,7 +12,8 @@ const scrapingAnt:ScraperSettings = {
    scrapeURL: (keyword: KeywordType, settings: SettingsType, countryData: countryData) => {
       const scraperCountries = ['AE', 'BR', 'CN', 'DE', 'ES', 'FR', 'GB', 'HK', 'PL', 'IN', 'IT', 'IL', 'JP', 'NL', 'RU', 'SA', 'US', 'CZ'];
       const country = resolveCountryCode(keyword.country, scraperCountries);
-      const lang = countryData[country][2];
+      const localeInfo = countryData[country] ?? countryData.US ?? Object.values(countryData)[0];
+      const lang = localeInfo?.[2] ?? 'en';
       const url = encodeURI(`https://www.google.com/search?num=100&hl=${lang}&q=${keyword.keyword}`);
       return `https://api.scrapingant.com/v2/extended?url=${url}&x-api-key=${settings.scraping_api}&proxy_country=${country}&browser=false`;
    },

--- a/scrapers/services/scrapingrobot.ts
+++ b/scrapers/services/scrapingrobot.ts
@@ -7,8 +7,9 @@ const scrapingRobot:ScraperSettings = {
    supportsMapPack: false,
    scrapeURL: (keyword, settings, countryData) => {
       const country = resolveCountryCode(keyword.country);
+      const localeInfo = countryData[country] ?? countryData.US ?? Object.values(countryData)[0];
       const device = keyword.device === 'mobile' ? '&mobile=true' : '';
-      const lang = countryData[country][2];
+      const lang = localeInfo?.[2] ?? 'en';
       const googleUrl = new URL('https://www.google.com/search');
       googleUrl.searchParams.set('num', '100');
       googleUrl.searchParams.set('hl', lang);

--- a/scrapers/services/searchapi.ts
+++ b/scrapers/services/searchapi.ts
@@ -21,7 +21,8 @@ const searchapi:ScraperSettings = {
      }),
   scrapeURL: (keyword) => {
    const country = resolveCountryCode(keyword.country);
-   const countryName = countries[country][0];
+   const countryInfo = countries[country] ?? countries.US;
+   const countryName = countryInfo?.[0] ?? countries.US[0];
    const { city, state } = parseLocation(keyword.location, keyword.country);
    const locationParts = [city, state, countryName].filter(Boolean);
    const location = city || state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';

--- a/scrapers/services/serpapi.ts
+++ b/scrapers/services/serpapi.ts
@@ -21,7 +21,8 @@ const serpapi:ScraperSettings = {
       }),
    scrapeURL: (keyword, settings) => {
       const country = resolveCountryCode(keyword.country);
-      const countryName = countries[country][0];
+      const countryInfo = countries[country] ?? countries.US;
+      const countryName = countryInfo?.[0] ?? countries.US[0];
       const { city, state } = parseLocation(keyword.location, keyword.country);
       const locationParts = [city, state, countryName].filter(Boolean);
       const location = city || state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';

--- a/scrapers/services/serper.ts
+++ b/scrapers/services/serper.ts
@@ -15,11 +15,10 @@ const serper:ScraperSettings = {
    allowsCity: true,
    scrapeURL: (keyword, settings, countryData) => {
       const countryCode = resolveCountryCode(keyword.country);
-      const normalizedCountry = countryCode.toUpperCase();
-      const gl = countryCode || normalizedCountry;
-      const fallbackInfo = countryData[normalizedCountry]
+      const fallbackInfo = countryData[countryCode]
          ?? countryData.US
          ?? Object.values(countryData)[0];
+      const gl = countryCode;
       const lang = fallbackInfo?.[2] ?? 'en';
       const countryName = fallbackInfo?.[0];
       const { city, state } = parseLocation(keyword.location, keyword.country);

--- a/scrapers/services/spaceserp.ts
+++ b/scrapers/services/spaceserp.ts
@@ -17,12 +17,14 @@ const spaceSerp:ScraperSettings = {
    allowsCity: true,
    scrapeURL: (keyword, settings, countryData) => {
       const country = resolveCountryCode(keyword.country);
-      const countryName = countries[country][0];
+      const countryInfo = countries[country] ?? countries.US;
+      const countryName = countryInfo?.[0] ?? countries.US[0];
       const { city, state } = parseLocation(keyword.location, keyword.country);
       const locationParts = [city, state, countryName].filter(Boolean);
       const location = city || state ? `&location=${encodeURIComponent(locationParts.join(','))}` : '';
       const device = keyword.device === 'mobile' ? '&device=mobile' : '';
-      const lang = countryData[country][2];
+      const localeInfo = countryData[country] ?? countryData.US ?? Object.values(countryData)[0];
+      const lang = localeInfo?.[2] ?? 'en';
       return `https://api.spaceserp.com/google/search?apiKey=${settings.scraping_api}&q=${encodeURIComponent(keyword.keyword)}&pageSize=100&gl=${country}&hl=${lang}${location}${device}&resultBlocks=`;
    },
    resultObjectKey: 'organic_results',

--- a/scrapers/services/valueserp.ts
+++ b/scrapers/services/valueserp.ts
@@ -19,11 +19,13 @@ const valueSerp:ScraperSettings = {
    timeoutMs: 35000, // ValueSerp responses often take longer, allow 35 seconds
    scrapeURL: (keyword, settings, countryData) => {
       const resolvedCountry = resolveCountryCode(keyword.country);
-      const country = resolvedCountry.toUpperCase();
-      const countryName = countries[country]?.[0] ?? countries.US[0];
+      const country = resolvedCountry;
+      const countryInfo = countries[country] ?? countries.US;
+      const countryName = countryInfo?.[0] ?? countries.US[0];
       const { city, state } = parseLocation(keyword.location, keyword.country);
       const locationParts = [city, state, countryName].filter(Boolean);
-      const lang = (countryData[country] ?? countryData.US)[2];
+      const localeInfo = countryData[country] ?? countryData.US ?? Object.values(countryData)[0];
+      const lang = localeInfo?.[2] ?? 'en';
       const googleDomain = getGoogleDomain(country);
       const params = new URLSearchParams();
      

--- a/utils/scraperHelpers.ts
+++ b/utils/scraperHelpers.ts
@@ -1,3 +1,5 @@
+import countries from './countries';
+
 /**
  * Resolves country code with fallback logic
  * @param {string} country - the country code to validate
@@ -5,18 +7,43 @@
  * @param {string} fallback - fallback country code (defaults to 'US')
  * @returns {string} - resolved country code
  */
+const isSupportedCountry = (code: string): boolean => {
+   const countryInfo = countries[code];
+   return Boolean(countryInfo && countryInfo[0] && countryInfo[0] !== 'Unknown');
+};
+
 export const resolveCountryCode = (
-   country: string = '', 
-   allowedCountries?: string[], 
+   country: string = '',
+   allowedCountries?: string[],
    fallback: string = 'US'
 ): string => {
-   if (!country) {
-      return fallback;
+   const normalizedFallback = (fallback || 'US').toUpperCase();
+   const fallbackIsValid = isSupportedCountry(normalizedFallback);
+   const safeFallback = fallbackIsValid ? normalizedFallback : 'US';
+
+   const hasAllowedCountries = Array.isArray(allowedCountries) && allowedCountries.length > 0;
+   const normalizedAllowed = hasAllowedCountries
+      ? new Set(allowedCountries.map((code) => code.toUpperCase()))
+      : null;
+
+   const normalizedCountry = (country || '').toUpperCase();
+   const countryIsValid = Boolean(normalizedCountry && isSupportedCountry(normalizedCountry));
+
+   if (countryIsValid && (!normalizedAllowed || normalizedAllowed.has(normalizedCountry))) {
+      return normalizedCountry;
    }
-   
-   if (allowedCountries && allowedCountries.length > 0) {
-      return allowedCountries.includes(country.toUpperCase()) ? country : fallback;
+
+   if (normalizedAllowed?.has(safeFallback)) {
+      return safeFallback;
    }
-   
-   return country;
+
+   if (normalizedAllowed) {
+      for (const code of normalizedAllowed) {
+         if (isSupportedCountry(code)) {
+            return code;
+         }
+      }
+   }
+
+   return safeFallback;
 };


### PR DESCRIPTION
## Summary
- normalize and validate country codes in `resolveCountryCode`, honoring fallbacks when locales are missing
- harden scraper URL builders to rely on sanitized country data and guard their locale lookups
- add unit tests for the resolver and a scrapingrobot regression case covering unsupported countries

## Testing
- npm test -- --runTestsByPath __tests__/utils/scraperHelpers.test.ts __tests__/scrapers/scrapingrobot.test.ts
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dda989e6a8832a97ada2bde66b59ee