### PR TITLE
Fix Serper map pack flag

### DIFF
--- a/scrapers/services/serper.ts
+++ b/scrapers/services/serper.ts
@@ -58,7 +58,7 @@ const serper: ScraperSettings = {
       }
     }
 
-    return { organic: extractedResult, mapPackTop3: [] }; //
+    return { organic: extractedResult, mapPackTop3: false };
   },
 };
 


### PR DESCRIPTION
## Summary
- ensure the Serper scraper returns a boolean map pack flag instead of an empty array

## Testing
- npm run lint
- npm test
- npm run build *(fails: Next.js build cannot find generated domain console/ideas pages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbbadbd4c832a91cafd01a14c59f1