### PR TITLE
Fetch branding config at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ All runtime behaviour is controlled through environment variables. The tables be
 | `WHITE_LABEL_LOGO_FILE` | `branding-logo.png` | Optional | File name under `/app/data` for the custom logo. Use a 96×96px PNG, SVG, or WEBP asset for best results. |
 | `NEXT_PUBLIC_PLATFORM_NAME` | `SerpBear` | Optional | Display name for the application and notification emails in white-label mode. |
 
+> **Runtime branding.** Changes to `NEXT_PUBLIC_WHITE_LABEL`, `NEXT_PUBLIC_PLATFORM_NAME`, or your logo asset are loaded on-demand by the UI. Update the environment values or files and refresh the browser—no container rebuild is required.
+
 ### Google integrations
 
 | Variable | Default | Required | Description |

--- a/__mocks__/data.ts
+++ b/__mocks__/data.ts
@@ -1,6 +1,6 @@
-import { getBranding } from '../utils/branding';
+import { DEFAULT_BRANDING } from '../utils/branding';
 
-const { platformName } = getBranding();
+const { platformName } = DEFAULT_BRANDING;
 
 export const dummyDomain = {
    ID: 1,

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -1,25 +1,52 @@
 import { render, screen } from '@testing-library/react';
 import Footer from '../../components/common/Footer';
-import { getBranding } from '../../utils/branding';
+import { DEFAULT_BRANDING, BrandingConfig } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 
-const { platformName } = getBranding();
+jest.mock('../../hooks/useBranding');
 
-const footerMatcher = (version: string) => (_: string, element?: Element | null) =>
-   element?.tagName === 'SPAN' &&
-   element.textContent?.replace(/\s+/g, ' ').trim() === `${platformName} v${version} by Vontainment`;
+const mockUseBranding = useBranding as jest.MockedFunction<typeof useBranding>;
+
+const buildState = (branding: BrandingConfig) => ({
+   branding,
+   isLoading: false,
+   isError: false,
+   isFetching: false,
+   refetch: jest.fn(),
+});
 
 describe('Footer component', () => {
+   beforeEach(() => {
+      mockUseBranding.mockReturnValue(buildState(DEFAULT_BRANDING));
+   });
+
+   afterEach(() => {
+      jest.clearAllMocks();
+   });
+
+   const footerMatcher = (platformName: string, version: string) => (
+      (_: string, element?: Element | null) => element?.tagName === 'SPAN'
+         && element.textContent?.replace(/\s+/g, ' ').trim() === `${platformName} v${version} by Vontainment`
+   );
+
    it('renders the default version with a Vontainment link', () => {
       render(<Footer currentVersion='' />);
-      expect(screen.getByText(footerMatcher('3.0.0'))).toBeVisible();
+      expect(screen.getByText(footerMatcher(DEFAULT_BRANDING.platformName, '3.0.0'))).toBeVisible();
       const link = screen.getByRole('link', { name: 'Vontainment' });
       expect(link).toHaveAttribute('href', 'https://vontainment.com');
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('rel', 'noopener noreferrer');
    });
 
-   it('renders a provided version number', () => {
+   it('renders a provided version number and custom platform name', () => {
+      const customBranding: BrandingConfig = {
+         ...DEFAULT_BRANDING,
+         whiteLabelEnabled: true,
+         platformName: 'Acme Rank',
+      };
+      mockUseBranding.mockReturnValue(buildState(customBranding));
+
       render(<Footer currentVersion='9.9.9' />);
-      expect(screen.getByText(footerMatcher('9.9.9'))).toBeVisible();
+      expect(screen.getByText(footerMatcher('Acme Rank', '9.9.9'))).toBeVisible();
    });
 });

--- a/__tests__/components/Settings.test.tsx
+++ b/__tests__/components/Settings.test.tsx
@@ -5,12 +5,16 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import Settings, { defaultSettings } from '../../components/settings/Settings';
 import { useClearFailedQueue, useFetchSettings, useUpdateSettings } from '../../services/settings';
+import { useBranding } from '../../hooks/useBranding';
+import { DEFAULT_BRANDING } from '../../utils/branding';
 
 jest.mock('../../services/settings');
+jest.mock('../../hooks/useBranding');
 
 const useFetchSettingsMock = useFetchSettings as jest.Mock;
 const useUpdateSettingsMock = useUpdateSettings as jest.Mock;
 const useClearFailedQueueMock = useClearFailedQueue as jest.Mock;
+const mockUseBranding = useBranding as jest.MockedFunction<typeof useBranding>;
 
 describe('Settings scraper reload behaviour', () => {
    const closeSettings = jest.fn();
@@ -23,6 +27,13 @@ describe('Settings scraper reload behaviour', () => {
 
    beforeEach(() => {
       queryClient = new QueryClient();
+      mockUseBranding.mockReturnValue({
+         branding: DEFAULT_BRANDING,
+         isLoading: false,
+         isError: false,
+         isFetching: false,
+         refetch: jest.fn(),
+      });
       const settingsData: SettingsType = {
          ...defaultSettings,
          notification_interval: 'never',

--- a/__tests__/components/Sidebar.test.tsx
+++ b/__tests__/components/Sidebar.test.tsx
@@ -1,17 +1,34 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import Sidebar from '../../components/common/Sidebar';
 import { dummyDomain } from '../../__mocks__/data';
-import { getBranding } from '../../utils/branding';
-
-const { platformName } = getBranding();
+import { DEFAULT_BRANDING } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 
 const addDomainMock = jest.fn();
+
+jest.mock('../../hooks/useBranding');
 jest.mock('next/router', () => jest.requireActual('next-router-mock'));
 
+const mockUseBranding = useBranding as jest.MockedFunction<typeof useBranding>;
+
 describe('Sidebar Component', () => {
+   beforeEach(() => {
+      mockUseBranding.mockReturnValue({
+         branding: DEFAULT_BRANDING,
+         isLoading: false,
+         isError: false,
+         isFetching: false,
+         refetch: jest.fn(),
+      });
+   });
+
+   afterEach(() => {
+      jest.clearAllMocks();
+   });
+
    it('renders without crashing', async () => {
        render(<Sidebar domains={[dummyDomain]} showAddModal={addDomainMock} />);
-       expect(screen.getByText(platformName)).toBeInTheDocument();
+       expect(screen.getByText(DEFAULT_BRANDING.platformName)).toBeInTheDocument();
    });
    it('renders domain list', async () => {
       render(<Sidebar domains={[dummyDomain]} showAddModal={addDomainMock} />);

--- a/__tests__/pages/domains.test.tsx
+++ b/__tests__/pages/domains.test.tsx
@@ -4,9 +4,12 @@ import * as ReactQuery from 'react-query';
 import { dummyDomain } from '../../__mocks__/data';
 import Domains from '../../pages/domains';
 import router from 'next-router-mock';
-import { getBranding } from '../../utils/branding';
+import { DEFAULT_BRANDING } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 
-const { platformName } = getBranding();
+jest.mock('../../hooks/useBranding');
+
+const mockUseBranding = useBranding as jest.MockedFunction<typeof useBranding>;
 
 // Mock the useAuth hook to always return authenticated state
 jest.mock('../../hooks/useAuth', () => ({
@@ -33,9 +36,9 @@ const asUrlString = (input: RequestInfo | URL): string => {
    return String(input);
 };
 
-const footerTextMatcher = (version: string) => (_: string, element?: Element | null) =>
-   element?.tagName === 'SPAN' &&
-   element.textContent?.replace(/\s+/g, ' ').includes(`${platformName} v${version} by Vontainment`);
+const footerTextMatcher = (version: string, platformName = DEFAULT_BRANDING.platformName) => (_: string, element?: Element | null) =>
+   element?.tagName === 'SPAN'
+   && element.textContent?.replace(/\s+/g, ' ').includes(`${platformName} v${version} by Vontainment`);
 
 function createJsonResponse<T>(payload: T, status = 200): Response {
    return {
@@ -91,6 +94,13 @@ afterAll(() => {
 
 beforeEach(() => {
    router.isReady = true;
+   mockUseBranding.mockReturnValue({
+      branding: DEFAULT_BRANDING,
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+      refetch: jest.fn(),
+   });
    useQuerySpy.mockImplementation(buildUseQueryImplementation());
    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = asUrlString(input);

--- a/components/common/Branding.tsx
+++ b/components/common/Branding.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Image from 'next/image';
 import Icon from './Icon';
-import { getBranding, buildLogoUrl } from '../../utils/branding';
+import { buildLogoUrl } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 
 type BrandMarkProps = {
    size?: number;
@@ -18,8 +19,9 @@ type BrandTitleProps = {
 const DEFAULT_MARK_CLASS = 'relative top-[3px] mr-1';
 
 export const BrandMark: React.FC<BrandMarkProps> = ({ size = 24, className = '' }) => {
-   const { hasCustomLogo, platformName } = getBranding();
-   const logoUrl = buildLogoUrl();
+   const { branding } = useBranding();
+   const { hasCustomLogo, platformName } = branding;
+   const logoUrl = buildLogoUrl(branding);
    const wrapperClassName = ['inline-flex items-center', className].filter(Boolean).join(' ');
 
    if (hasCustomLogo && logoUrl) {
@@ -50,7 +52,8 @@ export const BrandTitle: React.FC<BrandTitleProps> = ({
    markClassName = DEFAULT_MARK_CLASS,
    markSize = 24,
 }) => {
-   const { platformName } = getBranding();
+   const { branding } = useBranding();
+   const { platformName } = branding;
    const titleClassName = ['inline-flex items-center', className].filter(Boolean).join(' ');
 
    return (
@@ -60,4 +63,3 @@ export const BrandTitle: React.FC<BrandTitleProps> = ({
       </span>
    );
 };
-

--- a/components/common/Footer.tsx
+++ b/components/common/Footer.tsx
@@ -1,12 +1,14 @@
-import { getBranding } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 
 interface FooterProps {
    currentVersion: string
 }
 
-const { platformName } = getBranding();
+const Footer = ({ currentVersion = '' }: FooterProps) => {
+   const { branding } = useBranding();
+   const { platformName } = branding;
 
-const Footer = ({ currentVersion = '' }: FooterProps) => (
+   return (
       <footer className='text-center flex flex-1 justify-center pb-5 items-end'>
          <span className='text-gray-500 text-xs'>
             {platformName} v{currentVersion || '3.0.0'} by{' '}
@@ -21,5 +23,6 @@ const Footer = ({ currentVersion = '' }: FooterProps) => (
          </span>
       </footer>
    );
+};
 
 export default Footer;

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -7,7 +7,7 @@ import InputField from '../common/InputField';
 import Icon from '../common/Icon';
 import { useSendNotifications } from '../../services/settings';
 import { hasTrimmedLength } from '../../utils/security';
-import { getBranding } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 
 type NotificationSettingsProps = {
    settings: SettingsType,
@@ -20,7 +20,8 @@ type NotificationSettingsProps = {
 
 const NotificationSettings = ({ settings, settingsError, updateSettings }:NotificationSettingsProps) => {
    const { mutate: triggerNotifications, isLoading: sendingNotifications } = useSendNotifications();
-   const { platformName } = getBranding();
+   const { branding } = useBranding();
+   const { platformName } = branding;
 
    const sanitizedNotificationEmails = (settings.notification_email || '')
       .split(',')

--- a/components/settings/Settings.tsx
+++ b/components/settings/Settings.tsx
@@ -7,7 +7,8 @@ import NotificationSettings from './NotificationSettings';
 import ScraperSettings from './ScraperSettings';
 import useOnKey from '../../hooks/useOnKey';
 import IntegrationSettings from './IntegrationSettings';
-import { getBranding } from '../../utils/branding';
+import { DEFAULT_BRANDING } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 
 type SettingsProps = {
    closeSettings: Function,
@@ -19,9 +20,7 @@ type SettingsError = {
    msg: string
 }
 
-const { platformName } = getBranding();
-
-export const defaultSettings: SettingsType = {
+export const createDefaultSettings = (platformName: string): SettingsType => ({
    scraper_type: 'none',
    scrape_delay: 'none',
    scrape_retry: false,
@@ -38,9 +37,12 @@ export const defaultSettings: SettingsType = {
    search_console_client_email: '',
    search_console_private_key: '',
    keywordsColumns: ['Best', 'History', 'Volume', 'Search Console'],
-};
+});
+
+export const defaultSettings: SettingsType = createDefaultSettings(DEFAULT_BRANDING.platformName);
 
 const Settings = ({ closeSettings }:SettingsProps) => {
+   const { branding } = useBranding();
    const [currentTab, setCurrentTab] = useState<string>('scraper');
    const [settings, setSettings] = useState<SettingsType>(defaultSettings);
    const [settingsError, setSettingsError] = useState<SettingsError|null>(null);
@@ -53,6 +55,21 @@ const Settings = ({ closeSettings }:SettingsProps) => {
          setSettings(appSettings.settings);
       }
    }, [appSettings]);
+
+   useEffect(() => {
+      if (!appSettings?.settings) {
+         setSettings((currentSettings) => {
+            if (currentSettings.notification_email_from_name === DEFAULT_BRANDING.platformName
+               && branding.platformName !== DEFAULT_BRANDING.platformName) {
+               return {
+                  ...currentSettings,
+                  notification_email_from_name: branding.platformName,
+               };
+            }
+            return currentSettings;
+         });
+      }
+   }, [appSettings?.settings, branding.platformName]);
 
    const closeOnBGClick = (e:React.SyntheticEvent) => {
       e.stopPropagation();

--- a/hooks/useBranding.ts
+++ b/hooks/useBranding.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { useQuery } from 'react-query';
+import type { BrandingConfig } from '../utils/branding';
+import { DEFAULT_BRANDING } from '../utils/branding';
+
+export const BRANDING_QUERY_KEY = ['branding-config'] as const;
+
+export const fetchBrandingConfig = async (): Promise<BrandingConfig> => {
+   const response = await fetch('/api/branding/config', {
+      headers: {
+         Accept: 'application/json',
+      },
+   });
+
+   if (!response.ok) {
+      throw new Error(`Failed to load branding config: ${response.status}`);
+   }
+
+   return response.json() as Promise<BrandingConfig>;
+};
+
+const isClient = typeof window !== 'undefined';
+
+export const useBranding = () => {
+   const queryResult = useQuery(BRANDING_QUERY_KEY, fetchBrandingConfig, {
+      enabled: isClient,
+      staleTime: Infinity,
+      cacheTime: Infinity,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+      refetchOnMount: false,
+      suspense: false,
+      placeholderData: DEFAULT_BRANDING,
+   });
+
+   const brandingState = useMemo(() => ({
+      branding: queryResult.data ?? DEFAULT_BRANDING,
+      isLoading: queryResult.isLoading && queryResult.isFetching,
+      isFetching: queryResult.isFetching,
+      isError: queryResult.isError,
+      refetch: queryResult.refetch,
+   }), [queryResult.data, queryResult.isError, queryResult.isFetching, queryResult.isLoading, queryResult.refetch]);
+
+   return brandingState;
+};
+
+export type UseBrandingReturn = ReturnType<typeof useBranding>;

--- a/pages/api/branding/config.ts
+++ b/pages/api/branding/config.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getBranding } from '../../../utils/branding';
+
+type BrandingResponse = ReturnType<typeof getBranding>;
+
+const handler = (req: NextApiRequest, res: NextApiResponse<BrandingResponse | { error: string }>) => {
+   if (req.method !== 'GET') {
+      res.setHeader('Allow', 'GET');
+      res.status(405).json({ error: 'Method Not Allowed' });
+      return;
+   }
+
+   const branding = getBranding();
+   res.setHeader('Cache-Control', 'no-store, max-age=0');
+   res.status(200).json(branding);
+};
+
+export default handler;

--- a/pages/api/ideas/email.ts
+++ b/pages/api/ideas/email.ts
@@ -8,8 +8,6 @@ import { trimStringProperties } from '../../../utils/security';
 import generateKeywordIdeasEmail, { KeywordIdeasEmailKeyword } from '../../../utils/generateKeywordIdeasEmail';
 import { getBranding } from '../../../utils/branding';
 
-const { platformName } = getBranding();
-
 type EmailKeywordIdeasRequest = {
    domain?: string;
    keywords?: KeywordIdeasEmailKeyword[];
@@ -71,6 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
 const emailKeywordIdeas = async (req: NextApiRequest, res: NextApiResponse<EmailKeywordIdeasResponse>) => {
    const body = (req.body || {}) as EmailKeywordIdeasRequest;
+   const { platformName } = getBranding();
    const targetDomain = trimString(body.domain);
    if (!targetDomain) {
       return res.status(400).json({ success: false, error: 'A domain is required to email keyword ideas.' });

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -14,8 +14,6 @@ import { getAppSettings } from './settings';
 import { trimStringProperties } from '../../utils/security';
 import { getBranding } from '../../utils/branding';
 
-const { platformName } = getBranding();
-
 type NotifyResponse = {
    success?: boolean
    error?: string|null,
@@ -120,6 +118,8 @@ const sendNotificationEmail = async (domain: DomainType | Domain, settings: Sett
       console.log(`[EMAIL_THROTTLE] Skipping email for ${domainName}: ${throttleCheck.reason}`);
       return;
    }
+
+   const { platformName } = getBranding();
 
    const {
       smtp_server = '',

--- a/pages/api/settings.ts
+++ b/pages/api/settings.ts
@@ -11,33 +11,34 @@ import { logger } from '../../utils/logger';
 import { trimStringProperties } from '../../utils/security';
 import { getBranding } from '../../utils/branding';
 
-const { platformName } = getBranding();
-
-const SETTINGS_DEFAULTS: SettingsType = {
-   scraper_type: 'none',
-   scraping_api: '',
-   proxy: '',
-   notification_interval: 'never',
-   notification_email: '',
-   notification_email_from: '',
-   notification_email_from_name: platformName,
-   smtp_server: '',
-   smtp_port: '',
-   smtp_tls_servername: '',
-   smtp_username: '',
-   smtp_password: '',
-   scrape_interval: '',
-   scrape_delay: '',
-   scrape_retry: false,
-   search_console: true,
-   search_console_client_email: '',
-   search_console_private_key: '',
-   adwords_client_id: '',
-   adwords_client_secret: '',
-   adwords_refresh_token: '',
-   adwords_developer_token: '',
-   adwords_account_id: '',
-   keywordsColumns: ['Best', 'History', 'Volume', 'Search Console'],
+const buildSettingsDefaults = (): SettingsType => {
+   const { platformName } = getBranding();
+   return {
+      scraper_type: 'none',
+      scraping_api: '',
+      proxy: '',
+      notification_interval: 'never',
+      notification_email: '',
+      notification_email_from: '',
+      notification_email_from_name: platformName,
+      smtp_server: '',
+      smtp_port: '',
+      smtp_tls_servername: '',
+      smtp_username: '',
+      smtp_password: '',
+      scrape_interval: '',
+      scrape_delay: '',
+      scrape_retry: false,
+      search_console: true,
+      search_console_client_email: '',
+      search_console_private_key: '',
+      adwords_client_id: '',
+      adwords_client_secret: '',
+      adwords_refresh_token: '',
+      adwords_developer_token: '',
+      adwords_account_id: '',
+      keywordsColumns: ['Best', 'History', 'Volume', 'Search Console'],
+   };
 };
 
 type SettingsGetResponse = {
@@ -146,7 +147,7 @@ export const getAppSettings = async () : Promise<SettingsType> => {
    try {
       const settingsRaw = await readFile(settingsPath, { encoding: 'utf-8' });
       const settings: Partial<SettingsType> = settingsRaw ? JSON.parse(settingsRaw) : {};
-      const baseSettings: SettingsType = { ...SETTINGS_DEFAULTS, ...settings };
+      const baseSettings: SettingsType = { ...buildSettingsDefaults(), ...settings };
       let decryptedSettings: SettingsType = baseSettings;
 
       try {
@@ -174,6 +175,8 @@ export const getAppSettings = async () : Promise<SettingsType> => {
       } catch (error) {
          console.log('Error Decrypting Settings API Keys!', error);
       }
+
+      const { platformName } = getBranding();
 
       const normalizedSettings: SettingsType = {
          ...decryptedSettings,
@@ -210,7 +213,7 @@ export const getAppSettings = async () : Promise<SettingsType> => {
       };
    } catch (error) {
       console.log('[ERROR] Getting App Settings. ', error);
-      const defaults = { ...SETTINGS_DEFAULTS };
+      const defaults = { ...buildSettingsDefaults() };
       await writeFile(settingsPath, JSON.stringify(defaults), { encoding: 'utf-8' });
       await writeFile(failedQueuePath, JSON.stringify([]), { encoding: 'utf-8' });
       return {

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -16,12 +16,12 @@ import { useFetchKeywords } from '../../../services/keywords';
 import { useFetchSettings } from '../../../services/settings';
 import AddKeywords from '../../../components/keywords/AddKeywords';
 import Footer from '../../../components/common/Footer';
-import { getBranding } from '../../../utils/branding';
-
-const { platformName } = getBranding();
+import { useBranding } from '../../../hooks/useBranding';
 
 const SingleDomain: NextPage = () => {
    const router = useRouter();
+   const { branding } = useBranding();
+   const { platformName } = branding;
    const [showAddKeywords, setShowAddKeywords] = useState(false);
    const [showAddDomain, setShowAddDomain] = useState(false);
    const [showDomainSettings, setShowDomainSettings] = useState(false);

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -17,14 +17,14 @@ import { useFetchSCKeywords } from '../../../../services/searchConsole';
 import SCKeywordsTable from '../../../../components/keywords/SCKeywordsTable';
 import { useFetchSettings } from '../../../../services/settings';
 import Footer from '../../../../components/common/Footer';
-import { getBranding } from '../../../../utils/branding';
+import { useBranding } from '../../../../hooks/useBranding';
 import AddKeywords from '../../../../components/keywords/AddKeywords';
 import { useFetchKeywords } from '../../../../services/keywords';
 
-const { platformName } = getBranding();
-
 const DiscoverPage: NextPage = () => {
    const router = useRouter();
+   const { branding } = useBranding();
+   const { platformName } = branding;
    const [showDomainSettings, setShowDomainSettings] = useState(false);
    const [showSettings, setShowSettings] = useState(false);
    const [showAddKeywords, setShowAddKeywords] = useState(false);

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -17,14 +17,14 @@ import { useFetchSCInsight } from '../../../../services/searchConsole';
 import SCInsight from '../../../../components/insight/Insight';
 import { useFetchSettings } from '../../../../services/settings';
 import Footer from '../../../../components/common/Footer';
-import { getBranding } from '../../../../utils/branding';
+import { useBranding } from '../../../../hooks/useBranding';
 import AddKeywords from '../../../../components/keywords/AddKeywords';
 import { useFetchKeywords } from '../../../../services/keywords';
 
-const { platformName } = getBranding();
-
 const InsightPage: NextPage = () => {
    const router = useRouter();
+   const { branding } = useBranding();
+   const { platformName } = branding;
    const [showDomainSettings, setShowDomainSettings] = useState(false);
    const [showSettings, setShowSettings] = useState(false);
    const [showAddKeywords, setShowAddKeywords] = useState(false);

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -13,14 +13,14 @@ import DomainItem from '../../components/domains/DomainItem';
 import Footer from '../../components/common/Footer';
 import { withAuth } from '../../hooks/useAuth';
 import PageLoader from '../../components/common/PageLoader';
-import { getBranding } from '../../utils/branding';
-
-const { platformName } = getBranding();
+import { useBranding } from '../../hooks/useBranding';
 
 type thumbImages = { [domain:string] : string }
 
 const Domains: NextPage = () => {
    const router = useRouter();
+   const { branding } = useBranding();
+   const { platformName } = branding;
    // const [noScrapprtError, setNoScrapprtError] = useState(false);
    const [showSettings, setShowSettings] = useState(false);
    const [showAddDomain, setShowAddDomain] = useState(false);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,12 +3,13 @@ import { useEffect } from 'react';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import Icon from '../components/common/Icon';
-import { getBranding } from '../utils/branding';
-
-const { platformName } = getBranding();
+import { useBranding } from '../hooks/useBranding';
 
 const Home: NextPage = () => {
    const router = useRouter();
+   const { branding } = useBranding();
+   const { platformName } = branding;
+
    useEffect(() => {
       if (router) router.push('/domains');
    }, [router]);

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -3,7 +3,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { BrandTitle } from '../../components/common/Branding';
-import { getBranding } from '../../utils/branding';
+import { useBranding } from '../../hooks/useBranding';
 import { getClientOrigin } from '../../utils/client/origin';
 
 type LoginError = {
@@ -11,13 +11,13 @@ type LoginError = {
    msg: string,
 }
 
-const { platformName } = getBranding();
-
 const Login: NextPage = () => {
    const [error, setError] = useState<LoginError|null>(null);
    const [username, setUsername] = useState<string>('');
    const [password, setPassword] = useState<string>('');
    const router = useRouter();
+   const { branding } = useBranding();
+   const { platformName } = branding;
 
    const loginuser = async () => {
       let loginError: LoginError |null = null;

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -14,12 +14,12 @@ import SelectField from '../../components/common/SelectField';
 import allCountries, { adwordsLanguages } from '../../utils/countries';
 import Footer from '../../components/common/Footer';
 import { BrandTitle } from '../../components/common/Branding';
-import { getBranding } from '../../utils/branding';
-
-const { platformName } = getBranding();
+import { useBranding } from '../../hooks/useBranding';
 
 const Research: NextPage = () => {
    const router = useRouter();
+   const { branding } = useBranding();
+   const { platformName } = branding;
    const [showSettings, setShowSettings] = useState(false);
    const [showFavorites, setShowFavorites] = useState(false);
    const [language, setLanguage] = useState('1000');


### PR DESCRIPTION
## Summary
- add a server API for branding metadata and expose a `useBranding` hook that fetches configuration at runtime
- migrate UI screens and settings defaults to consume the hook so logos, names, and email from names react to live environment changes
- update unit tests and documentation to reflect the runtime branding behaviour and mock the new client hook in component specs

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df9622d6c4832ab6ea0efde7100502