### PR TITLE
Normalize keyword flag handling to numeric 0/1 and update UI checks

### DIFF
--- a/__mocks__/data.ts
+++ b/__mocks__/data.ts
@@ -51,10 +51,10 @@ export const dummyKeywords = [
             title: 'Alternative Result',
          },
        ],
-       sticky: false,
-       updating: false,
+       sticky: 0,
+       updating: 0,
        lastUpdateError: false as false,
-       mapPackTop3: true,
+       mapPackTop3: 1,
    },
    {
        ID: 2,
@@ -83,10 +83,10 @@ export const dummyKeywords = [
             title: 'Compress Image Tool',
          },
        ],
-       sticky: false,
-       updating: false,
+       sticky: 0,
+       updating: 0,
        lastUpdateError: false as false,
-       mapPackTop3: false,
+       mapPackTop3: 0,
    },
 ];
 

--- a/__tests__/services/keywords.fetchKeywords.test.ts
+++ b/__tests__/services/keywords.fetchKeywords.test.ts
@@ -32,7 +32,7 @@ describe('fetchKeywords normalisation', () => {
       fetchMock.mockReset();
    });
 
-   it('coerces string and numeric flags into booleans', async () => {
+   it('coerces string and numeric flags into numeric 0/1 values', async () => {
       const keywordPayload = {
          ID: 1,
          keyword: 'normalise flags',
@@ -50,7 +50,7 @@ describe('fetchKeywords normalisation', () => {
          tags: [],
          updating: 'false',
          lastUpdateError: false,
-         mapPackTop3: 'yes',
+         mapPackTop3: '1',
       } as unknown as KeywordType;
 
       fetchMock.mockResolvedValue({
@@ -69,10 +69,10 @@ describe('fetchKeywords normalisation', () => {
       expect(Array.isArray(response.keywords)).toBe(true);
 
       const [keyword] = response.keywords as KeywordType[];
-      expect(keyword.updating).toBe(false);
-      expect(typeof keyword.updating).toBe('boolean');
-      expect(keyword.sticky).toBe(false);
-      expect(keyword.mapPackTop3).toBe(true);
+      expect(keyword.updating).toBe(0);
+      expect(typeof keyword.updating).toBe('number');
+      expect(keyword.sticky).toBe(0);
+      expect(keyword.mapPackTop3).toBe(1);
       expect(Object.prototype.hasOwnProperty.call(keyword, 'mapPackTop3')).toBe(true);
    });
 

--- a/__tests__/utils/client/sortFilter.test.ts
+++ b/__tests__/utils/client/sortFilter.test.ts
@@ -11,12 +11,12 @@ describe('filterKeywords helpers', () => {
       added: '2024-01-01',
       position: 1,
       volume: 100,
-      sticky: false,
+      sticky: 0,
       history: {},
       lastResult: [],
       url: 'https://example.com',
       tags: ['seo'],
-      updating: false,
+      updating: 0,
       lastUpdateError: false,
       ...overrides,
    });
@@ -69,12 +69,12 @@ describe('sortKeywords', () => {
       added: '2024-01-01',
       position: 1,
       volume: 10,
-      sticky: false,
+      sticky: 0,
       history: {},
       lastResult: [],
       url: 'https://example.com',
       tags: [],
-      updating: false,
+      updating: 0,
       lastUpdateError: false,
       ...overrides,
    });
@@ -145,8 +145,8 @@ describe('sortKeywords', () => {
 
    it('keeps sticky keywords at the top after other sorts', () => {
       const keywords = [
-         buildKeyword({ ID: 1, keyword: 'bravo', sticky: true, added: '2024-01-03' }),
-         buildKeyword({ ID: 2, keyword: 'alpha', sticky: false, added: '2024-01-01' }),
+         buildKeyword({ ID: 1, keyword: 'bravo', sticky: 1, added: '2024-01-03' }),
+         buildKeyword({ ID: 2, keyword: 'alpha', sticky: 0, added: '2024-01-01' }),
       ];
 
       expect(sortKeywords(keywords, 'date_asc').map((k) => k.ID)).toEqual([1, 2]);

--- a/components/keywords/Keyword.tsx
+++ b/components/keywords/Keyword.tsx
@@ -240,7 +240,7 @@ const Keyword = (props: KeywordProps) => {
                   </li>
                   <li>
                      <a className={optionsButtonStyle}
-                     onClick={() => { favoriteKeyword({ keywordID: ID, sticky: sticky !== 1 }); setShowOptions(false); }}>
+                     onClick={() => { favoriteKeyword({ keywordID: ID, sticky: sticky === 1 ? 0 : 1 }); setShowOptions(false); }}>
                         <span className=' bg-yellow-300/30 text-yellow-500 px-1 rounded'>
                            <Icon type="star" size={14} />
                         </span> { sticky === 1 ? 'Unfavorite Keyword' : 'Favorite Keyword'}

--- a/components/keywords/Keyword.tsx
+++ b/components/keywords/Keyword.tsx
@@ -53,13 +53,13 @@ const Keyword = (props: KeywordProps) => {
         url = '',
         lastUpdated,
         country,
-        sticky,
+        sticky = 0,
         history = {},
-        updating = false,
+        updating = 0,
         lastUpdateError = false,
         volume,
         location,
-        mapPackTop3 = false,
+        mapPackTop3 = 0,
      } = keywordData;
 
    const [showOptions, setShowOptions] = useState(false);
@@ -134,7 +134,7 @@ const Keyword = (props: KeywordProps) => {
             >
                <span className="fflag-stack mr-2 flex-shrink-0">
                   <span className={`fflag fflag-${country} w-[18px] h-[12px]`} title={countries[country][0]} />
-                  {mapPackTop3 && (
+                  {mapPackTop3 === 1 && (
                      <span className="fflag fflag-map-pack w-[18px] h-[12px]" role="img" aria-label="Map pack top three" />
                   )}
                </span>
@@ -149,7 +149,7 @@ const Keyword = (props: KeywordProps) => {
                   )}
                </span>
             </a>
-            {sticky && <button className='ml-2 relative top-[2px]' title='Favorite'><Icon type="star-filled" size={16} color="#fbd346" /></button>}
+            {sticky === 1 && <button className='ml-2 relative top-[2px]' title='Favorite'><Icon type="star-filled" size={16} color="#fbd346" /></button>}
             {lastUpdateError && lastUpdateError.date
                && <button className='ml-2 relative top-[2px]' onClick={() => setPositionError(true)}>
                   <Icon type="error" size={18} color="#FF3672" />
@@ -160,7 +160,7 @@ const Keyword = (props: KeywordProps) => {
          <div
          className={`keyword_position absolute bg-[#f8f9ff] w-fit min-w-[50px] h-12 p-2 text-base mt-[-20px] rounded right-5 lg:relative
           lg:bg-transparent lg:w-auto lg:h-auto lg:mt-0 lg:p-0 lg:text-sm lg:flex-1 lg:basis-24 lg:grow-0 lg:right-0 text-center font-semibold`}>
-            <KeywordPosition position={position} updating={updating === 1} />
+            <KeywordPosition position={position} updating={updating} />
             {updating !== 1 && positionChange > 0 && <i className=' not-italic ml-1 text-xs text-[#5ed7c3]'>▲ {positionChange}</i>}
             {updating !== 1 && positionChange < 0 && <i className=' not-italic ml-1 text-xs text-red-300'>▼ {positionChange}</i>}
          </div>
@@ -240,10 +240,10 @@ const Keyword = (props: KeywordProps) => {
                   </li>
                   <li>
                      <a className={optionsButtonStyle}
-                     onClick={() => { favoriteKeyword({ keywordID: ID, sticky: !sticky }); setShowOptions(false); }}>
+                     onClick={() => { favoriteKeyword({ keywordID: ID, sticky: sticky !== 1 }); setShowOptions(false); }}>
                         <span className=' bg-yellow-300/30 text-yellow-500 px-1 rounded'>
                            <Icon type="star" size={14} />
-                        </span> { sticky ? 'Unfavorite Keyword' : 'Favorite Keyword'}
+                        </span> { sticky === 1 ? 'Unfavorite Keyword' : 'Favorite Keyword'}
                      </a>
                   </li>
                   <li><a className={optionsButtonStyle} onClick={() => { manageTags(); setShowOptions(false); }}>

--- a/components/keywords/KeywordDetails.tsx
+++ b/components/keywords/KeywordDetails.tsx
@@ -30,7 +30,7 @@ const KeywordDetails = ({ keyword, closeDetails }:KeywordDetailsProps) => {
    const keywordLocalResults: KeywordLocalResult[] = Array.isArray(keywordLocalResultsRaw)
       ? keywordLocalResultsRaw
       : fallbackLocalResults;
-   const mapPackTop3 = (keywordData?.mapPackTop3 ?? keyword.mapPackTop3) === true;
+   const mapPackTop3 = (keywordData?.mapPackTop3 ?? keyword.mapPackTop3) === 1;
    const dateOptions = [
       { label: 'Last 7 Days', value: '7' },
       { label: 'Last 30 Days', value: '30' },

--- a/components/keywords/KeywordPosition.tsx
+++ b/components/keywords/KeywordPosition.tsx
@@ -2,15 +2,17 @@ import Icon from '../common/Icon';
 
 type KeywordPositionProps = {
    position: number,
-   updating?: boolean,
+   updating?: number,
    type?: string,
 }
 
-const KeywordPosition = ({ position = 0, type = '', updating = false }:KeywordPositionProps) => {
-   if (!updating && position === 0) {
+const KeywordPosition = ({ position = 0, type = '', updating = 0 }:KeywordPositionProps) => {
+   const isUpdating = updating === 1;
+
+   if (!isUpdating && position === 0) {
       return <span className='text-gray-400' title='Not in Top 100'>{'>100'}</span>;
    }
-   if (updating && type !== 'sc') {
+   if (isUpdating && type !== 'sc') {
       return <span title='Updating Keyword Position'><Icon type="loading" /></span>;
    }
    return <>{Math.round(position)}</>;

--- a/utils/client/sortFilter.ts
+++ b/utils/client/sortFilter.ts
@@ -120,7 +120,9 @@ export const sortKeywords = (theKeywords:KeywordType[], sortBy:string, scDataTyp
    }
 
    // Stick Favorites item to top
-   sortedItems = [...sortedItems].sort((a: KeywordType, b: KeywordType) => (b.sticky === a.sticky ? 0 : (b.sticky ? 1 : -1)));
+   sortedItems = [...sortedItems].sort((a: KeywordType, b: KeywordType) => (
+      b.sticky === a.sticky ? 0 : (b.sticky === 1 ? 1 : -1)
+   ));
 
    return sortedItems;
 };


### PR DESCRIPTION
### Motivation
- The app mixes boolean and numeric representations for keyword flags (`updating`, `sticky`, `mapPackTop3`), causing inconsistent UI behavior for spinners and favorites.
- Convert these flags to a single numeric convention (0/1) so UI checks can reliably use `=== 1` and avoid boolean/number mixing.
- Update consumer components and client-side sorting to treat the flags as numeric to prevent rendering regressions when back-end returns numeric values.

### Description
- Replace boolean normalization with numeric coercion in `services/keywords.tsx` by adding `normaliseKeywordFlag` and returning `updating`, `sticky`, and `mapPackTop3` as `0` or `1` for both list and single-keyword fetches.
- Update polling logic in `useFetchKeywords` to check `x.updating === 1` and stop polling when all keywords are `0`.
- Change `components/keywords/Keyword.tsx` to default `updating`, `sticky`, and `mapPackTop3` to numeric values and use numeric comparisons (e.g., `sticky === 1`, `mapPackTop3 === 1`) and send `sticky: sticky !== 1` when toggling favorite.
- Update `components/keywords/KeywordPosition.tsx` to accept `updating?: number`, compute `isUpdating = updating === 1`, and render the loading icon when `isUpdating`.
- Adjust client-side sort behavior in `utils/client/sortFilter.ts` to treat `sticky` as numeric (compare with `=== 1`).
- Update mocks and tests to use numeric `0/1` for the flags and ensure `useFetchSingleKeyword` returns normalized `mapPackTop3` as numeric.

### Testing
- Ran the full test suite with `npm test`; overall result: `101` test suites passed and `4` failed out of `105` total, with failing suites: `__tests__/utils/refresh.test.ts`, `__tests__/api/notify.test.ts`, `__tests__/utils/refresh-business-name.test.ts`, and `__tests__/components/DomainItem.test.tsx`.
- Linting completed successfully with `npm run lint` and CSS linting succeeded with `npm run lint:css`.
- Updated unit tests touching keyword normalization and client sorting (`__tests__/services/keywords.fetchKeywords.test.ts`, `__tests__/utils/client/sortFilter.test.ts`, and related mocks) to reflect numeric 0/1 flags and those updated tests pass locally except for the suites listed above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ca4dd098832aa159d918a025a96e)