### PR TITLE
Upgrade Google Ads API usage and harden cleanup/auth edge cases

### DIFF
--- a/__tests__/api/adwords.test.ts
+++ b/__tests__/api/adwords.test.ts
@@ -240,6 +240,30 @@ describe('GET /api/adwords - refresh token retrieval', () => {
    });
 });
 
+
+  it('allows OAuth callback GET with code without verifyUser authorization', async () => {
+      (verifyUser as jest.Mock).mockReturnValue('not authorized');
+      getTokenMock.mockResolvedValue({ tokens: { refresh_token: 'refresh-token' } });
+
+      const req = {
+         method: 'GET',
+         query: { code: 'auth-code' },
+         headers: { host: 'localhost:3000' },
+      } as unknown as NextApiRequest;
+
+      const res = {
+         status: jest.fn().mockReturnThis(),
+         setHeader: jest.fn().mockReturnThis(),
+         send: jest.fn(),
+         json: jest.fn(),
+      } as unknown as NextApiResponse;
+
+      await handler(req, res);
+
+      expect(verifyUser).not.toHaveBeenCalled();
+      expect(getTokenMock).toHaveBeenCalledWith('auth-code');
+      expect(res.status).toHaveBeenCalledWith(200);
+   });
 describe('POST /api/adwords - validate integration', () => {
    const originalEnv = process.env;
 

--- a/__tests__/api/domains.test.ts
+++ b/__tests__/api/domains.test.ts
@@ -25,7 +25,7 @@ jest.mock('../../database/models/domain', () => ({
 
 jest.mock('../../database/models/keyword', () => ({
   __esModule: true,
-  default: { destroy: jest.fn() },
+  default: { destroy: jest.fn(), findAll: jest.fn() },
 }));
 
 jest.mock('../../utils/verifyUser', () => ({
@@ -47,7 +47,7 @@ jest.mock('../../utils/apiLogging', () => ({
 const verifyUserMock = verifyUser as unknown as jest.Mock;
 const dbMock = db as unknown as { sync: jest.Mock };
 const DomainMock = Domain as unknown as { findOne: jest.Mock; destroy: jest.Mock; bulkCreate: jest.Mock; findAll: jest.Mock };
-const KeywordMock = Keyword as unknown as { destroy: jest.Mock };
+const KeywordMock = Keyword as unknown as { destroy: jest.Mock; findAll: jest.Mock };
 const removeLocalSCDataMock = removeLocalSCData as unknown as jest.Mock;
 
 describe('GET /api/domains', () => {
@@ -605,6 +605,7 @@ describe('DELETE /api/domains', () => {
     dbMock.sync.mockResolvedValue(undefined);
     DomainMock.destroy.mockResolvedValue(1);
     KeywordMock.destroy.mockResolvedValue(0);
+    KeywordMock.findAll.mockResolvedValue([]);
     removeLocalSCDataMock.mockResolvedValue(false);
   });
 
@@ -623,6 +624,7 @@ describe('DELETE /api/domains', () => {
 
     expect(DomainMock.destroy).toHaveBeenCalledWith({ where: { domain: 'missing.example.com' } });
     expect(KeywordMock.destroy).not.toHaveBeenCalled();
+    expect(KeywordMock.findAll).not.toHaveBeenCalled();
     expect(removeLocalSCDataMock).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({

--- a/__tests__/api/keywords.test.ts
+++ b/__tests__/api/keywords.test.ts
@@ -50,6 +50,11 @@ jest.mock('../../scrapers/index', () => ({
   default: [],
 }));
 
+jest.mock('../../utils/retryQueueManager', () => ({
+  __esModule: true,
+  retryQueueManager: { removeBatch: jest.fn().mockResolvedValue(undefined) },
+}));
+
 jest.mock('../../utils/apiLogging', () => ({
   __esModule: true,
   withApiLogging: (handler: any) => handler,
@@ -556,5 +561,23 @@ describe('PUT /api/keywords tags updates', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+});
+
+
+describe('DELETE /api/keywords retry queue cleanup', () => {
+  it('removes deleted keyword IDs from retry queue', async () => {
+    const { retryQueueManager } = require('../../utils/retryQueueManager');
+    verifyUserMock.mockReturnValue('authorized');
+    keywordMock.findAll.mockResolvedValue([{ ID: 1, domain: 'example.com' }, { ID: 2, domain: 'example.com' }]);
+    keywordMock.destroy.mockResolvedValue(2);
+
+    const req = { method: 'DELETE', query: { id: '1,2' }, headers: {} } as unknown as NextApiRequest;
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as NextApiResponse;
+
+    await handler(req, res);
+
+    expect(retryQueueManager.removeBatch).toHaveBeenCalledWith(new Set([1, 2]));
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/__tests__/utils/adwordsKeywordIdeas.test.ts
+++ b/__tests__/utils/adwordsKeywordIdeas.test.ts
@@ -183,22 +183,22 @@ describe('getKeywordsVolume', () => {
     // and endpoint format for generateKeywordHistoricalMetrics, addressing the issue request
     
     // Verify the GOOGLE_ADS_API_VERSION constant is properly exported and used
-    expect(adwordsUtils.GOOGLE_ADS_API_VERSION).toBe('v21');
+    expect(adwordsUtils.GOOGLE_ADS_API_VERSION).toBe('v23');
     
     // Test URL construction pattern by checking what the function would build
     const testAccountId = '123-456-7890';
     const expectedUrlPattern = `https://googleads.googleapis.com/${adwordsUtils.GOOGLE_ADS_API_VERSION}/customers/${testAccountId.replace(/-/g, '')}:generateKeywordHistoricalMetrics`;
-    const expectedUrl = `https://googleads.googleapis.com/v21/customers/1234567890:generateKeywordHistoricalMetrics`;
+    const expectedUrl = `https://googleads.googleapis.com/v23/customers/1234567890:generateKeywordHistoricalMetrics`;
     
     expect(expectedUrlPattern).toBe(expectedUrl);
     
     // Verify this matches the pattern from the successful getAdwordsKeywordIdeas test 
     const keywordIdeasUrl = `https://googleads.googleapis.com/${adwordsUtils.GOOGLE_ADS_API_VERSION}/customers/1234567890:generateKeywordIdeas`;
-    expect(keywordIdeasUrl).toBe('https://googleads.googleapis.com/v21/customers/1234567890:generateKeywordIdeas');
+    expect(keywordIdeasUrl).toBe('https://googleads.googleapis.com/v23/customers/1234567890:generateKeywordIdeas');
     
     // The key insight: both functions should use the same API version and URL pattern
-    // getKeywordsVolume should construct: .../v21/customers/[ID]:generateKeywordHistoricalMetrics 
-    // getAdwordsKeywordIdeas constructs: .../v21/customers/[ID]:generateKeywordIdeas
+    // getKeywordsVolume should construct: .../v23/customers/[ID]:generateKeywordHistoricalMetrics 
+    // getAdwordsKeywordIdeas constructs: .../v23/customers/[ID]:generateKeywordIdeas
     expect(expectedUrl.replace(':generateKeywordHistoricalMetrics', ':generateKeywordIdeas')).toBe(keywordIdeasUrl);
     
     // Additional verification: test the URL construction with the specific constants
@@ -206,7 +206,7 @@ describe('getKeywordsVolume', () => {
     const baseUrl = `https://googleads.googleapis.com/${adwordsUtils.GOOGLE_ADS_API_VERSION}/customers/${customerId}`;
     
     expect(`${baseUrl}:generateKeywordHistoricalMetrics`).toBe(
-      'https://googleads.googleapis.com/v21/customers/1234567890:generateKeywordHistoricalMetrics'
+      'https://googleads.googleapis.com/v23/customers/1234567890:generateKeywordHistoricalMetrics'
     );
     
     console.log('✓ Verified getKeywordsVolume uses correct API version and URL format');

--- a/__tests__/utils/scraper.test.ts
+++ b/__tests__/utils/scraper.test.ts
@@ -184,6 +184,14 @@ describe('getSerp', () => {
   });
 });
 
+
+  it('matches domains when only www prefix differs', () => {
+    const results: Array<{ title: string; url: string; position: number }> = [
+      { position: 1, url: 'https://www.example.com/a', title: '' },
+    ];
+    const serp = getSerp('example.com', results);
+    expect(serp.position).toBe(1);
+  });
 describe('scraper error handling', () => {
   const originalFetch = global.fetch;
 

--- a/pages/api/adwords.ts
+++ b/pages/api/adwords.ts
@@ -88,6 +88,11 @@ const respondWithIntegrationResult = (
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
    const requestId = (req as ExtendedRequest).requestId;
+
+   if (req.method === 'GET' && typeof req.query.code === 'string' && req.query.code.trim()) {
+      return getAdwordsRefreshToken(req, res);
+   }
+
    const authorized = verifyUser(req, res);
    if (authorized !== 'authorized') {
       return res.status(401).json(errorResponse('UNAUTHORIZED', authorized, requestId));

--- a/pages/api/domains.ts
+++ b/pages/api/domains.ts
@@ -20,6 +20,7 @@ import { toDbBool } from '../../utils/dbBooleans';
 import { safeJsonParse } from '../../utils/safeJsonParse';
 import normalizeDomainBooleans from '../../utils/normalizeDomain';
 import { errorResponse } from '../../utils/api/response';
+import { retryQueueManager } from '../../utils/retryQueueManager';
 
 const TRUTHY = new Set(['true', '1', 'on', 'yes']);
 const FALSY = new Set(['false', '0', 'off', 'no']);
@@ -185,7 +186,12 @@ export const deleteDomain = async (req: NextApiRequest, res: NextApiResponse) =>
       if (removedDomCount === 0) {
          return res.status(404).json(errorResponse('NOT_FOUND', 'Domain not found', requestId));
       }
+      const keywordsToRemove = await Keyword.findAll({ where: { domain }, attributes: ['ID'] });
+      const keywordIdsToRemove = new Set<number>(keywordsToRemove.map((keyword) => keyword.ID).filter((id): id is number => Number.isFinite(id)));
       const removedKeywordCount: number = await Keyword.destroy({ where: { domain } });
+      if (keywordIdsToRemove.size > 0) {
+         await retryQueueManager.removeBatch(keywordIdsToRemove);
+      }
       const SCDataRemoved = await removeLocalSCData(domain as string);
       return res.status(200).json({ domainRemoved: removedDomCount, keywordsRemoved: removedKeywordCount, SCDataRemoved });
    } catch (error) {

--- a/pages/api/keywords.ts
+++ b/pages/api/keywords.ts
@@ -15,6 +15,7 @@ import { withApiLogging } from '../../utils/apiLogging';
 import { toDbBool } from '../../utils/dbBooleans';
 import { refreshQueue } from '../../utils/refreshQueue';
 import { errorResponse } from '../../utils/api/response';
+import { retryQueueManager } from '../../utils/retryQueueManager';
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
    const requestId = (req as ExtendedRequest).requestId;
@@ -371,6 +372,7 @@ const deleteKeywords = async (req: NextApiRequest, res: NextApiResponse) => {
       
       const removeQuery = { where: { ID: { [Op.in]: keywordsToRemove } } };
       const removedKeywordCount: number = await Keyword.destroy(removeQuery);
+      await retryQueueManager.removeBatch(new Set(keywordsToRemove));
       return res.status(200).json({ keywordsRemoved: removedKeywordCount });
    } catch (error) {
       logger.error('Removing Keyword. ', error instanceof Error ? error : new Error(String(error)));

--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -9,7 +9,7 @@ import countries from './countries';
 import { readLocalSCData } from './searchConsole';
 import { logger } from './logger';
 
-export const GOOGLE_ADS_API_VERSION = 'v21';
+export const GOOGLE_ADS_API_VERSION = 'v23';
 
 const memoryCache = new TTLCache({ max: 10000 });
 

--- a/utils/scraper.ts
+++ b/utils/scraper.ts
@@ -819,6 +819,8 @@ const resolveResultURL = (value: string | undefined | null): URL | null => {
    }
 };
 
+const normalizeComparableHost = (host: string): string => host.replace(/^www\./i, '').toLowerCase();
+
 export const getSerp = (domainURL:string, result:SearchResult[]) : SERPObject => {
    if (result.length === 0 || !domainURL) { return { position: 0, url: '' }; }
 
@@ -830,7 +832,7 @@ export const getSerp = (domainURL:string, result:SearchResult[]) : SERPObject =>
       return { position: 0, url: '' };
    }
 
-   const targetHost = URLToFind.hostname;
+   const targetHost = normalizeComparableHost(URLToFind.hostname);
    const targetPath = URLToFind.pathname.replace(/\/$/, '');
    const hasSpecificPath = targetPath.length > 0;
 
@@ -844,9 +846,9 @@ export const getSerp = (domainURL:string, result:SearchResult[]) : SERPObject =>
 
       const itemPath = parsedURL.pathname.replace(/\/$/, '');
       if (hasSpecificPath) {
-         return parsedURL.hostname === targetHost && itemPath === targetPath;
+         return normalizeComparableHost(parsedURL.hostname) === targetHost && itemPath === targetPath;
       }
-      return parsedURL.hostname === targetHost;
+      return normalizeComparableHost(parsedURL.hostname) === targetHost;
    });
 
    const foundItem = matchingItems.length > 0


### PR DESCRIPTION
## Summary
This PR implements the requested Ads/scraping reliability updates in one combined change set:

1. **Google Ads API version bump**
   - Updated `GOOGLE_ADS_API_VERSION` from `v21` to `v23` in `utils/adwords.ts`.
   - Updated related assertions in Ads unit tests.

2. **OAuth callback auth bypass fix**
   - In `pages/api/adwords.ts`, the handler now routes `GET` callbacks with a non-empty `?code=` directly to `getAdwordsRefreshToken` **before** `verifyUser`.
   - This prevents OAuth callback failures when auth/cookie/session conditions are impacted by reverse proxy behavior.

3. **Retry queue cleanup on deletions**
   - In `pages/api/domains.ts`, domain deletion now collects matching keyword IDs and calls `retryQueueManager.removeBatch(...)` after keyword deletion.
   - In `pages/api/keywords.ts`, keyword deletion now removes deleted IDs from the retry queue via `retryQueueManager.removeBatch(new Set(ids))`.

4. **www-prefixed host matching in SERP detection**
   - In `utils/scraper.ts`, `getSerp()` now normalizes hosts by stripping leading `www.` and lowercasing before comparison.
   - This avoids false misses between `example.com` and `www.example.com`.

## Tests Updated
- `__tests__/utils/adwordsKeywordIdeas.test.ts`
- `__tests__/api/adwords.test.ts`
- `__tests__/api/domains.test.ts`
- `__tests__/api/keywords.test.ts`
- `__tests__/utils/scraper.test.ts`

## Notes
- Subdomain inclusion patterns (comma-separated or `*`) were not implemented in this PR; that appears to be a separate feature addition rather than a direct regression fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1324fba074832a865f4ad473100f6a)