### PR TITLE
Preserve parsed settings on decryption/parse errors and only create defaults when file is missing

### DIFF
--- a/__tests__/cron.worker.test.ts
+++ b/__tests__/cron.worker.test.ts
@@ -60,6 +60,7 @@ describe('getAppSettings', () => {
     smtp_port: '',
     smtp_username: '',
     smtp_password: '',
+    scrape_interval: '',
   };
   let originalSettingsContent = '';
   const originalSecret = process.env.SECRET;
@@ -101,6 +102,8 @@ describe('getAppSettings', () => {
     expect(settings).toEqual(expect.objectContaining({
       scraper_type: 'serpapi',
       notification_interval: 'daily',
+      scraping_api: '',
+      smtp_password: '',
     }));
   });
 
@@ -117,5 +120,24 @@ describe('getAppSettings', () => {
     expect(updatedContent).toBe(invalidContent);
     expect(writeSpy).not.toHaveBeenCalled();
     writeSpy.mockRestore();
+  });
+
+  it('creates settings file with defaults when file is missing (ENOENT)', async () => {
+    const { unlink } = require('fs/promises');
+    const { getAppSettings } = require('../cron.js');
+    
+    // Ensure file doesn't exist
+    try {
+      await unlink(settingsPath);
+    } catch (_error) {
+      // File may already not exist, which is fine
+    }
+
+    const settings = await getAppSettings();
+    const createdContent = await fsPromises.readFile(settingsPath, { encoding: 'utf-8' });
+    const createdSettings = JSON.parse(createdContent);
+
+    expect(settings).toEqual(defaultSettings);
+    expect(createdSettings).toEqual(defaultSettings);
   });
 });

--- a/__tests__/cron.worker.test.ts
+++ b/__tests__/cron.worker.test.ts
@@ -48,3 +48,74 @@ describe('cron worker helpers', () => {
     expect(normalizeCronExpression(0, '0 0 0 * * *')).toBe('0 0 0 * * *');
   });
 });
+
+describe('getAppSettings', () => {
+  const { promises: fsPromises } = require('fs');
+  const settingsPath = `${process.cwd()}/data/settings.json`;
+  const defaultSettings = {
+    scraper_type: 'none',
+    notification_interval: 'never',
+    notification_email: '',
+    smtp_server: '',
+    smtp_port: '',
+    smtp_username: '',
+    smtp_password: '',
+  };
+  let originalSettingsContent = '';
+  const originalSecret = process.env.SECRET;
+
+  beforeAll(async () => {
+    originalSettingsContent = await fsPromises.readFile(settingsPath, { encoding: 'utf-8' });
+  });
+
+  afterEach(async () => {
+    process.env.SECRET = originalSecret;
+    jest.unmock('cryptr');
+    jest.resetModules();
+    jest.restoreAllMocks();
+    await fsPromises.writeFile(settingsPath, originalSettingsContent, { encoding: 'utf-8' });
+  });
+
+  afterAll(() => {
+    process.env.SECRET = originalSecret;
+  });
+
+  it('returns non-sensitive settings when decryption fails', async () => {
+    const settingsPayload = {
+      scraper_type: 'serpapi',
+      notification_interval: 'daily',
+      scraping_api: 'encrypted-value',
+      smtp_password: 'encrypted-password',
+    };
+    await fsPromises.writeFile(settingsPath, JSON.stringify(settingsPayload), { encoding: 'utf-8' });
+
+    jest.doMock('cryptr', () => jest.fn(() => {
+      throw new Error('Missing secret');
+    }));
+
+    // @ts-expect-error - test case for missing secret
+    delete process.env.SECRET;
+    const { getAppSettings } = require('../cron.js');
+    const settings = await getAppSettings();
+
+    expect(settings).toEqual(expect.objectContaining({
+      scraper_type: 'serpapi',
+      notification_interval: 'daily',
+    }));
+  });
+
+  it('returns defaults without overwriting invalid JSON settings', async () => {
+    const invalidContent = '{not-json';
+    await fsPromises.writeFile(settingsPath, invalidContent, { encoding: 'utf-8' });
+
+    const writeSpy = jest.spyOn(fsPromises, 'writeFile');
+    const { getAppSettings } = require('../cron.js');
+    const settings = await getAppSettings();
+    const updatedContent = await fsPromises.readFile(settingsPath, { encoding: 'utf-8' });
+
+    expect(settings).toEqual(defaultSettings);
+    expect(updatedContent).toBe(invalidContent);
+    expect(writeSpy).not.toHaveBeenCalled();
+    writeSpy.mockRestore();
+  });
+});

