### PR TITLE
Potential fix for code scanning alert no. 1120: Bad HTML filtering regexp

### DIFF
--- a/__tests__/api/adwords.test.ts
+++ b/__tests__/api/adwords.test.ts
@@ -59,7 +59,7 @@ jest.mock('../../utils/apiLogging', () => ({
 }));
 
 const extractScriptContent = (html: string) => {
-   const match = html.match(/<script\b[^>]*>([\s\S]*?)<\/script\s*>/i);
+   const match = html.match(/<script\b[^>]*>([\s\S]*?)<\/script\b[^>]*>/i);
    if (!match) {
       throw new Error('Script tag not found.');
    }


### PR DESCRIPTION
Potential fix for [https://github.com/djav1985/v-serpbear/security/code-scanning/1120](https://github.com/djav1985/v-serpbear/security/code-scanning/1120)

General fix: avoid brittle HTML regexes when possible; use a parser/sanitizer library.  
Best fix within the shown snippet (and without broader refactors): make the script end-tag portion permissive enough to match parser-error variants that browsers accept.

In `__tests__/api/adwords.test.ts`, update `extractScriptContent` so the closing-tag part allows optional non-`>` attributes/text before `>` (e.g. `</script foo="bar">`, `</script\t\n bar>`), instead of only whitespace. Concretely, replace:

- `/<script\b[^>]*>([\s\S]*?)<\/script\s*>/i`

with:

- `/<script\b[^>]*>([\s\S]*?)<\/script\b[^>]*>/i`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
