### PR TITLE
Use bulk Keyword.update to set updating flags for refresh

### DIFF
--- a/pages/api/cron.ts
+++ b/pages/api/cron.ts
@@ -87,19 +87,17 @@ const processSingleDomain = async (domain: string, settings: SettingsType): Prom
       
       const now = new Date().toJSON();
       keywordQueries = await Keyword.findAll({ where: { domain } });
-      await Promise.all(
-         keywordQueries.map(async (keyword) => {
-            await keyword.update({ updating: toDbBool(true), lastUpdateError: 'false', updatingStartedAt: now });
-            if (typeof keyword.reload === 'function') {
-               await keyword.reload();
-            }
-         }),
-      );
       
       if (keywordQueries.length === 0) {
          logger.info(`No keywords found for domain: ${domain}`);
          return;
       }
+
+      const keywordIds = keywordQueries.map((keyword) => keyword.ID);
+      await Keyword.update(
+         { updating: toDbBool(true), lastUpdateError: 'false', updatingStartedAt: now },
+         { where: { ID: keywordIds } },
+      );
       
       logger.info(`Processing ${keywordQueries.length} keywords for domain: ${domain}`);
       

--- a/pages/api/refresh.ts
+++ b/pages/api/refresh.ts
@@ -175,10 +175,9 @@ const refreshTheKeywords = async (req: NextApiRequest, res: NextApiResponse<Keyw
 
       const keywordIdsToRefresh = keywordsToRefresh.map((keyword) => keyword.ID);
       const now = new Date().toJSON();
-      await Promise.all(
-         keywordsToRefresh.map((keyword) =>
-            keyword.update({ updating: toDbBool(true), lastUpdateError: 'false', updatingStartedAt: now }),
-         ),
+      await Keyword.update(
+         { updating: toDbBool(true), lastUpdateError: 'false', updatingStartedAt: now },
+         { where: { ID: { [Op.in]: keywordIdsToRefresh } } },
       );
 
       // Generate unique task ID using crypto to prevent collisions in concurrent scenarios


### PR DESCRIPTION
### Motivation
- Reduce the number of per-row DB calls and lower SQLite lock contention when marking keywords as `updating` during manual and cron-driven refreshes.

### Description
- In `pages/api/refresh.ts` replace the per-keyword `Promise.all(... keyword.update(...))` with a single `Keyword.update(...)` scoped to the IDs in `keywordIdsToRefresh`.
- In `pages/api/cron.ts` move the `updating` flag write to a single `Keyword.update(...)` after loading `keywordQueries` and remove the previous per-row pre-update and reload loop.
- Preserve existing per-row clearing of `updating` flags on error so error handling behavior is unchanged.

### Testing
- No automated tests were run for this change (existing test suite was not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988716be9e0832a819307b63ad06567)