### PR TITLE
Potential fix for code scanning alert no. 1117: Bad HTML filtering regexp

### DIFF
--- a/__tests__/api/adwords.test.ts
+++ b/__tests__/api/adwords.test.ts
@@ -59,7 +59,7 @@ jest.mock('../../utils/apiLogging', () => ({
 }));
 
 const extractScriptContent = (html: string) => {
-   const match = html.match(/<script>([\s\S]*?)<\/script>/);
+   const match = html.match(/<script\b[^>]*>([\s\S]*?)<\/script\s*>/i);
    if (!match) {
       throw new Error('Script tag not found.');
    }


### PR DESCRIPTION
Potential fix for [https://github.com/djav1985/v-serpbear/security/code-scanning/1117](https://github.com/djav1985/v-serpbear/security/code-scanning/1117)

Use a case-insensitive match for the script tag extraction regex so it handles uppercase/mixed-case `<script>` tags as browsers do.

Best minimal fix (without changing behavior otherwise):
- In `__tests__/api/adwords.test.ts`, update `extractScriptContent` at line 62.
- Change:
  - `/<script>([\s\S]*?)<\/script>/`
- To:
  - `/<script\b[^>]*>([\s\S]*?)<\/script\s*>/i`

Why this version:
- `i` handles uppercase/mixed-case tags.
- `<script\b[^>]*>` tolerates attributes/spacing in opening tag.
- `</script\s*>` tolerates trailing whitespace before `>`.
- Still captures only script body in group 1, preserving downstream logic.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
