### PR TITLE
Potential fix for code scanning alert no. 1116: Server-side request forgery

### DIFF
--- a/utils/adwords.ts
+++ b/utils/adwords.ts
@@ -304,7 +304,17 @@ export const getAdwordsKeywordIdeas = async (credentials: AdwordsCredentials, ad
 
       try {
          // API: https://developers.google.com/google-ads/api/rest/reference/rest/v21/customers/generateKeywordIdeas
-         const customerID = account_id.replaceAll('-', '');
+         // Accept only Google Ads customer IDs in expected format: digits with optional dashes.
+         const normalizedAccountId = typeof account_id === 'string' ? account_id.trim() : '';
+         if (!/^\d[\d-]*\d$|^\d$/.test(normalizedAccountId)) {
+            logger.warn('Skipping keyword idea lookup: invalid Google Ads account_id format');
+            return [];
+         }
+         const customerID = normalizedAccountId.replaceAll('-', '');
+         if (!/^\d{10}$/.test(customerID)) {
+            logger.warn('Skipping keyword idea lookup: invalid Google Ads customerID length');
+            return [];
+         }
          const countryData = countries[country];
          const geoTargetConstants = countryData ? countryData[3] : undefined;
 


### PR DESCRIPTION
Potential fix for [https://github.com/djav1985/v-serpbear/security/code-scanning/1116](https://github.com/djav1985/v-serpbear/security/code-scanning/1116)

General fix: never place raw user input in request URLs. Normalize and strictly validate identifier components (like Google Ads customer IDs) against an allowlisted pattern before interpolation.

Best fix here (without changing functionality): in `utils/adwords.ts`, validate `account_id` right before building `customerID` and before using it in URL/headers. Accept only Google Ads customer IDs as digits with optional dashes, then normalize by removing dashes and require exactly 10 digits. If invalid, log a warning and return `[]` (consistent with existing non-fatal early-return behavior used elsewhere in this function).

Changes needed:
- **File:** `utils/adwords.ts`
- **Region:** inside `getAdwordsKeywordIdeas`, in the `try` block where `customerID` is currently computed (`const customerID = account_id.replaceAll('-', '');`).
- Replace that line with strict validation + normalization logic.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
