### PR TITLE
docs: explain per-domain scraper overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ SerpBear integrates with several managed APIs in addition to a "bring your own p
 
 \*Pricing details are indicative; confirm current pricing with each vendor before purchasing. All managed integrations authenticate with the headers or query parameters shown in the final column, exactly as implemented in the `/scrapers/services` directory.
 
+### Per-domain scraper overrides
+
+Every domain can opt into its own scraping provider without changing the global default. Open the **Domains** page, click a domain, and switch to the **Scraper** tab in the settings modal to reveal the override controls. Use the drop-down to choose a provider or revert to **System Scraper**, then supply the API key in the masked input when the provider requires one. Stored keys are encrypted before they are persisted, and the helper keeps the latest key for the same provider unless you explicitly clear it. Domains that keep the **System Scraper** option inherit the global configuration, matching how the refresh pipeline falls back when no override exists. Because overrides change the effective scraper per domain, they also influence whether a refresh job can run keywords in parallel—the pipeline checks each domain’s final scraper settings before opting into the faster path.
+
 ---
 
 ## Feature deep dive


### PR DESCRIPTION
## Summary
- add README guidance for configuring per-domain scraper overrides
- document encryption, inheritance, and parallel refresh behaviour tied to overrides

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dfca569ae4832a9ec0eab069a415d6