### PR TITLE
Align TopBar branding layout

### DIFF
--- a/components/common/TopBar.tsx
+++ b/components/common/TopBar.tsx
@@ -39,9 +39,15 @@ const TopBar = ({ showSettings, showAddModal }:TopbarProps) => {
        ${isDomainsPage ? 'lg:justify-between' : 'lg:justify-end'} bg-white lg:bg-transparent`}
       >
 
-         <h3 className={`p-4 text-base font-bold text-blue-700 ${isDomainsPage ? 'lg:pl-0' : 'lg:hidden'}`}>
-            <BrandTitle />
-            <button className='px-3 py-1 font-bold text-blue-700  lg:hidden ml-3 text-lg' onClick={() => showAddModal()}>+</button>
+         <h3
+            className={`flex items-center gap-3 p-4 text-base font-bold text-blue-700 ${isDomainsPage ? 'lg:pl-0' : 'lg:hidden'}`}
+         >
+            <BrandTitle
+               className="text-base font-bold text-blue-700"
+               markSize={64}
+               markClassName="mr-2"
+            />
+            <button className='px-3 py-1 font-bold text-blue-700 lg:hidden text-lg' onClick={() => showAddModal()}>+</button>
          </h3>
          {!isDomainsPage && router.asPath !== '/research' && (
             <Link


### PR DESCRIPTION
## Summary
- align the TopBar heading container with flex spacing so the logo, title, and mobile add button share a baseline
- enlarge the BrandTitle mark to 64px via explicit props while keeping the label vertically centered

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfa104c534832aa6f56f4c5f239a0a