### PR TITLE
Fix modal transitions with forwarded refs

### DIFF
--- a/__tests__/pages/domain.test.tsx
+++ b/__tests__/pages/domain.test.tsx
@@ -104,6 +104,29 @@ describe('SingleDomain Page', () => {
       if (button) fireEvent.click(button);
       expect(screen.getByTestId('adddomain_modal')).toBeVisible();
    });
+
+   it('toggles the AddDomain modal without transition errors', async () => {
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
+
+      const openButton = screen.getByTestId('add_domain');
+      expect(() => fireEvent.click(openButton)).not.toThrow();
+
+      await waitFor(() => {
+         expect(screen.getByTestId('adddomain_modal')).toBeVisible();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i });
+      expect(() => fireEvent.click(cancelButton)).not.toThrow();
+
+      await waitFor(() => {
+         expect(screen.queryByTestId('adddomain_modal')).not.toBeInTheDocument();
+      });
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+   });
    it('Should Display the AddKeywords Modal on Add Keyword Button Click.', async () => {
       render(<QueryClientProvider client={queryClient}><SingleDomain /></QueryClientProvider>);
       const button = screen.getByTestId('add_keyword');

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -10,7 +10,13 @@ type ModalProps = {
    closeModal: Function,
 }
 
-const Modal = ({ children, width = '1/2', closeModal, title, verticalCenter = false }:ModalProps) => {
+const Modal = React.forwardRef<HTMLDivElement, ModalProps>(({
+   children,
+   width = '1/2',
+   closeModal,
+   title,
+   verticalCenter = false,
+}:ModalProps, ref) => {
    useOnKey('Escape', closeModal);
 
    const closeOnBGClick = (e:React.SyntheticEvent) => {
@@ -20,10 +26,10 @@ const Modal = ({ children, width = '1/2', closeModal, title, verticalCenter = fa
    };
 
    return (
-      <div className='modal fixed top-0 left-0 bg-white/[.7] w-full h-dvh z-50 overflow-y-auto' onClick={closeOnBGClick}>
+      <div ref={ref} className='modal fixed top-0 left-0 bg-white/[.7] w-full h-dvh z-50 overflow-y-auto' onClick={closeOnBGClick}>
          <div
-         className={`modal__content max-w-[340px] absolute left-0 right-0 ml-auto mr-auto w-${width} 
-         lg:max-w-md bg-white shadow-md rounded-md p-5 border-t-[1px] border-gray-100 text-base 
+         className={`modal__content max-w-[340px] absolute left-0 right-0 ml-auto mr-auto w-${width}
+         lg:max-w-md bg-white shadow-md rounded-md p-5 border-t-[1px] border-gray-100 text-base
          ${verticalCenter ? ' top-1/2 translate-y-[-50%]' : 'top-1/4'}`}>
             {title && <h3 className=' font-semibold mb-3'>{title}</h3>}
             <button
@@ -35,6 +41,8 @@ const Modal = ({ children, width = '1/2', closeModal, title, verticalCenter = fa
          </div>
       </div>
    );
-};
+});
+
+Modal.displayName = 'Modal';
 
 export default Modal;

--- a/components/domains/AddDomain.tsx
+++ b/components/domains/AddDomain.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import Modal from '../common/Modal';
 import { useAddDomain } from '../../services/domains';
 import { isValidUrl } from '../../utils/client/validators';
@@ -8,7 +8,7 @@ type AddDomainProps = {
    closeModal: Function
 }
 
-const AddDomain = ({ closeModal, domains = [] }: AddDomainProps) => {
+const AddDomain = forwardRef<HTMLDivElement, AddDomainProps>(({ closeModal, domains = [] }: AddDomainProps, ref) => {
    const [newDomain, setNewDomain] = useState<string>('');
    const [newDomainError, setNewDomainError] = useState('');
    const { mutate: addMutate, isLoading: isAdding } = useAddDomain(() => closeModal());
@@ -56,7 +56,7 @@ const AddDomain = ({ closeModal, domains = [] }: AddDomainProps) => {
    };
 
    return (
-      <Modal closeModal={() => { closeModal(false); }} title={'Add New Domain'}>
+      <Modal ref={ref} closeModal={() => { closeModal(false); }} title={'Add New Domain'}>
          <div data-testid="adddomain_modal">
             <h4 className='text-sm mt-4 pb-2'>Website URL(s)</h4>
             <textarea
@@ -77,6 +77,8 @@ const AddDomain = ({ closeModal, domains = [] }: AddDomainProps) => {
          </div>
       </Modal>
    );
-};
+});
+
+AddDomain.displayName = 'AddDomain';
 
 export default AddDomain;

--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { forwardRef, useState } from 'react';
 import Icon from '../common/Icon';
 import Modal from '../common/Modal';
 import { useDeleteDomain, useFetchDomain, useUpdateDomain } from '../../services/domains';
@@ -24,7 +24,7 @@ const deriveDomainActiveState = (domainData?: DomainType | null) => {
    return (scrapeEnabled !== false) && (notification !== false);
 };
 
-const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
+const DomainSettings = forwardRef<HTMLDivElement, DomainSettingsProps>(({ domain, closeModal }: DomainSettingsProps, ref) => {
    const router = useRouter();
    const [currentTab, setCurrentTab] = useState<'notification'|'searchconsole'>('notification');
    const [showRemoveDomain, setShowRemoveDomain] = useState<boolean>(false);
@@ -87,7 +87,7 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
    const tabStyle = `inline-block px-4 py-2 rounded-md mr-3 cursor-pointer text-sm select-none z-10
                      text-gray-600 border border-b-0 relative top-[1px] rounded-b-none`;
    return (
-      <div>
+      <div ref={ref}>
          <Modal closeModal={() => closeModal(false)} title={'Domain Settings'} width="[500px]" verticalCenter={currentTab === 'searchconsole'} >
             <div data-testid="domain_settings" className=" text-sm">
                <div className=' mt-3 mb-5 border  border-slate-200 px-2 py-4 pb-0
@@ -235,6 +235,8 @@ const DomainSettings = ({ domain, closeModal }: DomainSettingsProps) => {
          )}
       </div>
    );
-};
+});
+
+DomainSettings.displayName = 'DomainSettings';
 
 export default DomainSettings;

--- a/components/keywords/AddKeywords.tsx
+++ b/components/keywords/AddKeywords.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Icon from '../common/Icon';
 import Modal from '../common/Modal';
 import SelectField from '../common/SelectField';
@@ -24,7 +24,13 @@ type KeywordsInput = {
    state?:string,
 }
 
-const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCity = false }: AddKeywordsProps) => {
+const AddKeywords = forwardRef<HTMLDivElement, AddKeywordsProps>(({
+   closeModal,
+   domain,
+   keywords,
+   scraperName = '',
+   allowsCity = false,
+}: AddKeywordsProps, ref) => {
    const inputRef = useRef(null);
    const [error, setError] = useState<string>('');
    const [showTagSuggestions, setShowTagSuggestions] = useState(false);
@@ -131,7 +137,7 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
    const deviceTabStyle = 'cursor-pointer px-2 py-2 rounded';
 
    return (
-      <Modal closeModal={() => { closeModal(false); }} title={'Add New Keywords'} width="[420px]">
+      <Modal ref={ref} closeModal={() => { closeModal(false); }} title={'Add New Keywords'} width="[420px]">
          <div data-testid="addkeywords_modal">
             <div>
                <div>
@@ -260,6 +266,8 @@ const AddKeywords = ({ closeModal, domain, keywords, scraperName = '', allowsCit
          </div>
       </Modal>
    );
-};
+});
+
+AddKeywords.displayName = 'AddKeywords';
 
 export default AddKeywords;

--- a/components/settings/Settings.tsx
+++ b/components/settings/Settings.tsx
@@ -1,6 +1,6 @@
 /// <reference path="../../types.d.ts" />
 
-import React, { useEffect, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { useFetchSettings, useUpdateSettings } from '../../services/settings';
 import Icon from '../common/Icon';
 import NotificationSettings from './NotificationSettings';
@@ -41,7 +41,7 @@ export const createDefaultSettings = (platformName: string): SettingsType => ({
 
 export const defaultSettings: SettingsType = createDefaultSettings(DEFAULT_BRANDING.platformName);
 
-const Settings = ({ closeSettings }:SettingsProps) => {
+const Settings = forwardRef<HTMLDivElement, SettingsProps>(({ closeSettings }:SettingsProps, ref) => {
    const { branding } = useBranding();
    const [currentTab, setCurrentTab] = useState<string>('scraper');
    const [settings, setSettings] = useState<SettingsType>(defaultSettings);
@@ -137,7 +137,7 @@ const Settings = ({ closeSettings }:SettingsProps) => {
    const tabStyleActive = 'bg-white text-blue-600 border-slate-200';
 
    return (
-       <div className="settings fixed w-full h-dvh top-0 left-0 z-[9999]" onClick={closeOnBGClick}>
+       <div ref={ref} className="settings fixed w-full h-dvh top-0 left-0 z-[9999]" onClick={closeOnBGClick}>
             <div className="absolute w-full max-w-md bg-white customShadow top-0 right-0 h-dvh overflow-y-auto" data-loading={isLoading} >
                {isLoading && <div className='absolute flex content-center items-center h-full'><Icon type="loading" size={24} /></div>}
                <div className='settings__header px-5 py-4 text-slate-500'>
@@ -193,6 +193,8 @@ const Settings = ({ closeSettings }:SettingsProps) => {
             </div>
        </div>
    );
-};
+});
+
+Settings.displayName = 'Settings';
 
 export default Settings;

--- a/pages/domain/[slug]/index.tsx
+++ b/pages/domain/[slug]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -27,6 +27,10 @@ export const DomainPage: NextPage = () => {
    const [showAddDomain, setShowAddDomain] = useState(false);
    const [showDomainSettings, setShowDomainSettings] = useState(false);
    const [showSettings, setShowSettings] = useState(false);
+   const addDomainNodeRef = useRef<HTMLDivElement>(null);
+   const domainSettingsNodeRef = useRef<HTMLDivElement>(null);
+   const settingsNodeRef = useRef<HTMLDivElement>(null);
+   const addKeywordsNodeRef = useRef<HTMLDivElement>(null);
    const [keywordSPollInterval, setKeywordSPollInterval] = useState<undefined|number>(undefined);
    const { data: appSettingsData, isLoading: isAppSettingsLoading } = useFetchSettings();
    const { data: domainsData } = useFetchDomains(router, false);
@@ -89,21 +93,23 @@ export const DomainPage: NextPage = () => {
             </div>
          </div>
 
-         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
-            <AddDomain closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
+         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addDomainNodeRef}>
+            <AddDomain ref={addDomainNodeRef} closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
          </CSSTransition>
 
-         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={domainSettingsNodeRef}>
             <DomainSettings
+            ref={domainSettingsNodeRef}
             domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>
-         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter>
-             <Settings closeSettings={() => setShowSettings(false)} />
+         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter nodeRef={settingsNodeRef}>
+             <Settings ref={settingsNodeRef} closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
-         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addKeywordsNodeRef}>
             <AddKeywords
+               ref={addKeywordsNodeRef}
                domain={activDomain?.domain || ''}
                scraperName={activeScraper?.label || ''}
                keywords={theKeywords}

--- a/pages/domain/console/[slug]/index.tsx
+++ b/pages/domain/console/[slug]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -30,6 +30,10 @@ export const DomainConsolePage: NextPage = () => {
    const [showSettings, setShowSettings] = useState(false);
    const [showAddKeywords, setShowAddKeywords] = useState(false);
    const [showAddDomain, setShowAddDomain] = useState(false);
+   const addDomainNodeRef = useRef<HTMLDivElement>(null);
+   const domainSettingsNodeRef = useRef<HTMLDivElement>(null);
+   const settingsNodeRef = useRef<HTMLDivElement>(null);
+   const addKeywordsNodeRef = useRef<HTMLDivElement>(null);
    const [scDateFilter, setSCDateFilter] = useState('thirtyDays');
    const { data: appSettings } = useFetchSettings();
    const appSettingsData: SettingsType = appSettings?.settings || {};
@@ -131,21 +135,23 @@ export const DomainConsolePage: NextPage = () => {
             </div>
          </div>
 
-         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
-            <AddDomain closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
+         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addDomainNodeRef}>
+            <AddDomain ref={addDomainNodeRef} closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
          </CSSTransition>
 
-         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={domainSettingsNodeRef}>
             <DomainSettings
+            ref={domainSettingsNodeRef}
             domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>
-         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter>
-             <Settings closeSettings={() => setShowSettings(false)} />
+         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter nodeRef={settingsNodeRef}>
+             <Settings ref={settingsNodeRef} closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
-         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addKeywordsNodeRef}>
             <AddKeywords
+               ref={addKeywordsNodeRef}
                domain={activDomain?.domain || ''}
                scraperName={activeScraper?.label || ''}
                keywords={trackedKeywords}

--- a/pages/domain/ideas/[slug]/index.tsx
+++ b/pages/domain/ideas/[slug]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -29,6 +29,10 @@ export const DomainIdeasPage: NextPage = () => {
    const [showAddKeywords, setShowAddKeywords] = useState(false);
    const [showUpdateModal, setShowUpdateModal] = useState(false);
    const [showFavorites, setShowFavorites] = useState(false);
+   const addDomainNodeRef = useRef<HTMLDivElement>(null);
+   const domainSettingsNodeRef = useRef<HTMLDivElement>(null);
+   const settingsNodeRef = useRef<HTMLDivElement>(null);
+   const addKeywordsNodeRef = useRef<HTMLDivElement>(null);
 
    const { data: appSettings } = useFetchSettings();
    const appSettingsData: SettingsType = appSettings?.settings || {};
@@ -101,19 +105,20 @@ export const DomainIdeasPage: NextPage = () => {
             </div>
          </div>
 
-         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
-            <AddDomain closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
+         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addDomainNodeRef}>
+            <AddDomain ref={addDomainNodeRef} closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
          </CSSTransition>
 
-         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={domainSettingsNodeRef}>
             <DomainSettings
+            ref={domainSettingsNodeRef}
             domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>
 
-         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter>
-             <Settings closeSettings={() => setShowSettings(false)} />
+         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter nodeRef={settingsNodeRef}>
+             <Settings ref={settingsNodeRef} closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
 
          {showUpdateModal && activDomain?.domain && (
@@ -127,8 +132,9 @@ export const DomainIdeasPage: NextPage = () => {
                />
             </Modal>
          )}
-         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addKeywordsNodeRef}>
             <AddKeywords
+               ref={addKeywordsNodeRef}
                domain={activDomain?.domain || ''}
                scraperName={activeScraper?.label || ''}
                keywords={trackedKeywords}

--- a/pages/domain/insight/[slug]/index.tsx
+++ b/pages/domain/insight/[slug]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -30,6 +30,10 @@ export const DomainInsightPage: NextPage = () => {
    const [showSettings, setShowSettings] = useState(false);
    const [showAddKeywords, setShowAddKeywords] = useState(false);
    const [showAddDomain, setShowAddDomain] = useState(false);
+   const addDomainNodeRef = useRef<HTMLDivElement>(null);
+   const domainSettingsNodeRef = useRef<HTMLDivElement>(null);
+   const settingsNodeRef = useRef<HTMLDivElement>(null);
+   const addKeywordsNodeRef = useRef<HTMLDivElement>(null);
    const [scDateFilter, setSCDateFilter] = useState('thirtyDays');
    const { data: appSettings } = useFetchSettings();
    const appSettingsData: SettingsType = appSettings?.settings || {};
@@ -94,21 +98,23 @@ export const DomainInsightPage: NextPage = () => {
             </div>
          </div>
 
-         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
-            <AddDomain closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
+         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addDomainNodeRef}>
+            <AddDomain ref={addDomainNodeRef} closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
          </CSSTransition>
 
-         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showDomainSettings} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={domainSettingsNodeRef}>
             <DomainSettings
+            ref={domainSettingsNodeRef}
             domain={showDomainSettings && theDomains && activDomain && activDomain.domain ? activDomain : null}
             closeModal={setShowDomainSettings}
             />
          </CSSTransition>
-         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter>
-             <Settings closeSettings={() => setShowSettings(false)} />
+         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter nodeRef={settingsNodeRef}>
+             <Settings ref={settingsNodeRef} closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
-         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
+         <CSSTransition in={showAddKeywords} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addKeywordsNodeRef}>
             <AddKeywords
+               ref={addKeywordsNodeRef}
                domain={activDomain?.domain || ''}
                scraperName={activeScraper?.label || ''}
                keywords={trackedKeywords}

--- a/pages/domains/index.tsx
+++ b/pages/domains/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -24,7 +24,9 @@ const Domains: NextPage = () => {
    // const [noScrapprtError, setNoScrapprtError] = useState(false);
    const [showSettings, setShowSettings] = useState(false);
    const [showAddDomain, setShowAddDomain] = useState(false);
+   const addDomainNodeRef = useRef<HTMLDivElement>(null);
    const [domainThumbs, setDomainThumbs] = useState<thumbImages>({});
+   const settingsNodeRef = useRef<HTMLDivElement>(null);
    const { data: appSettingsData, isLoading: isAppSettingsLoading } = useFetchSettings();
    const { data: domainsData, isLoading: isDomainsLoading } = useFetchDomains(router, true);
 
@@ -155,11 +157,11 @@ const Domains: NextPage = () => {
             </div>
          </div>
 
-         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter>
-            <AddDomain closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
+         <CSSTransition in={showAddDomain} timeout={300} classNames="modal_anim" unmountOnExit mountOnEnter nodeRef={addDomainNodeRef}>
+            <AddDomain ref={addDomainNodeRef} closeModal={() => setShowAddDomain(false)} domains={domainsData?.domains || []} />
          </CSSTransition>
-         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter>
-             <Settings closeSettings={() => setShowSettings(false)} />
+         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter nodeRef={settingsNodeRef}>
+             <Settings ref={settingsNodeRef} closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
          <Footer currentVersion={appSettings?.version ? appSettings.version : ''} />
       </PageLoader>

--- a/pages/research/index.tsx
+++ b/pages/research/index.tsx
@@ -1,7 +1,7 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import Icon from '../../components/common/Icon';
 import TopBar from '../../components/common/TopBar';
@@ -25,6 +25,7 @@ const Research: NextPage = () => {
    const [language, setLanguage] = useState('1000');
    const [country, setCountry] = useState('US');
    const [seedKeywords, setSeedKeywords] = useState('');
+   const settingsNodeRef = useRef<HTMLDivElement>(null);
 
    const { data: appSettings } = useFetchSettings();
    const adwordsConnected = Boolean(
@@ -144,8 +145,8 @@ const Research: NextPage = () => {
                />
             </div>
          </div>
-         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter>
-             <Settings closeSettings={() => setShowSettings(false)} />
+         <CSSTransition in={showSettings} timeout={300} classNames="settings_anim" unmountOnExit mountOnEnter nodeRef={settingsNodeRef}>
+             <Settings ref={settingsNodeRef} closeSettings={() => setShowSettings(false)} />
          </CSSTransition>
          <Footer currentVersion={appSettings?.settings?.version ? appSettings.settings.version : ''} />
       </div>


### PR DESCRIPTION
## Summary
- forward refs through the shared Modal component and modal presenters so callers can supply stable DOM nodes
- update each page that animates these modals to pass dedicated nodeRef handles to CSSTransition
- add a regression test that toggles the Add Domain modal without triggering transition errors

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfa7e1cdf4832ab4cc8e615fca94a0