### PR TITLE
docs: document refresh queue concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. Releases no
 ### Documentation
 - Documented the fork's stability, security, and performance improvements at the top of the README for quick comparison with upstream SerpBear.
 - Clarified that local development must use Node.js 20.18.1+ to align with the `.nvmrc` pin and dependency requirements.
+- Documented refresh queue concurrency controls and per-domain locking behavior in the README configuration reference.
 
 ### Build
 - Adopted `@stylistic/stylelint-plugin` and upgraded Stylelint tooling to v16 so indentation rules continue working under the plugin namespace.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Not every scraper provider is validated on every release—please report any iss
 - **Frontend & API:** Next.js 15 application serving React pages and JSON endpoints from a single codebase.
 - **Database:** SQLite (via a custom `better-sqlite3` dialect) by default, with optional external database support through Sequelize.
 - **Background workers:** Node-based cron runner schedules scrapes, retries, Google Search Console refreshes, and notification emails according to configurable cron expressions and timezone settings.
+- **Refresh queue:** Per-domain locking ensures the same domain is never refreshed twice simultaneously, while configurable concurrency keeps multiple domains processing in parallel.
 - **Integrations:** Scraper selection, Google Ads credentials, and SMTP settings are managed in the Settings UI (persisted in `data/settings.json`), while Search Console credentials can be supplied in Settings or via the `SEARCH_CONSOLE_*` environment variables as a global fallback.
 
 ![Animated dashboard tour](https://serpbear.b-cdn.net/serpbear_readme_v2.gif "Animated dashboard tour")
@@ -175,6 +176,7 @@ All cron expressions are normalised at runtime—quotes and stray whitespace are
 | `LOG_LEVEL` | `info` | Optional | Controls log verbosity for the structured logger. Accepts `error`, `warn`, `info`, `debug`; set to `off`, `none`, `false`, or `0` to disable logging. |
 | `LOG_SUCCESS_EVENTS` | — | Optional | Reserved for future use; ignored in the current codebase. |
 | `NEXT_REMOVE_CONSOLE` | — | Optional | Not wired in `next.config.js`; currently has no effect. |
+| `REFRESH_QUEUE_CONCURRENCY` | `3` | Optional | Maximum number of domains that can be refreshed in parallel. The queue still prevents duplicate refreshes for the same domain. |
 
 Set `ANALYZE=true` before running `next build` to generate a static bundle analysis report (`bundle-analyzer-report.html`) as configured in [`next.config.js`](./next.config.js).
 


### PR DESCRIPTION
### Motivation
- Document the new refresh queue behaviour so operators understand the per-domain locking and how to control parallel domain refreshes via an environment variable.

### Description
- Updated `README.md` to add a short `Refresh queue` overview in the architecture section and to document the `REFRESH_QUEUE_CONCURRENCY` env var in the configuration reference, and updated `CHANGELOG.md` to note the documentation entry.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698863db2284832aa4330ec7c904a754)