--- a/cron.js
+++ b/cron.js
@@ -69,8 +69,8 @@ const getAppSettings = async () => {
          console.error('Error Decrypting Settings API Keys!', error);
          return {
             ...settings,
-            scraping_api: settings.scraping_api || '',
-            smtp_password: settings.smtp_password || ''
+            scraping_api: '',
+            smtp_password: ''
          };
       }
    } catch (error) {

--- a/cron.js
+++ b/cron.js
@@ -38,6 +38,17 @@ const CRON_MAIN_SCHEDULE = normalizeCronExpression(process.env.CRON_MAIN_SCHEDUL
 const CRON_EMAIL_SCHEDULE = normalizeCronExpression(process.env.CRON_EMAIL_SCHEDULE, '0 0 6 * * *');
 const CRON_FAILED_SCHEDULE = normalizeCronExpression(process.env.CRON_FAILED_SCHEDULE, '0 0 */1 * * *');
 
+/**
+ * Get application settings from data/settings.json
+ * 
+ * Error handling behavior:
+ * - ENOENT (file missing): Creates file with defaults and returns defaults
+ * - Invalid JSON: Returns defaults WITHOUT overwriting the file (to preserve recoverable data)
+ * - Decryption failure: Returns parsed settings with empty strings for encrypted fields
+ * 
+ * Note: This differs from pages/api/settings.ts which overwrites the file on ANY read error.
+ * The cron worker is more conservative to avoid data loss during automated operations.
+ */
 const getAppSettings = async () => {
    const settingsPath = `${process.cwd()}/data/settings.json`;
    const defaultSettings = {
@@ -47,7 +58,8 @@ const getAppSettings = async () => {
       smtp_server: '',
       smtp_port: '',
       smtp_username: '',
-      smtp_password: ''
+      smtp_password: '',
+      scrape_interval: '',
    };
    // console.log('process.env.SECRET: ', process.env.SECRET);
    try {


### PR DESCRIPTION
### Motivation
- Prevent losing non-sensitive configuration when decryption fails (e.g. missing `SECRET`) by returning the parsed settings instead of an empty object. 
- Avoid overwriting a potentially recoverable `data/settings.json` when that file contains invalid JSON; return defaults but do not modify the file. 
- Ensure the default settings file is only written when the file is actually missing (`ENOENT`).

### Description
- Updated `getAppSettings` in `cron.js` to read `data/settings.json` into a `settings` object and handle JSON parse errors by logging and returning `defaultSettings` without writing to disk. 
- On decryption errors (e.g. `new Cryptr(process.env.SECRET)` throwing), return the parsed `settings` object and keep encrypted fields as-is or set them to empty strings, rather than dropping other fields. 
- Only write `defaultSettings` to `data/settings.json` when the read error has `code === 'ENOENT'`. 
- Exported `getAppSettings` from `cron.js` so it can be tested. 
- Added/updated tests in `__tests__/cron.worker.test.ts` covering decryption failure fallback and invalid JSON handling without overwriting the settings file.

### Testing
- Added two unit tests in `__tests__/cron.worker.test.ts`: one to confirm non-sensitive settings are returned when decryption fails, and one to confirm invalid JSON does not trigger an overwrite and returns defaults; both tests pass. 
- Ran full test suite with `npm test` and observed all tests passing (`107` test suites, `561` tests). 
- Ran linting and style checks with `npm run lint` and `npm run lint:css`; linter runs completed successfully after the small test fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69783d5a1d44832a9e2acadf5ed488bc)