### PR TITLE
Refactor domain pages to expose named exports for auth

### DIFF
--- a/__tests__/pages/domain.test.tsx
+++ b/__tests__/pages/domain.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import SingleDomain from '../../pages/domain/[slug]';
+import { DomainPage as SingleDomain } from '../../pages/domain/[slug]';
 import { useAddDomain, useDeleteDomain, useFetchDomain, useFetchDomains, useUpdateDomain } from '../../services/domains';
 import { useAddKeywords, useDeleteKeywords,
    useFavKeywords, useFetchKeywords, useRefreshKeywords, useFetchSingleKeyword } from '../../services/keywords';

--- a/__tests__/pages/domainIdeasPage.test.tsx
+++ b/__tests__/pages/domainIdeasPage.test.tsx
@@ -2,7 +2,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import DomainIdeasPage from '../../pages/domain/ideas/[slug]';
+import { DomainIdeasPage } from '../../pages/domain/ideas/[slug]';
 import { useFetchDomains } from '../../services/domains';
 import { useFetchKeywordIdeas } from '../../services/adwords';
 import { useFetchSettings } from '../../services/settings';

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -17,8 +17,9 @@ import { useFetchSettings } from '../../../services/settings';
 import AddKeywords from '../../../components/keywords/AddKeywords';
 import Footer from '../../../components/common/Footer';
 import { useBranding } from '../../../hooks/useBranding';
+import { withAuth } from '../../../hooks/useAuth';
 
-const SingleDomain: NextPage = () => {
+export const DomainPage: NextPage = () => {
    const router = useRouter();
    const { branding } = useBranding();
    const { platformName } = branding;
@@ -115,4 +116,4 @@ const SingleDomain: NextPage = () => {
    );
 };
 
-export default SingleDomain;
+export default withAuth(DomainPage);

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -20,8 +20,9 @@ import Footer from '../../../../components/common/Footer';
 import { useBranding } from '../../../../hooks/useBranding';
 import AddKeywords from '../../../../components/keywords/AddKeywords';
 import { useFetchKeywords } from '../../../../services/keywords';
+import { withAuth } from '../../../../hooks/useAuth';
 
-const DiscoverPage: NextPage = () => {
+export const DomainConsolePage: NextPage = () => {
    const router = useRouter();
    const { branding } = useBranding();
    const { platformName } = branding;
@@ -157,4 +158,4 @@ const DiscoverPage: NextPage = () => {
    );
 };
 
-export default DiscoverPage;
+export default withAuth(DomainConsolePage);

--- a/pages/domain/ideas/[slug]/index.tsx
+++ b/pages/domain/ideas/[slug]/index.tsx
@@ -19,8 +19,9 @@ import Modal from '../../../../components/common/Modal';
 import Footer from '../../../../components/common/Footer';
 import AddKeywords from '../../../../components/keywords/AddKeywords';
 import { useFetchKeywords } from '../../../../services/keywords';
+import { withAuth } from '../../../../hooks/useAuth';
 
-const DiscoverPage: NextPage = () => {
+export const DomainIdeasPage: NextPage = () => {
    const router = useRouter();
    const [showDomainSettings, setShowDomainSettings] = useState(false);
    const [showSettings, setShowSettings] = useState(false);
@@ -140,4 +141,4 @@ const DiscoverPage: NextPage = () => {
    );
 };
 
-export default DiscoverPage;
+export default withAuth(DomainIdeasPage);

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -20,8 +20,9 @@ import Footer from '../../../../components/common/Footer';
 import { useBranding } from '../../../../hooks/useBranding';
 import AddKeywords from '../../../../components/keywords/AddKeywords';
 import { useFetchKeywords } from '../../../../services/keywords';
+import { withAuth } from '../../../../hooks/useAuth';
 
-const InsightPage: NextPage = () => {
+export const DomainInsightPage: NextPage = () => {
    const router = useRouter();
    const { branding } = useBranding();
    const { platformName } = branding;
@@ -120,4 +121,4 @@ const InsightPage: NextPage = () => {
    );
 };
 
-export default InsightPage;
+export default withAuth(DomainInsightPage);


### PR DESCRIPTION
## Summary
- export named React components for the various domain pages and wrap their default exports with the withAuth HOC
- update page unit tests to import the named exports so they continue to exercise the unwrapped components

## Testing
- npm test -- __tests__/pages/domain.test.tsx __tests__/pages/domainIdeasPage.test.tsx
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfa39aa224832aa5cd0f0e26ebb740