### PR TITLE
Allow API-key clients to access /api/ideas (GET, POST)

### DIFF
--- a/__tests__/utils/verifyUser.test.ts
+++ b/__tests__/utils/verifyUser.test.ts
@@ -135,6 +135,29 @@ describe('verifyUser', () => {
          expect(result).toBe('authorized');
       });
 
+
+      it('should allow API key access to ideas GET route', () => {
+         process.env.APIKEY = 'test-api-key';
+         req.headers = { authorization: 'Bearer test-api-key' };
+         req.url = '/api/ideas';
+         req.method = 'GET';
+
+         const result = verifyUser(req as NextApiRequest, res as NextApiResponse);
+
+         expect(result).toBe('authorized');
+      });
+
+      it('should allow API key access to ideas POST route', () => {
+         process.env.APIKEY = 'test-api-key';
+         req.headers = { authorization: 'Bearer test-api-key' };
+         req.url = '/api/ideas';
+         req.method = 'POST';
+
+         const result = verifyUser(req as NextApiRequest, res as NextApiResponse);
+
+         expect(result).toBe('authorized');
+      });
+
       it('should reject API key access to non-allowed routes', () => {
          process.env.APIKEY = 'test-api-key';
          req.headers = { authorization: 'Bearer test-api-key' };

--- a/utils/verifyUser.ts
+++ b/utils/verifyUser.ts
@@ -25,6 +25,8 @@ const verifyUser = (req: NextApiRequest, res: NextApiResponse): string => {
       'POST:/api/searchconsole',
       'GET:/api/searchconsole',
       'GET:/api/insight',
+      'GET:/api/ideas',
+      'POST:/api/ideas',
    ];
    
    // Validate Bearer prefix before extracting API key


### PR DESCRIPTION
### Motivation
- API-key authenticated clients were blocked from the ideas/discovery endpoints because `utils/verifyUser.ts` did not include `/api/ideas` in the API-key allowlist, preventing discovery flows and saved-ideas access.

### Description
- Added `'GET:/api/ideas'` and `'POST:/api/ideas'` to the `allowedApiRoutes` array in `utils/verifyUser.ts` and added two unit tests to `__tests__/utils/verifyUser.test.ts` that assert API-key access is allowed for `GET /api/ideas` and `POST /api/ideas` while leaving existing route restrictions intact.

### Testing
- Ran the targeted test file with `npm test -- __tests__/utils/verifyUser.test.ts`, and the suite passed (`10 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13005e59d0832ab6c7c716b5f119e0)