### PR TITLE
Simplify manual refresh keyword flag updates

### DIFF
--- a/pages/api/refresh.ts
+++ b/pages/api/refresh.ts
@@ -174,9 +174,9 @@ const refreshTheKeywords = async (req: NextApiRequest, res: NextApiResponse<Keyw
       const keywordIdsToRefresh = keywordsToRefresh.map((keyword) => keyword.ID);
       const now = new Date().toJSON();
       await Promise.all(
-         keywordsToRefresh.map(async (keyword) => {
-            await keyword.update({ updating: toDbBool(true), lastUpdateError: 'false', updatingStartedAt: now });
-         }),
+         keywordsToRefresh.map((keyword) =>
+            keyword.update({ updating: toDbBool(true), lastUpdateError: 'false', updatingStartedAt: now }),
+         ),
       );
 
       // Generate unique task ID using crypto to prevent collisions in concurrent scenarios


### PR DESCRIPTION
### Motivation
- Reduce unnecessary async wrapping when marking keywords as updating before enqueuing a manual refresh by simplifying the per-keyword update call to avoid extra micro-tasks and clarify intent.

### Description
- Replace the `Promise.all(keywordsToRefresh.map(async (keyword) => { await keyword.update(...) }))` pattern with a direct `Promise.all(keywordsToRefresh.map((keyword) => keyword.update(...)))` call in `pages/api/refresh.ts`, preserving the same flag values and existing usage of `clearKeywordUpdatingFlags`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886a5390f8832a9d6c890f425e83d5)