### PR TITLE
Ensure logout cookies respect secure contexts

### DIFF
--- a/pages/api/logout.ts
+++ b/pages/api/logout.ts
@@ -43,8 +43,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
 const logout = async (req: NextApiRequest, res: NextApiResponse<logoutResponse>, startTime: number) => {
    try {
-      const cookies = new Cookies(req, res);
-      
+      const secureCookie = isRequestSecure(req);
+      const cookies = new Cookies(req, res, { secure: secureCookie });
+
       // Get user info before clearing token for logging
       let username = 'unknown_user';
       try {
@@ -59,8 +60,6 @@ const logout = async (req: NextApiRequest, res: NextApiResponse<logoutResponse>,
       }
 
       // Clear the token cookie
-      const secureCookie = isRequestSecure(req);
-
       cookies.set('token', '', {
          httpOnly: true,
          sameSite: 'lax',


### PR DESCRIPTION
## Summary
- align the logout handler's Cookies instantiation with the login handler so secure contexts are respected when clearing the token
- keep the secure cookie flag consistent between constructor and setter during logout
- extend the authentication cookie tests to verify the logout constructor receives the secure option when requests are served over HTTPS

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfa2aee0f0832ab71d0fa326ea2b73