### PR TITLE
Adjust keyword email table column layout

### DIFF
--- a/email/email.html
+++ b/email/email.html
@@ -351,23 +351,28 @@
       }
       .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(2){
          font-weight: bold;
+         padding-right: 16px;
+         width: 240px;
       }
       .keyword_table:not(.keyword_table--sc) th:nth-child(3),
-      .keyword_table:not(.keyword_table--sc) th:nth-child(4),
-      .keyword_table:not(.keyword_table--sc) th:nth-child(5),
-      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(3),
-      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4),
-      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(5){
-         text-align: center;
+      .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(3){
+         text-align: left;
       }
       .keyword_table:not(.keyword_table--sc) th:nth-child(4),
-      .keyword_table:not(.keyword_table--sc) th:nth-child(5),
+      .keyword_table:not(.keyword_table--sc) th:nth-child(5){
+         font-size: 12px;
+         padding: 0 4px 10px;
+         text-align: right;
+         width: 70px;
+      }
       .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4),
       .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(5){
-         width: 90px;
+         font-size: 12px;
+         padding: 10px 4px;
+         text-align: right;
+         width: 70px;
       }
       .keyword_table:not(.keyword_table--sc) .keyword td:nth-child(4){
-         font-size: 12px;
          color: #888;
       }
       .keyword_table--sc th:first-child,


### PR DESCRIPTION
## Summary
- left-align the email keyword table location column while right-aligning position metrics
- tighten the position and best columns and expand keyword spacing for clearer layout

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df9893759c832a90ad2dbecc7dd02b