### PR TITLE
Align scraper tab layout with other settings

### DIFF
--- a/components/domains/DomainSettings.tsx
+++ b/components/domains/DomainSettings.tsx
@@ -311,10 +311,10 @@ const DomainSettings = forwardRef<HTMLDivElement, DomainSettingsProps>(
                               updateField={(updated: string[]) => handleScraperSelect(updated)}
                               multiple={false}
                               rounded={'rounded'}
-                              fullWidth
+                              minWidth={210}
                            />
                         </div>
-                        <div className="mb-4 flex flex-col justify-between items-center w-full">
+                        <div className="mb-4 flex flex-col items-start gap-2 w-full">
                            <SecretField
                               label='API Key'
                               value={scraperKeyInput}


### PR DESCRIPTION
## Summary
- match the scraper tab dropdown width with other Domain Settings inputs
- left-align the API key field and helper copy to mirror the rest of the form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfb4344284832a87f8de72dec027c7