### PR TITLE
Add share link token support for notification emails

### DIFF
--- a/__tests__/utils/generateEmail.test.ts
+++ b/__tests__/utils/generateEmail.test.ts
@@ -19,6 +19,68 @@ const createSettings = (overrides: Record<string, unknown> = {}) => ({
 }) as any;
 
 describe('generateEmail', () => {
+  const baseDomain = {
+    domain: 'example.com',
+    keywordsTracked: 3,
+    avgPosition: 2,
+    mapPackKeywords: 1,
+  } as any;
+
+  const baseKeyword = {
+    ID: 1,
+    keyword: 'test keyword',
+    device: 'desktop',
+    country: 'US',
+    domain: 'example.com',
+    lastUpdated: new Date().toISOString(),
+    added: new Date().toISOString(),
+    position: 5,
+    volume: 0,
+    sticky: false,
+    history: {},
+    lastResult: [],
+    url: '',
+    tags: [],
+    updating: false,
+    lastUpdateError: false,
+  } as any;
+
+  it('prefers generated share dashboard URL when provided', async () => {
+    const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.example.com';
+
+    mockReadFile.mockResolvedValue('<html>{{shareDashboardURL}}</html>');
+
+    const html = await generateEmail(
+      baseDomain,
+      [baseKeyword],
+      createSettings(),
+      'https://share.example.com/token',
+    );
+
+    expect(html).toBe('<html>https://share.example.com/token</html>');
+
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  });
+
+  it('falls back to app URL when share dashboard URL generation fails', async () => {
+    const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.example.com';
+
+    mockReadFile.mockResolvedValue('<html>{{shareDashboardURL}}</html>');
+
+    const html = await generateEmail(
+      baseDomain,
+      [baseKeyword],
+      createSettings(),
+      undefined,
+    );
+
+    expect(html).toBe('<html>https://app.example.com</html>');
+
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  });
+
   it('includes location details in keyword table when provided', async () => {
     mockReadFile.mockResolvedValue('<html>{{domainStats}}{{keywordsTable}}</html>');
 

--- a/__tests__/utils/shareLinks.test.ts
+++ b/__tests__/utils/shareLinks.test.ts
@@ -1,0 +1,97 @@
+import { createDomainShareLink, hashShareToken, resolveDomainForShareToken, buildShareUrl } from '../../utils/shareLinks';
+import Domain from '../../database/models/domain';
+
+jest.mock('../../database/models/domain', () => ({
+  __esModule: true,
+  default: {
+    findByPk: jest.fn(),
+    findOne: jest.fn(),
+  },
+}));
+
+const mockedDomain = Domain as unknown as {
+  findByPk: jest.Mock;
+  findOne: jest.Mock;
+};
+
+describe('shareLinks utility', () => {
+  const originalSecret = process.env.SECRET;
+  const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+  const originalTtl = process.env.SHARE_TOKEN_TTL_HOURS;
+
+  beforeEach(() => {
+    process.env.SECRET = 'test-secret';
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.example.com';
+    delete process.env.SHARE_TOKEN_TTL_HOURS;
+    mockedDomain.findByPk.mockReset();
+    mockedDomain.findOne.mockReset();
+  });
+
+  afterAll(() => {
+    process.env.SECRET = originalSecret;
+    process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+    if (originalTtl) {
+      process.env.SHARE_TOKEN_TTL_HOURS = originalTtl;
+    } else {
+      delete process.env.SHARE_TOKEN_TTL_HOURS;
+    }
+  });
+
+  it('creates and persists a share token for a domain', async () => {
+    const update = jest.fn();
+    mockedDomain.findByPk.mockResolvedValue({ update });
+
+    const result = await createDomainShareLink({ ID: 1 } as any);
+
+    expect(result.url).toMatch(/https:\/\/app\.example\.com\/share\//);
+    expect(typeof result.token).toBe('string');
+    expect(result.token.length).toBeGreaterThan(10);
+
+    const hashed = hashShareToken(result.token);
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      share_token_hash: hashed,
+    }));
+
+    const expiresAt = new Date(result.expiresAt).getTime();
+    expect(expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('resolves domain when token is valid and not expired', async () => {
+    const token = 'valid-token';
+    const hash = hashShareToken(token);
+
+    mockedDomain.findOne.mockResolvedValue({
+      get: () => ({
+        ID: 1,
+        domain: 'example.com',
+        share_token_hash: hash,
+        share_token_expires_at: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    });
+
+    const { domain, expired } = await resolveDomainForShareToken(token);
+    expect(expired).toBe(false);
+    expect(domain?.domain).toBe('example.com');
+  });
+
+  it('marks token as expired when expiry timestamp has passed', async () => {
+    const token = 'expired-token';
+    mockedDomain.findOne.mockResolvedValue({
+      get: () => ({
+        ID: 2,
+        domain: 'old.com',
+        share_token_hash: hashShareToken(token),
+        share_token_expires_at: new Date(Date.now() - 1).toISOString(),
+      }),
+    });
+
+    const { domain, expired } = await resolveDomainForShareToken(token);
+    expect(expired).toBe(true);
+    expect(domain).toBeNull();
+  });
+
+  it('builds relative share URL when app URL is missing', () => {
+    delete process.env.NEXT_PUBLIC_APP_URL;
+    expect(buildShareUrl('token-123')).toBe('/share/token-123');
+  });
+});

--- a/components/domains/DomainHeader.tsx
+++ b/components/domains/DomainHeader.tsx
@@ -14,66 +14,98 @@ type DomainHeaderProps = {
    scFilter?: string
    setScFilter?: Function
    showIdeaUpdateModal?:Function
+   hideDomainSelector?: boolean
+   hideSettingsButton?: boolean
+   hideKeywordAddButton?: boolean
+   readOnlyActions?: boolean
+   linkOverrides?: Partial<Record<'tracking' | 'discover' | 'insight' | 'ideas', string>>
 }
 
 const DomainHeader = (
-   { domain, showAddModal, showSettingsModal, exportCsv, domains, scFilter = 'thirtyDays', setScFilter, showIdeaUpdateModal }: DomainHeaderProps,
+   {
+      domain,
+      showAddModal,
+      showSettingsModal,
+      exportCsv,
+      domains,
+      scFilter = 'thirtyDays',
+      setScFilter,
+      showIdeaUpdateModal,
+      hideDomainSelector = false,
+      hideSettingsButton = false,
+      hideKeywordAddButton = false,
+      readOnlyActions = false,
+      linkOverrides = {},
+   }: DomainHeaderProps,
 ) => {
    const router = useRouter();
    const [showOptions, setShowOptions] = useState<boolean>(false);
    const [ShowSCDates, setShowSCDates] = useState<boolean>(false);
    const { mutate: refreshMutate } = useRefreshKeywords(() => {});
-   const isConsole = router.pathname === '/domain/console/[slug]';
-   const isInsight = router.pathname === '/domain/insight/[slug]';
-   const isIdeas = router.pathname === '/domain/ideas/[slug]';
-   const canShowAddKeywordButton = typeof showAddModal === 'function';
+   const currentPath = router.pathname || '';
+   const isShareRoute = currentPath.startsWith('/share/');
+   const isConsole = currentPath === (isShareRoute ? '/share/[token]/discover' : '/domain/console/[slug]');
+   const isInsight = currentPath === (isShareRoute ? '/share/[token]/insight' : '/domain/insight/[slug]');
+   const isIdeas = currentPath === (isShareRoute ? '/share/[token]/ideas' : '/domain/ideas/[slug]');
+   const canShowAddKeywordButton = typeof showAddModal === 'function' && !hideKeywordAddButton;
 
    const daysName = (dayKey:string) => dayKey.replace('three', '3').replace('seven', '7').replace('thirty', '30').replace('Days', ' Days');
    const buttonStyle = 'leading-6 inline-block px-2 py-2 text-gray-500 hover:text-gray-700';
    const buttonLabelStyle = 'ml-2 text-sm not-italic lg:invisible lg:opacity-0';
    const tabStyle = 'rounded rounded-b-none cursor-pointer border-[#e9ebff] border-b-0';
    const scDataFilterStyle = 'px-3 py-2 block w-full';
+   const navigationLinks = {
+      tracking: linkOverrides.tracking || `/domain/${domain.slug}`,
+      discover: linkOverrides.discover || `/domain/console/${domain.slug}`,
+      insight: linkOverrides.insight || `/domain/insight/${domain.slug}`,
+      ideas: linkOverrides.ideas || `/domain/ideas/${domain.slug}`,
+   };
+
+   const isTrackingActive = currentPath === (isShareRoute ? '/share/[token]' : '/domain/[slug]');
+
    return (
       <div className='domain_kewywords_head w-full '>
          <div>
             <h1 className="hidden lg:block text-xl font-bold my-3" data-testid="domain-header">
                <><i className=' capitalize font-bold not-italic'>{domain.domain.charAt(0)}</i>{domain.domain.slice(1)}</>
             </h1>
-            <div className='domain_selector bg-white mt-2 lg:hidden relative z-10'>
-               <SelectField
-               options={domains && domains.length > 0 ? domains.map((d) => ({ label: d.domain, value: d.slug })) : []}
-               selected={[domain.slug]}
-               defaultLabel="Select Domain"
-               updateField={(updateSlug:[string]) => updateSlug && updateSlug[0] && router.push(`${updateSlug[0]}`)}
-               multiple={false}
-               rounded={'rounded'}
-               />
-            </div>
+            {!hideDomainSelector && (
+               <div className='domain_selector bg-white mt-2 lg:hidden relative z-10'>
+                  <SelectField
+                  options={domains && domains.length > 0 ? domains.map((d) => ({ label: d.domain, value: d.slug })) : []}
+                  selected={[domain.slug]}
+                  defaultLabel="Select Domain"
+                  updateField={(updateSlug:[string]) => updateSlug && updateSlug[0] && router.push(`${updateSlug[0]}`)}
+                  multiple={false}
+                  rounded={'rounded'}
+                  />
+               </div>
+            )}
          </div>
       <div className='flex w-full justify-between mt-4 lg:mt-0'>
          <ul className=' max-w-[270px] overflow-auto flex items-end text-sm relative top-[2px] lg:max-w-none'>
-            <li className={`${tabStyle} ${router.pathname === '/domain/[slug]' ? 'bg-white border border-b-0 font-semibold' : ''}`}>
-               <Link href={`/domain/${domain.slug}`} className='px-4 py-2 inline-block'>
+            <li className={`${tabStyle} ${(isTrackingActive) ? 'bg-white border border-b-0 font-semibold' : ''}`}>
+               <Link href={navigationLinks.tracking} className='px-4 py-2 inline-block'>
                   <Icon type="tracking" color='#999' classes='hidden lg:inline-block' />
                   <span className='text-xs lg:text-sm lg:ml-2'>Tracking</span>
                </Link>
             </li>
-            <li className={`${tabStyle} ${router.pathname === '/domain/console/[slug]' ? 'bg-white border border-b-0 font-semibold' : ''}`}>
-               <Link href={`/domain/console/${domain.slug}`} className='px-4 py-2 inline-block'>
+            <li className={`${tabStyle} ${isConsole ? 'bg-white border border-b-0 font-semibold' : ''}`}>
+               <Link href={navigationLinks.discover} className='px-4 py-2 inline-block'>
                   <Icon type="google" size={13} classes='hidden lg:inline-block' />
                   <span className='text-xs lg:text-sm lg:ml-2'>Discover</span>
                   <Icon type='help' size={14} color="#aaa" classes="ml-2 hidden lg:inline-block" title='Discover Keywords you already Rank For' />
                </Link>
             </li>
-            <li className={`${tabStyle} ${router.pathname === '/domain/insight/[slug]' ? 'bg-white border border-b-0 font-semibold' : ''}`}>
-               <Link href={`/domain/insight/${domain.slug}`} className='px-4 py-2 inline-block'>
+            <li className={`${tabStyle} ${isInsight ? 'bg-white border border-b-0 font-semibold' : ''}`}>
+               <Link href={navigationLinks.insight} className='px-4 py-2 inline-block'>
                   <Icon type="google" size={13} classes='hidden lg:inline-block' />
                   <span className='text-xs lg:text-sm lg:ml-2'>Insight</span>
                   <Icon type='help' size={14} color="#aaa" classes="ml-2 hidden lg:inline-block" title='Insight for Google Search Console Data' />
                </Link>
             </li>
-            <li className={`${tabStyle} ${router.pathname === '/domain/ideas/[slug]' ? 'bg-white border border-b-0 font-semibold' : ''}`}>
-               <Link href={`/domain/ideas/${domain.slug}`} className='px-4 py-2 inline-block'>
+            <li className={`${tabStyle} ${isIdeas ? 'bg-white border border-b-0 font-semibold' : ''}`}>
+               <Link href={navigationLinks.ideas} className='px-4 py-2 inline-block'>
                   <Icon type="adwords" size={13} classes='hidden lg:inline-block' />
                   <span className='text-xs lg:text-sm lg:ml-2'>Ideas</span>
                   <Icon
@@ -96,7 +128,7 @@ const DomainHeader = (
             className={`absolute top-full right-0 w-40 mt-2 bg-white border border-gray-100 rounded z-[70] ${
                showOptions ? 'block' : 'hidden'
             } lg:block lg:static lg:mt-0 lg:border-0 lg:w-auto lg:bg-transparent`}>
-               {!isInsight && (
+               {!isInsight && !readOnlyActions && (
                   <button
                   className={`domheader_action_button relative ${buttonStyle}`}
                   aria-pressed="false"
@@ -104,7 +136,7 @@ const DomainHeader = (
                      <Icon type='download' size={20} /><i className={`${buttonLabelStyle}`}>Export as csv</i>
                   </button>
                )}
-               {!isConsole && !isInsight && !isIdeas && (
+               {!isConsole && !isInsight && !isIdeas && !readOnlyActions && (
                   <button
                   className={`domheader_action_button relative ${buttonStyle} lg:ml-3`}
                   aria-pressed="false"
@@ -112,13 +144,15 @@ const DomainHeader = (
                      <Icon type='reload' size={14} /><i className={`${buttonLabelStyle}`}>Reload All Serps</i>
                   </button>
                 )}
-               <button
-               data-testid="show_domain_settings"
-               className={`domheader_action_button relative ${buttonStyle} lg:ml-3`}
-               aria-pressed="false"
-               onClick={() => { showSettingsModal(true); setShowOptions(false); }}><Icon type='settings' size={20} />
-                  <i className={`${buttonLabelStyle}`}>Domain Settings</i>
-               </button>
+               {!hideSettingsButton && (
+                  <button
+                  data-testid="show_domain_settings"
+                  className={`domheader_action_button relative ${buttonStyle} lg:ml-3`}
+                  aria-pressed="false"
+                  onClick={() => { showSettingsModal(true); setShowOptions(false); }}><Icon type='settings' size={20} />
+                     <i className={`${buttonLabelStyle}`}>Domain Settings</i>
+                  </button>
+               )}
             </div>
             {canShowAddKeywordButton && (
                <button
@@ -148,7 +182,7 @@ const DomainHeader = (
                   )}
                </div>
             )}
-            {isIdeas && (
+            {isIdeas && !readOnlyActions && (
                <button
                data-testid="load_ideas"
                className={'ml-2 text-blue-700 font-bold text-sm flex items-center lg:px-4 lg:py-2'}

--- a/database/migrations/1737608000000-add-domain-share-token-columns.js
+++ b/database/migrations/1737608000000-add-domain-share-token-columns.js
@@ -1,0 +1,53 @@
+// Migration: Add share token columns to domain table for secure dashboard sharing.
+
+module.exports = {
+   up: async function up(params = {}, legacySequelize) {
+      const queryInterface = params?.context ?? params;
+      const SequelizeLib = params?.Sequelize
+         ?? legacySequelize
+         ?? queryInterface?.sequelize?.constructor
+         ?? require('sequelize');
+
+      return queryInterface.sequelize.transaction(async (transaction) => {
+         const domainTableDefinition = await queryInterface.describeTable('domain');
+
+         if (!domainTableDefinition?.share_token_hash) {
+            await queryInterface.addColumn(
+               'domain',
+               'share_token_hash',
+               { type: SequelizeLib.DataTypes.STRING, allowNull: true, defaultValue: null },
+               { transaction },
+            );
+         }
+
+         if (!domainTableDefinition?.share_token_expires_at) {
+            await queryInterface.addColumn(
+               'domain',
+               'share_token_expires_at',
+               { type: SequelizeLib.DataTypes.DATE, allowNull: true, defaultValue: null },
+               { transaction },
+            );
+         }
+
+         console.log('Ensured domain share token columns exist.');
+      });
+   },
+
+   down: async function down(params = {}) {
+      const queryInterface = params?.context ?? params;
+
+      return queryInterface.sequelize.transaction(async (transaction) => {
+         const domainTableDefinition = await queryInterface.describeTable('domain');
+
+         if (domainTableDefinition?.share_token_expires_at) {
+            await queryInterface.removeColumn('domain', 'share_token_expires_at', { transaction });
+         }
+
+         if (domainTableDefinition?.share_token_hash) {
+            await queryInterface.removeColumn('domain', 'share_token_hash', { transaction });
+         }
+
+         console.log('Removed domain share token columns.');
+      });
+   },
+};

--- a/database/models/domain.ts
+++ b/database/models/domain.ts
@@ -50,6 +50,12 @@ class Domain extends Model {
 
    @Column({ type: DataType.TEXT, allowNull: true, defaultValue: null })
    scraper_settings!: string | null;
+
+   @Column({ type: DataType.STRING, allowNull: true, defaultValue: null })
+   share_token_hash!: string | null;
+
+   @Column({ type: DataType.DATE, allowNull: true, defaultValue: null })
+   share_token_expires_at!: Date | null;
 }
 
 export default Domain;

--- a/email/email.html
+++ b/email/email.html
@@ -608,7 +608,7 @@
               <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block powered-by">
-                    Powered by {{platformName}} |  <a href="{{appURL}}">Visit Dashboard</a>
+                   Powered by {{platformName}} |  <a href="{{shareDashboardURL}}">Open Shared Dashboard</a>
                   </td>
                 </tr>
               </table>

--- a/pages/api/notify.ts
+++ b/pages/api/notify.ts
@@ -13,6 +13,7 @@ import { canSendEmail, recordEmailSent } from '../../utils/emailThrottle';
 import { getAppSettings } from './settings';
 import { trimStringProperties } from '../../utils/security';
 import { getBranding } from '../../utils/branding';
+import { createDomainShareLink } from '../../utils/shareLinks';
 
 type NotifyResponse = {
    success?: boolean
@@ -165,7 +166,15 @@ const sendNotificationEmail = async (domain: DomainType | Domain, settings: Sett
       const domainsWithStats = await getdomainStats([domainObj]);
       const domainWithStats = domainsWithStats[0] || domainObj;
       
-      const emailHTML = await generateEmail(domainWithStats, keywords, settings);
+      let shareDashboardUrl: string | undefined;
+      try {
+         const shareLink = await createDomainShareLink(domainObj);
+         shareDashboardUrl = shareLink.url;
+      } catch (shareError) {
+         console.error(`[EMAIL] Failed to create share link for ${domainName}:`, shareError);
+      }
+
+      const emailHTML = await generateEmail(domainWithStats, keywords, settings, shareDashboardUrl);
 
       const domainNotificationEmails = trimString(domain.notification_emails);
       const fallbackNotification = notification_email;

--- a/types.d.ts
+++ b/types.d.ts
@@ -26,6 +26,8 @@ type DomainType = {
    search_console?: string,
    ideas_settings?: string,
    scraper_settings?: DomainScraperSettings | null,
+   share_token_hash?: string | null,
+   share_token_expires_at?: string | null,
 }
 
 type KeywordHistory = {

--- a/utils/generateEmail.ts
+++ b/utils/generateEmail.ts
@@ -106,7 +106,12 @@ const calculateKeywordSummary = (items: KeywordType[]): KeywordSummary => items.
  * @param {keywords[]} keywords - Keywords to scrape
  * @returns {Promise}
  */
-const generateEmail = async (domain:DomainType, keywords:KeywordType[], settings: SettingsType) : Promise<string> => {
+const generateEmail = async (
+   domain:DomainType,
+   keywords:KeywordType[],
+   settings: SettingsType,
+   shareDashboardUrl?: string,
+) : Promise<string> => {
    const domainName = domain.domain;
    const emailTemplate = await readFile(path.join(__dirname, '..', '..', '..', '..', 'email', 'email.html'), { encoding: 'utf-8' });
    const currentDate = dayjs(new Date()).format('MMMM D, YYYY');
@@ -206,6 +211,9 @@ const generateEmail = async (domain:DomainType, keywords:KeywordType[], settings
 
    const { emailLogo, platformName: brandName } = resolveEmailBranding();
 
+   const fallbackAppUrl = process.env.NEXT_PUBLIC_APP_URL || '';
+   const resolvedShareUrl = shareDashboardUrl || fallbackAppUrl;
+
    const updatedEmail = emailTemplate
          .replace('{{logo}}', `<img class="logo_img" src="${emailLogo}" alt="${brandName}" width="24" height="24" />`)
          .replace(/{{platformName}}/g, brandName)
@@ -214,7 +222,7 @@ const generateEmail = async (domain:DomainType, keywords:KeywordType[], settings
          .replace('{{keywordsCount}}', keywordsCount.toString())
          .replace('{{keywordsTable}}', keywordsTable)
          .replace('{{domainStats}}', domainStatsHTML)
-         .replace('{{appURL}}', process.env.NEXT_PUBLIC_APP_URL || '')
+         .replace('{{shareDashboardURL}}', resolvedShareUrl)
          .replace('{{stat}}', stat)
          .replace('{{preheader}}', stat);
 

--- a/utils/shareLinks.ts
+++ b/utils/shareLinks.ts
@@ -1,0 +1,125 @@
+import crypto from 'crypto';
+import Domain from '../database/models/domain';
+
+const SHARE_TOKEN_BYTES = 32;
+const DEFAULT_TOKEN_TTL_HOURS = 24 * 7; // one week
+
+export type ShareLinkResult = {
+   token: string;
+   url: string;
+   expiresAt: string;
+};
+
+const getSecret = (): string => {
+   const secret = process.env.SECRET;
+   if (!secret) {
+      throw new Error('SECRET environment variable is not configured.');
+   }
+   return secret;
+};
+
+export const hashShareToken = (token: string): string => {
+   const secret = getSecret();
+   return crypto.createHmac('sha256', secret).update(token).digest('hex');
+};
+
+const resolveBaseUrl = (): string => {
+   const base = process.env.NEXT_PUBLIC_APP_URL || '';
+   return base.replace(/\/$/, '');
+};
+
+const resolveExpiryDate = (): Date => {
+   const configuredTtl = Number(process.env.SHARE_TOKEN_TTL_HOURS);
+   const ttlHours = Number.isFinite(configuredTtl) && configuredTtl > 0
+      ? configuredTtl
+      : DEFAULT_TOKEN_TTL_HOURS;
+   const expires = new Date();
+   expires.setHours(expires.getHours() + ttlHours);
+   return expires;
+};
+
+const persistShareToken = async (domainInstance: Domain, tokenHash: string, expiresAt: Date) => {
+   await domainInstance.update({
+      share_token_hash: tokenHash,
+      share_token_expires_at: expiresAt,
+   });
+};
+
+const generateRawToken = (): string => crypto.randomBytes(SHARE_TOKEN_BYTES).toString('hex');
+
+const ensureDomainInstance = async (domain: DomainType | Domain): Promise<Domain> => {
+   try {
+      if (domain instanceof Domain) {
+         return domain;
+      }
+   } catch (_error) {
+      // noop - instanceof can throw if Domain is mocked in tests
+   }
+
+   if (domain && typeof (domain as Domain)?.update === 'function' && typeof (domain as Domain)?.get === 'function') {
+      return domain as Domain;
+   }
+
+   if (!domain?.ID) {
+      throw new Error('Domain identifier is missing.');
+   }
+
+   const found = await Domain.findByPk(domain.ID);
+   if (!found) {
+      throw new Error('Domain not found while generating share token.');
+   }
+   return found;
+};
+
+export const buildShareUrl = (token: string, pathSuffix = ''): string => {
+   const baseUrl = resolveBaseUrl();
+   const sanitizedSuffix = pathSuffix ? `/${pathSuffix.replace(/^\//, '')}` : '';
+   if (!baseUrl) {
+      return `/share/${token}${sanitizedSuffix}`;
+   }
+   return `${baseUrl}/share/${token}${sanitizedSuffix}`;
+};
+
+export const createDomainShareLink = async (domain: DomainType | Domain): Promise<ShareLinkResult> => {
+   const domainInstance = await ensureDomainInstance(domain);
+   const rawToken = generateRawToken();
+   const hashedToken = hashShareToken(rawToken);
+   const expiresAt = resolveExpiryDate();
+
+   await persistShareToken(domainInstance, hashedToken, expiresAt);
+
+   return {
+      token: rawToken,
+      url: buildShareUrl(rawToken),
+      expiresAt: expiresAt.toISOString(),
+   };
+};
+
+export const resolveDomainForShareToken = async (
+   rawToken: string,
+): Promise<{ domain: DomainType | null; expired: boolean }> => {
+   if (!rawToken) {
+      return { domain: null, expired: false };
+   }
+
+   const hashed = hashShareToken(rawToken);
+   const instance = await Domain.findOne({ where: { share_token_hash: hashed } });
+   if (!instance) {
+      return { domain: null, expired: false };
+   }
+
+   const plain = instance.get({ plain: true }) as DomainType;
+   const expiresAt = plain.share_token_expires_at ? new Date(plain.share_token_expires_at) : null;
+   if (expiresAt && expiresAt.getTime() < Date.now()) {
+      return { domain: null, expired: true };
+   }
+
+   return { domain: plain, expired: false };
+};
+
+export const invalidateShareToken = async (domain: DomainType | Domain) => {
+   const domainInstance = await ensureDomainInstance(domain);
+   await domainInstance.update({ share_token_hash: null, share_token_expires_at: null });
+};
+
+export default createDomainShareLink;


### PR DESCRIPTION
## Summary
- add nullable share token hash and expiry fields to the domain model and provide a migration to create them automatically
- implement a share link utility that hashes tokens, persists them on email sends, and expose helpers for verification
- update the notification email flow and template to inject share dashboard URLs and extend unit tests to cover the new behaviour

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e020d14bd8832a824897f0b10a1540